### PR TITLE
core: add isNodeSdk flag

### DIFF
--- a/.changeset/red-houses-unite.md
+++ b/.changeset/red-houses-unite.md
@@ -1,0 +1,8 @@
+---
+"@whereby.com/core": minor
+---
+
+Add flag for Node SDK usage
+
+disables local media and explicitly sets the mediasoup device handler to one
+that supports node

--- a/packages/core/src/redux/slices/__tests__/app.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/app.unit.ts
@@ -6,6 +6,7 @@ describe("appSlice", () => {
             const result = appSlice.reducer(
                 undefined,
                 appSlice.actions.doAppJoin({
+                    isNodeSdk: true,
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",
                     displayName: "displayName",
@@ -22,6 +23,7 @@ describe("appSlice", () => {
                 displayName: "displayName",
                 sdkVersion: "sdkVersion",
                 externalId: "externalId",
+                isNodeSdk: true,
             });
         });
 

--- a/packages/core/src/redux/slices/__tests__/localMedia.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/localMedia.unit.ts
@@ -4,21 +4,23 @@ describe("localMediaSlice", () => {
     describe("reactors", () => {
         describe("reactLocalMediaStart", () => {
             it.each`
-                appWantsToJoin | localMediaStatus | localMediaOptions               | expected
-                ${false}       | ${""}            | ${undefined}                    | ${undefined}
-                ${false}       | ${"started"}     | ${undefined}                    | ${undefined}
-                ${false}       | ${"started"}     | ${{ audio: true, video: true }} | ${undefined}
-                ${true}        | ${"started"}     | ${{ audio: true, video: true }} | ${undefined}
-                ${true}        | ${""}            | ${undefined}                    | ${undefined}
-                ${true}        | ${""}            | ${{ audio: true, video: true }} | ${{ audio: true, video: true }}
+                appWantsToJoin | localMediaStatus | localMediaOptions               | isNodeSdk | expected
+                ${false}       | ${""}            | ${undefined}                    | ${false}  | ${undefined}
+                ${false}       | ${"started"}     | ${undefined}                    | ${false}  | ${undefined}
+                ${false}       | ${"started"}     | ${{ audio: true, video: true }} | ${false}  | ${undefined}
+                ${true}        | ${"started"}     | ${{ audio: true, video: true }} | ${false}  | ${undefined}
+                ${true}        | ${""}            | ${undefined}                    | ${false}  | ${undefined}
+                ${true}        | ${""}            | ${{ audio: true, video: true }} | ${true}   | ${undefined}
+                ${true}        | ${""}            | ${{ audio: true, video: true }} | ${false}  | ${{ audio: true, video: true }}
             `(
-                "expected $expected when appWantsToJoin=$appWantsToJoin, localMediaStatus=$localMediaStatus, localMediaOptions=$localMediaOptions",
-                ({ appWantsToJoin, localMediaStatus, localMediaOptions, expected }) => {
+                "expected $expected when appWantsToJoin=$appWantsToJoin, localMediaStatus=$localMediaStatus, localMediaOptions=$localMediaOptions, isNodeSdk=$isNodeSdk",
+                ({ appWantsToJoin, localMediaStatus, localMediaOptions, isNodeSdk, expected }) => {
                     expect(
                         selectLocalMediaShouldStartWithOptions.resultFunc(
                             appWantsToJoin,
                             localMediaStatus,
                             localMediaOptions,
+                            isNodeSdk,
                         ),
                     ).toEqual(expected);
                 },

--- a/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
@@ -61,21 +61,23 @@ describe("roomConnectionSlice", () => {
             const x = () => oneOf(true, false);
 
             it.each`
-                organizationId | roomConnectionStatus | signalIdentified | localMediaStatus | expected
-                ${undefined}   | ${"initializing"}    | ${x()}           | ${"started"}     | ${false}
-                ${"orgId"}     | ${"initializing"}    | ${true}          | ${"started"}     | ${true}
-                ${"orgId"}     | ${"connected"}       | ${x()}           | ${"started"}     | ${false}
-                ${"orgId"}     | ${"initializing"}    | ${false}         | ${"starting"}    | ${false}
-                ${"orgId"}     | ${"initializing"}    | ${x()}           | ${"error"}       | ${false}
+                organizationId | roomConnectionStatus | signalIdentified | localMediaStatus | isNodeSdk | expected
+                ${undefined}   | ${"initializing"}    | ${x()}           | ${"started"}     | ${x()}    | ${false}
+                ${"orgId"}     | ${"initializing"}    | ${true}          | ${"started"}     | ${false}  | ${true}
+                ${"orgId"}     | ${"connected"}       | ${x()}           | ${"started"}     | ${x()}    | ${false}
+                ${"orgId"}     | ${"initializing"}    | ${false}         | ${"starting"}    | ${x()}    | ${false}
+                ${"orgId"}     | ${"initializing"}    | ${x()}           | ${"error"}       | ${false}  | ${false}
+                ${"orgId"}     | ${"initializing"}    | ${true}          | ${"error"}       | ${true}   | ${true}
             `(
-                "should return $expected when hasOrganizationIdFetched=$hasOrganizationIdFetched, roomConnectionStatus=$roomConnectionStatus, signalIdentified=$signalIdentified, localMediaStatus=$localMediaStatus",
-                ({ organizationId, roomConnectionStatus, signalIdentified, localMediaStatus, expected }) => {
+                "Should return $expected when organizationId=$organizationId, roomConnectionStatus=$roomConnectionStatus, signalIdentified=$signalIdentified, localMediaStatus=$localMediaStatus, isNodeSdk=$isNodeSdk",
+                ({ organizationId, roomConnectionStatus, signalIdentified, localMediaStatus, isNodeSdk, expected }) => {
                     expect(
                         selectShouldConnectRoom.resultFunc(
                             organizationId,
                             roomConnectionStatus,
                             signalIdentified,
                             localMediaStatus,
+                            isNodeSdk,
                         ),
                     ).toEqual(expected);
                 },

--- a/packages/core/src/redux/slices/app.ts
+++ b/packages/core/src/redux/slices/app.ts
@@ -6,6 +6,7 @@ import type { LocalMediaOptions } from "./localMedia";
  * Reducer
  */
 export interface AppState {
+    isNodeSdk: boolean;
     wantsToJoin: boolean;
     roomUrl: string | null;
     roomName: string | null;
@@ -16,6 +17,7 @@ export interface AppState {
 }
 
 const initialState: AppState = {
+    isNodeSdk: false,
     wantsToJoin: false,
     roomName: null,
     roomKey: null,
@@ -32,6 +34,7 @@ export const appSlice = createSlice({
         doAppJoin: (
             state,
             action: PayloadAction<{
+                isNodeSdk?: boolean;
                 displayName: string;
                 localMediaOptions?: LocalMediaOptions;
                 roomKey: string | null;
@@ -77,3 +80,4 @@ export const selectAppRoomKey = (state: RootState) => state.app.roomKey;
 export const selectAppDisplayName = (state: RootState) => state.app.displayName;
 export const selectAppSdkVersion = (state: RootState) => state.app.sdkVersion;
 export const selectAppExternalId = (state: RootState) => state.app.externalId;
+export const selectAppIsNodeSdk = (state: RootState) => state.app.isNodeSdk;

--- a/packages/core/src/redux/slices/localMedia.ts
+++ b/packages/core/src/redux/slices/localMedia.ts
@@ -3,7 +3,7 @@ import { getStream, getUpdatedDevices, getDeviceData } from "@whereby/jslib-medi
 import { createAppAsyncThunk, createAppThunk } from "../thunk";
 import { RootState } from "../store";
 import { createReactor, startAppListening } from "../listenerMiddleware";
-import { doAppJoin, selectAppWantsToJoin } from "./app";
+import { doAppJoin, selectAppIsNodeSdk, selectAppWantsToJoin } from "./app";
 import debounce from "../../utils/debounce";
 
 export type LocalMediaOptions = {
@@ -14,7 +14,6 @@ export type LocalMediaOptions = {
 /**
  * Reducer
  */
-
 export interface LocalMediaState {
     busyDeviceIds: string[];
     cameraDeviceError?: unknown;
@@ -603,8 +602,9 @@ export const selectLocalMediaShouldStartWithOptions = createSelector(
     selectAppWantsToJoin,
     selectLocalMediaStatus,
     selectLocalMediaOptions,
-    (appWantsToJoin, localMediaStatus, localMediaOptions) => {
-        if (appWantsToJoin && localMediaStatus === "" && localMediaOptions) {
+    selectAppIsNodeSdk,
+    (appWantsToJoin, localMediaStatus, localMediaOptions, isNodeSdk) => {
+        if (appWantsToJoin && localMediaStatus === "" && !isNodeSdk && localMediaOptions) {
             return localMediaOptions;
         }
     },

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -10,6 +10,7 @@ import {
     selectAppSdkVersion,
     selectAppExternalId,
     setRoomKey,
+    selectAppIsNodeSdk,
 } from "./app";
 
 import { selectOrganizationId } from "./organization";
@@ -197,10 +198,16 @@ export const selectRoomConnectionStatus = (state: RootState) => state.roomConnec
  */
 
 export const selectShouldConnectRoom = createSelector(
-    [selectOrganizationId, selectRoomConnectionStatus, selectSignalConnectionDeviceIdentified, selectLocalMediaStatus],
-    (hasOrganizationIdFetched, roomConnectionStatus, signalConnectionDeviceIdentified, localMediaStatus) => {
+    [
+        selectOrganizationId,
+        selectRoomConnectionStatus,
+        selectSignalConnectionDeviceIdentified,
+        selectLocalMediaStatus,
+        selectAppIsNodeSdk,
+    ],
+    (hasOrganizationIdFetched, roomConnectionStatus, signalConnectionDeviceIdentified, localMediaStatus, isNodeSdk) => {
         if (
-            localMediaStatus === "started" &&
+            (localMediaStatus === "started" || isNodeSdk) &&
             signalConnectionDeviceIdentified &&
             !!hasOrganizationIdFetched &&
             ["initializing", "reconnect"].includes(roomConnectionStatus)

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -11,7 +11,8 @@ import RtcManagerDispatcher, {
 import { createReactor, startAppListening } from "../../listenerMiddleware";
 import { selectRemoteParticipants, streamStatusUpdated } from "../remoteParticipants";
 import { StreamState } from "../../../RoomParticipant";
-import { selectAppWantsToJoin } from "../app";
+import { selectAppIsNodeSdk, selectAppWantsToJoin } from "../app";
+import { Chrome111 as MediasoupDeviceHandler } from "mediasoup-client/lib/handlers/Chrome111.js";
 import {
     selectIsCameraEnabled,
     selectIsMicrophoneEnabled,
@@ -165,6 +166,7 @@ export const doConnectRtc = createAppThunk(() => (dispatch, getState) => {
     const dispatcher = selectRtcConnectionRaw(state).rtcManagerDispatcher;
     const isCameraEnabled = selectIsCameraEnabled(state);
     const isMicrophoneEnabled = selectIsMicrophoneEnabled(state);
+    const isNodeSdk = selectAppIsNodeSdk(state);
 
     if (dispatcher) {
         return;
@@ -193,6 +195,7 @@ export const doConnectRtc = createAppThunk(() => (dispatch, getState) => {
             vp9On: false,
             h264On: false,
             simulcastScreenshareOn: false,
+            deviceHandlerFactory: isNodeSdk ? MediasoupDeviceHandler.createFactory() : undefined,
         },
     });
 

--- a/packages/core/src/types.d.ts
+++ b/packages/core/src/types.d.ts
@@ -1,4 +1,6 @@
 declare module "@whereby/jslib-media/src/webrtc/RtcManagerDispatcher" {
+    import { type HandlerFactory } from "mediasoup-client/lib/handlers/HandlerInterface";
+
     enum RtcEventNames {
         rtc_manager_created = "rtc_manager_created",
         stream_added = "stream_added",
@@ -36,6 +38,7 @@ declare module "@whereby/jslib-media/src/webrtc/RtcManagerDispatcher" {
             vp9On: boolean;
             h264On: boolean;
             simulcastScreenshareOn: boolean;
+            deviceHandlerFactory?: HandlerFactory;
         };
         logger: {
             debug: (message: string) => void;


### PR DESCRIPTION
# Add isNodeSdk flag to app state

### Description

**Summary:**
Adds a flag to disable local media and explicitly pass a device handler to the RtcManagerDisatcher that supports Node clients

**Related Issue:**

https://linear.app/whereby/issue/COB-529/add-islocalmediadisabled-flag-to-store-initialization

### Testing
it shouldn't affect browser clients, but is required for the Node client

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
