### PR TITLE
common: Adjust exit prerelease workflow

### DIFF
--- a/.github/workflows/exit-prerelease.yml
+++ b/.github/workflows/exit-prerelease.yml
@@ -21,7 +21,6 @@ jobs:
               uses: actions/checkout@v4
               if: steps.check_files.outputs.files_exists == 'true'
               with:
-                  # Checkout the branch that triggered this workflow (This should be development branch in most cases)
                   ref: ${{ github.event.pull_request.head.ref }}
                   # Fetch entire git history so  Changesets can generate changelogs
                   # with the correct commits
@@ -33,30 +32,10 @@ jobs:
               with:
                   node-version: 20.x
 
-              # Get the previous tag
-            - name: Get latest tagged version
-              id: previoustag
-              uses: WyriHaximus/github-action-get-previous-tag@v1
+              # Exit prerelease mode
+            - name: Exit prerelease mode
               if: steps.check_files.outputs.files_exists == 'true'
-
-            - name: Remove 'v' prefix from version number (e.g. v1.0.0)
-              uses: mad9000/actions-find-and-replace-string@4
-              id: formatversion
-              if: steps.check_files.outputs.files_exists == 'true'
-              with:
-                  source: ${{ steps.previoustag.outputs.tag }}
-                  find: "v"
-                  replace: ""
-
-            - name: Write previous version to package.json
-              uses: jaywcjlove/github-action-package@v1.3.2
-              if: steps.check_files.outputs.files_exists == 'true'
-              with:
-                  version: ${{ steps.formatversion.outputs.value }}
-
-            - name: Remove pre.json
-              if: steps.check_files.outputs.files_exists == 'true'
-              run: npx rimraf .changeset/pre.json
+              run: yarn changesets pre exit
 
             - uses: stefanzweifel/git-auto-commit-action@v5
               if: steps.check_files.outputs.files_exists == 'true'


### PR DESCRIPTION
### Description
Some changes to the exit prerelease flow:
* If the pre.json file exists on a PR to main,
* we run `yarn changeset pre exit` on the branch (development)
* This will edit the pre.json file, but not remove it. 
* Then it's merged in to main
* `yarn changeset version` will run on push to main
* A new PR will be opened with correct version bumps, and the pre.json will be removed.


**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Reviewers

<!-- Tag the relevant team members or maintainers who should review this PR.
-->

@havardholvik
@kevinwhereby
@nandito
@thyal

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
