### PR TITLE
browser-sdk: Add peopleToggle to types and examples

### DIFF
--- a/.changeset/brave-eagles-rest.md
+++ b/.changeset/brave-eagles-rest.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": patch
+---
+
+Adds people_toggle to example docs

--- a/apps/embed-element-app/src/App.tsx
+++ b/apps/embed-element-app/src/App.tsx
@@ -27,6 +27,7 @@ const events = [
     "participant_join",
     "participant_leave",
     "participantupdate",
+    "people_toggle",
     "pip_toggle",
     "screenshare_toggle",
 ];

--- a/packages/browser-sdk/src/lib/embed/index.ts
+++ b/packages/browser-sdk/src/lib/embed/index.ts
@@ -50,6 +50,7 @@ interface WherebyEmbedElementEventMap {
     microphone_toggle: CustomEvent<{ enabled: boolean }>;
     camera_toggle: CustomEvent<{ enabled: boolean }>;
     chat_toggle: CustomEvent<{ open: boolean }>;
+    people_toggle: CustomEvent<{ open: boolean }>;
     pip_toggle: CustomEvent<{ open: boolean }>;
     deny_device_permission: CustomEvent<{ denied: boolean }>;
     screenshare_toggle: CustomEvent<{ enabled: boolean }>;


### PR DESCRIPTION
### Description

**Summary:**
Adding documentation of the `people_toggle` event listener.
<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**
https://linear.app/whereby/issue/PAN-825/add-event-listener-for-people-button-to-whereby-embed
<!-- Link to the GitHub issue that this PR addresses, if applicable. -->
https://github.com/whereby/pwa/pull/3912
### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Dependency Updates

Will create a changeset after the first release goes out later.

<!-- If this PR includes dependency updates, please list them here along with
the reason for the update. -->

### Reviewers

<!-- Tag the relevant team members or maintainers who should review this PR.
-->

@thyal

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
