### PR TITLE
browser-sdk: Stop video tracks when disabling camera

### DIFF
--- a/.changeset/weak-pugs-push.md
+++ b/.changeset/weak-pugs-push.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": patch
+---
+
+Fix issue which kept camera light on after disabling video

--- a/packages/browser-sdk/src/lib/__mocks__/MediaStream.ts
+++ b/packages/browser-sdk/src/lib/__mocks__/MediaStream.ts
@@ -61,7 +61,5 @@ export default class MockMediaStream implements MediaStream {
     removeEventListener(type: unknown, listener: unknown, options?: unknown): void {
         throw new Error(`Method not implemented. ${type}, ${listener}, ${options}`);
     }
-    dispatchEvent(event: Event): boolean {
-        throw new Error(`Method not implemented. ${event}`);
-    }
+    dispatchEvent = jest.fn();
 }


### PR DESCRIPTION
### Description
This fixes a bug which prevented us from stopping the video tracks when the camera was disabled.

### Testing

1. `yarn dev`
2. In "roomConnection with local media", connect to a room
3. Toggle camera, verify light goes off.
4. Toggle back on, ensure video is flowing.
5. Leave room, ensure camera light stays on.
