### PR TITLE
core: Return client claim when joining a room

### DIFF
--- a/.changeset/heavy-carrots-sort.md
+++ b/.changeset/heavy-carrots-sort.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/core": minor
+"@whereby.com/browser-sdk": minor
+---
+
+core: Return client claim when joining a room

--- a/packages/core/src/redux/slices/__tests__/remoteParticipants.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/remoteParticipants.unit.ts
@@ -17,6 +17,7 @@ describe("remoteParticipantsSlice", () => {
                     signalEvents.roomJoined({
                         isLocked: false,
                         selfId: "selfId",
+                        clientClaim: "clientClaim",
                         room: {
                             clients: [
                                 {

--- a/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
@@ -11,6 +11,7 @@ describe("roomConnectionSlice", () => {
                     signalEvents.roomJoined({
                         error: "room_locked",
                         selfId: "selfId",
+                        clientClaim: "clientClaim",
                         isLocked: true,
                     }),
                 );
@@ -28,6 +29,7 @@ describe("roomConnectionSlice", () => {
                     signalEvents.roomJoined({
                         error: "room_locked",
                         selfId: "selfId",
+                        clientClaim: "clientClaim",
                         isLocked: false,
                     }),
                 );

--- a/packages/core/src/redux/slices/__tests__/waitingParticipants.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/waitingParticipants.unit.ts
@@ -12,6 +12,7 @@ describe("reducer", () => {
                 signalEvents.roomJoined({
                     isLocked: true,
                     selfId: "self-id",
+                    clientClaim: "client-claim",
                     room: {
                         clients: [],
                         knockers: [

--- a/packages/core/src/redux/slices/localParticipant.ts
+++ b/packages/core/src/redux/slices/localParticipant.ts
@@ -12,6 +12,7 @@ import { signalEvents } from "./signalConnection/actions";
 export interface LocalParticipantState extends LocalParticipant {
     isScreenSharing: boolean;
     roleName: string;
+    clientClaim?: string;
 }
 
 const initialState: LocalParticipantState = {
@@ -23,6 +24,7 @@ const initialState: LocalParticipantState = {
     stream: undefined,
     isScreenSharing: false,
     roleName: "",
+    clientClaim: undefined,
 };
 
 export const doEnableAudio = createAppAsyncThunk(
@@ -106,6 +108,7 @@ export const localParticipantSlice = createSlice({
             return {
                 ...state,
                 id: action.payload.selfId,
+                clientClaim: action.payload.clientClaim,
                 roleName: client?.role.roleName || "",
             };
         });
@@ -116,6 +119,7 @@ export const { doSetLocalParticipant } = localParticipantSlice.actions;
 
 export const selectLocalParticipantRaw = (state: RootState) => state.localParticipant;
 export const selectSelfId = (state: RootState) => state.localParticipant.id;
+export const selectLocalParticipantClientClaim = (state: RootState) => state.localParticipant.clientClaim;
 export const selectLocalParticipantRole = (state: RootState) => state.localParticipant.roleName;
 export const selectLocalParticipantIsScreenSharing = (state: RootState) => state.localParticipant.isScreenSharing;
 

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -20,7 +20,7 @@ import {
     socketReconnecting,
 } from "./signalConnection";
 import { selectIsCameraEnabled, selectIsMicrophoneEnabled, selectLocalMediaStatus } from "./localMedia";
-import { selectSelfId } from "./localParticipant";
+import { selectSelfId, selectLocalParticipantClientClaim } from "./localParticipant";
 
 export type ConnectionStatus =
     | "initializing"
@@ -160,6 +160,7 @@ export const doConnectRoom = createAppThunk(() => (dispatch, getState) => {
     const isCameraEnabled = selectIsCameraEnabled(getState());
     const isMicrophoneEnabled = selectIsMicrophoneEnabled(getState());
     const selfId = selectSelfId(getState());
+    const clientClaim = selectLocalParticipantClientClaim(getState());
 
     socket?.emit("join_room", {
         avatarUrl: null,
@@ -176,6 +177,7 @@ export const doConnectRoom = createAppThunk(() => (dispatch, getState) => {
         roomKey,
         roomName,
         selfId,
+        ...(!!clientClaim && { clientClaim }),
         userAgent: `browser-sdk:${sdkVersion || "unknown"}`,
         externalId,
     });

--- a/packages/core/src/types.d.ts
+++ b/packages/core/src/types.d.ts
@@ -188,6 +188,7 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
             } | null;
         };
         selfId: string;
+        clientClaim?: string;
     }
 
     interface RoomKnockedEvent {
@@ -257,6 +258,8 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
         organizationId: string;
         roomName: string;
         displayName?: string;
+        selfId?: string;
+        clientClaim?: string;
     }
 
     interface KnockRoomRequest {


### PR DESCRIPTION
### Description

Store the client claim returned from the server when joining a room and send it back in any subsequent room joining request.

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
