### PR TITLE
common: Read .env variables in each rollup config

### DIFF
--- a/packages/browser-sdk/rollup.config.js
+++ b/packages/browser-sdk/rollup.config.js
@@ -8,6 +8,11 @@ const pkg = require("./package.json");
 const typescript = require("rollup-plugin-typescript2");
 const { dts } = require("rollup-plugin-dts");
 const nodePolyfills = require("rollup-plugin-polyfill-node");
+const dotenv = require("dotenv");
+
+dotenv.config({
+    path: `../../.env`,
+});
 
 const baseConfig = require("../../rollup.base.config");
 const replaceValues = baseConfig(__dirname, {}).replaceValues;

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -5,6 +5,11 @@ const replace = require("@rollup/plugin-replace");
 const nodeResolve = require("@rollup/plugin-node-resolve");
 const pkg = require("./package.json");
 const { dts } = require("rollup-plugin-dts");
+const dotenv = require("dotenv");
+
+dotenv.config({
+    path: `../../.env`,
+});
 
 const baseConfig = require("../../rollup.base.config");
 const replaceValues = baseConfig(__dirname, {}).replaceValues;

--- a/rollup.base.config.js
+++ b/rollup.base.config.js
@@ -1,8 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const dotenv = require("dotenv");
-
-dotenv.config();
-
 module.exports = function buildConfig(packageDirectory, pkgConfig) {
     const pkg = require(`${packageDirectory}/package.json`);
 


### PR DESCRIPTION
### Description

We are not actually sharing the rollup config yet, we're just importing and using some values from the shared config, so the shared reading from `.env` doesn't work.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Reviewers

<!-- Tag the relevant team members or maintainers who should review this PR.
-->

@havardholvik
@kevinwhereby
@nandito
@thyal

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
