### PR TITLE
browser-sdk: Add "meeting_end" embed event

### DIFF
--- a/.changeset/sharp-ducks-end.md
+++ b/.changeset/sharp-ducks-end.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": minor
+---
+
+Add support for meeting_end event on embed element

--- a/packages/browser-sdk/src/lib/embed/index.ts
+++ b/packages/browser-sdk/src/lib/embed/index.ts
@@ -47,6 +47,7 @@ interface WherebyEmbedElementEventMap {
     leave: CustomEvent<{ removed: boolean }>;
     participant_join: CustomEvent<{ participant: { metadata: string } }>;
     participant_leave: CustomEvent<{ participant: { metadata: string } }>;
+    meeting_end: CustomEvent;
     microphone_toggle: CustomEvent<{ enabled: boolean }>;
     camera_toggle: CustomEvent<{ enabled: boolean }>;
     chat_toggle: CustomEvent<{ open: boolean }>;

--- a/packages/browser-sdk/src/stories/prebuilt-ui.stories.tsx
+++ b/packages/browser-sdk/src/stories/prebuilt-ui.stories.tsx
@@ -78,6 +78,7 @@ const WherebyEmbed = ({
 }: Partial<WherebyEmbedAttributes>) => {
     const elmRef = useRef<WherebyEmbedElement>(null);
     const [cameraEnabled, setCameraEnabled] = useState(video);
+    const [meetingEnded, setMeetingEnded] = useState(false);
 
     useEffect(() => {
         const element = elmRef.current;
@@ -86,11 +87,16 @@ const WherebyEmbed = ({
             const cameraEnabled = e.detail.enabled;
             setCameraEnabled(cameraEnabled);
         });
+
+        element?.addEventListener("meeting_end", () => {
+            setMeetingEnded(true);
+        });
     }, []);
 
     return (
         <p>
-            <span>Camera: {cameraEnabled ? "ENABLED" : "DISABLED"}</span>
+            <p>Camera: {cameraEnabled ? "ENABLED" : "DISABLED"}</p>
+            <p>Meeting ended: {meetingEnded ? "TRUE" : "FALSE"}</p>
             <whereby-embed
                 audio={offOn(audio)}
                 avatarUrl={avatarUrl}


### PR DESCRIPTION
### Description
Allow customers to take action whenever a meeting has been explicitly ended by the host.

### Testing
Ensure you have a .env set up with a room url which works with Storybook.

1. `yarn dev`
2. Visit `http://localhost:6006/?path=/story/examples-pre-built-ui--whereby-embed-element-example`
3. Join room, then end meeting for all.
4. Verify "Meeting ended: TRUE" is present in the top

### Screenshots/GIFs (if applicable)
![Screenshot 2024-03-19 at 09 41 51](https://github.com/whereby/sdk/assets/778534/ee863b07-a841-474d-a3e9-2a73e203fde9)

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

