### PR TITLE
core: handle signal disconnect events

### DIFF
--- a/.changeset/clean-pumas-know.md
+++ b/.changeset/clean-pumas-know.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/core": minor
+---
+
+Update roomConnection and signalConnection status on signal disconnect
+events

--- a/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
@@ -55,6 +55,7 @@ describe("roomConnectionSlice", () => {
                 });
             });
         });
+
         describe("signalEvents.clientKicked", () => {
             it("should set status to kicked if the client is kicked", () => {
                 const result = roomConnectionSlice.reducer(
@@ -66,6 +67,18 @@ describe("roomConnectionSlice", () => {
 
                 expect(result).toEqual({
                     status: "kicked",
+                    session: null,
+                    error: null,
+                });
+            });
+        });
+
+        describe("signalEvents.disconnect", () => {
+            it("should set status to disconnected", () => {
+                const result = roomConnectionSlice.reducer(undefined, signalEvents.disconnect());
+
+                expect(result).toEqual({
+                    status: "disconnected",
                     session: null,
                     error: null,
                 });

--- a/packages/core/src/redux/slices/__tests__/signalConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/signalConnection.unit.ts
@@ -1,7 +1,22 @@
 import { oneOf } from "../../../__mocks__/appMocks";
-import { selectShouldConnectSignal, selectShouldIdentifyDevice } from "../signalConnection";
+import { selectShouldConnectSignal, selectShouldIdentifyDevice, signalConnectionSlice } from "../signalConnection";
+import { signalEvents } from "../signalConnection/actions";
 
 describe("signalConnectionSlice", () => {
+    describe("reducers", () => {
+        describe("signalEvents.disconnect", () => {
+            it("should set status to disconnected", () => {
+                const result = signalConnectionSlice.reducer(undefined, signalEvents.disconnect());
+
+                expect(result).toEqual({
+                    deviceIdentified: false,
+                    isIdentifyingDevice: false,
+                    socket: null,
+                    status: "disconnected",
+                });
+            });
+        });
+    });
     describe("reactors", () => {
         describe("selectShouldConnectSignal", () => {
             const x = () => oneOf(true, false);

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -87,6 +87,12 @@ export const roomConnectionSlice = createSlice({
                 session: action.payload.room?.session ?? null,
             };
         });
+        builder.addCase(signalEvents.disconnect, (state) => {
+            return {
+                ...state,
+                status: "disconnected",
+            };
+        });
         builder.addCase(signalEvents.newClient, (state, action) => {
             return {
                 ...state,

--- a/packages/core/src/redux/slices/signalConnection/index.ts
+++ b/packages/core/src/redux/slices/signalConnection/index.ts
@@ -103,6 +103,14 @@ export const signalConnectionSlice = createSlice({
             };
         },
     },
+    extraReducers: (builder) => {
+        builder.addCase(signalEvents.disconnect, (state) => {
+            return {
+                ...state,
+                status: "disconnected",
+            };
+        });
+    },
 });
 
 export const { deviceIdentifying, deviceIdentified, socketConnected, socketConnecting, socketDisconnected } =


### PR DESCRIPTION
-------

### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->
The signal socket emits a 'disconnect' event when it loses connection
with the server - i.e. when the network is lost
We should update the signalConnection status and roomConenction status
when this happens


**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->
https://linear.app/whereby/issue/COB-522/auto-stop-captioner

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->
On main, open a room in an SDK client. Turn off your network to disconnect from Signal and keep an eye on the signal/roomConnection status and Redux events. After about 30 seconds there will be a `disconnect` event from signal, but the SDK will think signal and room connection are still `connected`

Do the same on this branch and see the roomConnection and signalConnection status to update to `disconnected`

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->