### PR TITLE
Pass roomSessionId to RTCStats whenever it changes

### DIFF
--- a/.changeset/fuzzy-crews-smoke.md
+++ b/.changeset/fuzzy-crews-smoke.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": minor
+---
+
+Fix RTC stats bug


### PR DESCRIPTION
### Description
We are not passing `roomSessionId` to RTC stats if it changes during a call. That's why we have the bug where we only have insights for SDK clients that joins a room with another client already in the room.

**Summary:**
- Pass `roomSessionId` to RTC stats whenever it changes.

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. Start local-stack with aws-vault
2. Go to storybook on this branch, and go to a story (room connection only, f.ex)
3. Join the same room with another client
4. Stay in the room for a couple of minutes
5. Leave with both clients
6. Go to the dashboard -> insights
7. Find the session (the last one)
8. Find the SDK client, click on the insight page for that client
9. Verify that there are insights.

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Dependency Updates

<!-- If this PR includes dependency updates, please list them here along with
the reason for the update. -->

### Reviewers


### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
