### PR TITLE
remove detection of node environment

### DIFF
--- a/.changeset/six-rabbits-poke.md
+++ b/.changeset/six-rabbits-poke.md
@@ -2,4 +2,4 @@
 "@whereby.com/browser-sdk": minor
 ---
 
-Fix RTC stats bug
+Remove detection of node environment

--- a/packages/browser-sdk/src/lib/core/redux/slices/__tests__/app.unit.ts
+++ b/packages/browser-sdk/src/lib/core/redux/slices/__tests__/app.unit.ts
@@ -22,7 +22,7 @@ describe("appSlice", () => {
                 displayName: "displayName",
                 sdkVersion: "sdkVersion",
                 externalId: "externalId",
-                isNodeSdk: true,
+                isNodeSdk: false,
             });
         });
 

--- a/packages/browser-sdk/src/lib/core/redux/slices/app.ts
+++ b/packages/browser-sdk/src/lib/core/redux/slices/app.ts
@@ -24,7 +24,7 @@ const initialState: AppState = {
     displayName: null,
     sdkVersion: null,
     externalId: null,
-    isNodeSdk: typeof process !== "undefined" && process.release.name === "node",
+    isNodeSdk: false,
 };
 
 export const appSlice = createSlice({


### PR DESCRIPTION
SSR apps render in node, so this doesn't work. We'll explicitly pass `{
app: { isNodeSdk } }` to `createStore` when needed