### PR TITLE
browser-sdk: Update repo url in package.json

### DIFF
--- a/.changeset/gentle-walls-thank.md
+++ b/.changeset/gentle-walls-thank.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": minor
+---
+
+Update repo field in package.json to point to this repository.

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -6,7 +6,8 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/whereby/browser-sdk.git"
+        "url": "https://github.com/whereby/sdk.git",
+        "directory": "packages/browser-sdk"
     },
     "browserslist": "> 0.5%, last 2 versions, not dead",
     "source": "src/index.js",


### PR DESCRIPTION
### Description
This was missed when moving the package over from
the old repository.