### PR TITLE
browser-sdk: add attributes to embed element

### DIFF
--- a/.changeset/wild-ducks-sing.md
+++ b/.changeset/wild-ducks-sing.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": minor
+---
+
+Add attributes for timer, skipMediaPermissionPrompt, precallCeremony, bottomToolbar, and autoSpotlight

--- a/packages/browser-sdk/src/lib/embed/__tests__/embed.spec.ts
+++ b/packages/browser-sdk/src/lib/embed/__tests__/embed.spec.ts
@@ -21,7 +21,7 @@ describe("@whereby/browser-sdk", () => {
             expect(define).toHaveBeenCalledWith(
                 expect.any(String),
                 expect.objectContaining({
-                    observedAttributes: [
+                    observedAttributes: expect.arrayContaining([
                         "displayname",
                         "minimal",
                         "room",
@@ -57,7 +57,12 @@ describe("@whereby/browser-sdk", () => {
                         "subgridlabels",
                         "lowdata",
                         "breakout",
-                    ],
+                        "autospotlight",
+                        "bottomtoolbar",
+                        "precallceremony",
+                        "skipmediapermissionprompt",
+                        "timer",
+                    ]),
                 }),
             );
         });

--- a/packages/browser-sdk/src/lib/embed/index.ts
+++ b/packages/browser-sdk/src/lib/embed/index.ts
@@ -5,8 +5,13 @@ import { parseRoomUrlAndSubdomain } from "@whereby.com/core/utils";
 
 interface WherebyEmbedElementAttributes extends ReactHTMLElement<HTMLElement> {
     audio: string;
+    /**
+     * Automatically spotlight the local participant on room join. Can only be used with users joining with host privileges.
+     */
+    autoSpotlight: string;
     avatarUrl: string;
     background: string;
+    bottomToolbar: string;
     breakout: string;
     cameraAccess: string;
     chat: string;
@@ -27,13 +32,22 @@ interface WherebyEmbedElementAttributes extends ReactHTMLElement<HTMLElement> {
     participantCount: string;
     people: string;
     pipButton: string;
+    /**
+     * Displays a device and connectivity test for the user. Is dependent on precallReview being enabled
+     */
+    precallCeremony: string;
     precallReview: string;
     recording: string;
     room: string;
     settingsButton: string;
     screenshare: string;
+    /**
+     * Skips the Whereby permissions UI and causes browser to automatically request device permissions. Required for Android app integrations.
+     */
+    skipMediaPermissionPrompt: string;
     style: { [key: string]: string };
     subgridLabels: string;
+    timer: string;
     title: string;
     video: string;
     virtualBackgroundUrl: string;
@@ -87,7 +101,9 @@ declare global {
 
 const boolAttrs = [
     "audio",
+    "autoSpotlight",
     "background",
+    "bottomToolbar",
     "cameraAccess",
     "chat",
     "people",
@@ -95,6 +111,7 @@ const boolAttrs = [
     "emptyRoomInvitation",
     "help",
     "leaveButton",
+    "precallCeremony",
     "precallReview",
     "screenshare",
     "video",
@@ -107,9 +124,11 @@ const boolAttrs = [
     "pipButton",
     "moreButton",
     "personality",
+    "skipMediaPermissionPrompt",
     "subgridLabels",
     "lowData",
     "breakout",
+    "timer"
 ];
 
 define("WherebyEmbed", {


### PR DESCRIPTION
Add attributes for timer, skipMediaPermissionPrompt, precallCeremony, bottomToolbar, and autoSpotlight

### Description

**Summary:**

Looking to expand the attributes our Embed Element offers to include most (if not all) the URL parameters we have. Customers get confused on occasion and (understandably) assume they can use all params as attributes.

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
