### PR TITLE
common: Use .nvmrc for Node.js setup in workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,16 @@
+# Workflow setup
+
+## Node versionining
+We rely on nvm / .nvmrc to ensure the correct Node.js version is used throughout
+this repo. For workflows, this means that `actions/setup-node` step should be 
+configured to read `.nvmrc` like so:
+
+```
+- name: Setup Node.js
+    uses: actions/setup-node@v4
+    with:
+        node-version-file: .nvmrc
+        cache: "yarn"
+        cache-dependency-path: |
+            yarn.lock
+```

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -15,11 +15,13 @@ jobs:
             - name: Checkout Repo
               uses: actions/checkout@v3
 
-            - name: Setup Node.js 20
-              uses: actions/setup-node@v3
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version-file: .nvmrc
                   cache: "yarn"
+                  cache-dependency-path: |
+                      yarn.lock
 
             - name: Cache turbo setup
               uses: actions/cache@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,14 +8,18 @@ jobs:
         runs-on: macos-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version-file: .nvmrc
                   cache: "yarn"
                   cache-dependency-path: |
                       yarn.lock
+
             - name: Install dependencies
               run: yarn install --frozen-lockfile
+
             - uses: actions/cache@v3
               name: Check for Playwright browsers cache
               id: playwright-cache
@@ -27,10 +31,12 @@ jobs:
             - name: Install Playwright Browsers
               run: npx playwright install --with-deps
               if: steps.playwright-cache.outputs.cache-hit != 'true'
+
             - name: Run Playwright tests
               run: yarn test:e2e
               env:
                   WHEREBY_API_KEY: ${{ secrets.WHEREBY_API_KEY }}
+
             - uses: actions/upload-artifact@v3
               if: always()
               with:

--- a/.github/workflows/exit-prerelease.yml
+++ b/.github/workflows/exit-prerelease.yml
@@ -26,11 +26,14 @@ jobs:
                   # with the correct commits
                   fetch-depth: 0
 
-            - name: Setup Node.js 20.x
+            - name: Setup Node.js
               uses: actions/setup-node@v4
               if: steps.check_files.outputs.files_exists == 'true'
               with:
-                  node-version: 20
+                  node-version-file: .nvmrc
+                  cache: "yarn"
+                  cache-dependency-path: |
+                      yarn.lock
 
               # Exit prerelease mode
             - name: Exit prerelease mode

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -15,10 +15,13 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Setup Node.js 20.x
+            - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version-file: .nvmrc
+                  cache: "yarn"
+                  cache-dependency-path: |
+                      yarn.lock
 
             - name: Install Dependencies
               run: yarn install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,13 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-turbo-
 
-            - name: Setup Node.js 20.x
-              uses: actions/setup-node@v3
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version-file: .nvmrc
+                  cache: "yarn"
+                  cache-dependency-path: |
+                      yarn.lock
 
             - name: Install Dependencies
               run: yarn install --frozen-lockfile


### PR DESCRIPTION
### Description
Prevent config drift by using the same source of
truth for Node.js version in all workflows.
