### PR TITLE
core: handle room_joined errors

### DIFF
--- a/.changeset/tasty-geese-sit.md
+++ b/.changeset/tasty-geese-sit.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": minor
+---
+
+Handle errors while joining a room

--- a/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
@@ -39,6 +39,24 @@ describe("roomConnectionSlice", () => {
                 });
             });
 
+            it("should set status to disconnected and populate the error if the there is an error", () => {
+                const result = roomConnectionSlice.reducer(
+                    undefined,
+                    signalEvents.roomJoined({
+                        error: "room_full",
+                        selfId: "selfId",
+                        isLocked: false,
+                    }),
+                );
+
+                expect(result).toEqual({
+                    status: "disconnected",
+                    session: null,
+                    error: "room_full",
+                });
+            });
+        });
+        describe("signalEvents.clientKicked", () => {
             it("should set status to kicked if the client is kicked", () => {
                 const result = roomConnectionSlice.reducer(
                     undefined,

--- a/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
@@ -26,7 +26,6 @@ describe("roomConnectionSlice", () => {
                 const result = roomConnectionSlice.reducer(
                     undefined,
                     signalEvents.roomJoined({
-                        error: "room_locked",
                         selfId: "selfId",
                         isLocked: false,
                     }),

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -42,7 +42,7 @@ export type ConnectionStatus =
 export interface RoomConnectionState {
     session: { createdAt: string; id: string } | null;
     status: ConnectionStatus;
-    error: unknown;
+    error: string | null;
 }
 
 const initialState: RoomConnectionState = {
@@ -64,13 +64,20 @@ export const roomConnectionSlice = createSlice({
     },
     extraReducers: (builder) => {
         builder.addCase(signalEvents.roomJoined, (state, action) => {
-            //TODO: Handle error
             const { error, isLocked } = action.payload;
 
             if (error === "room_locked" && isLocked) {
                 return {
                     ...state,
                     status: "room_locked",
+                };
+            }
+
+            if (error) {
+                return {
+                    ...state,
+                    status: "disconnected",
+                    error,
                 };
             }
 
@@ -192,6 +199,7 @@ export const selectRoomConnectionRaw = (state: RootState) => state.roomConnectio
 export const selectRoomConnectionSession = (state: RootState) => state.roomConnection.session;
 export const selectRoomConnectionSessionId = (state: RootState) => state.roomConnection.session?.id;
 export const selectRoomConnectionStatus = (state: RootState) => state.roomConnection.status;
+export const selectRoomConnectionError = (state: RootState) => state.roomConnection.error;
 
 /**
  * Reactors


### PR DESCRIPTION
-------

### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->
Currently for any error except `room_locked`, the SDK thinks it joins
the room successfully. Rather than explicily handle all possible errors,
we can fall back to this handler and add more specific cases as they are
required by the SDK


**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->
https://linear.app/whereby/issue/COB-522/auto-stop-captioner
We need to know if the room join fails, so we can kill the captioning process

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->
To see the error, make a small room and try to join it with 5 SDK clients. using the example apps If you keep an eye on the room connection status you'll see it says 'connected' for all clients even though the 5th is refused entry due to "room_full"

Now build this branch and run the same test, you'll see the last client changes it's roomConnectionStatus to 'disconnected' and sets the error to "room_full"

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->