### PR TITLE
common: Add workflow for canary releases

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -1,0 +1,105 @@
+name: Canary
+
+on:
+    issue_comment:
+        types: [created]
+
+concurrency: ${{ github.workflow }}-${{ github.ref}}
+
+jobs:
+    canary_release:
+        name: Canary Release
+        if: |
+            github.event.issue.pull_request != null &&
+            (github.event.comment.body == '/canary' || github.event.comment.body == '/canary-release')
+        runs-on: ubuntu-latest
+        steps:
+            - name: Enforce permission requirement
+              uses: prince-chrismc/check-actor-permissions-action@v3
+              with:
+                  permission: write
+
+            - name: Add initial reaction
+              uses: peter-evans/create-or-update-comment@v4
+              with:
+                  comment-id: ${{ github.event.comment.id }}
+                  reactions: eyes
+
+            - name: Checkout Repo
+              uses: actions/checkout@v4
+
+            - name: Checkout PR
+              run: gh pr checkout ${{ github.event.issue.number }}
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Reset changeset files on changeset-release/main branch
+              run: |
+                  if [[ $(git branch --show-current) == "changeset-release/main" ]]; then
+                      git checkout origin/main -- .changeset
+                  fi
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: .nvmrc
+                  cache: "yarn"
+                  cache-dependency-path: |
+                      yarn.lock
+
+            - name: Install Dependencies
+              run: yarn install --frozen-lockfile
+
+            - name: Create an .npmrc
+              env:
+                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+              run: |
+                  cat << EOF > "$HOME/.npmrc"
+                    //registry.npmjs.org/:_authToken=$NPM_TOKEN
+                  EOF
+
+            - name: Create and publish canary release
+              uses: actions/github-script@v7
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  script: |
+                      const execa = require('execa')
+
+                      await execa.command('yarn changeset version -- --snapshot canary', { stdio: 'inherit' })
+
+                      const releaseProcess = execa.command('yarn release -- --no-git-tags --snapshot --tag canary')
+                      releaseProcess.stdout.pipe(process.stdout)
+
+                      const {stdout} = await releaseProcess
+
+                      const newTags = Array
+                        .from(stdout.matchAll(/New tag:\s+([^\s\n]+)/g))
+                        .map(([_, tag]) => tag)
+
+                      if (newTags.length) {
+                        const multiple = newTags.length > 1
+
+                        const body = (
+                          `🚀 **The canary release${multiple ? 's have' : ' has'} been published to npm.**\n\n` +
+                          `You can test the release${multiple ? 's' : ''} by installing the ` +
+                          `newly published version${multiple ? 's' : ''}:\n` +
+                          newTags.map(tag => (
+                            '```sh\n' +
+                            `yarn add ${tag}\n` +
+                            '```'
+                          )).join('\n')
+                        )
+                        await github.rest.issues.createComment({
+                          issue_number: context.issue.number,
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          body,
+                        })
+                      }
+
+            - name: Add final reaction
+              uses: peter-evans/create-or-update-comment@v4
+              with:
+                  comment-id: ${{ github.event.comment.id }}
+                  reactions: rocket

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Pre-releases are done from the `development` branch. To create a pre-release, fo
 
 Once the pull request is merged, the pre-release will be published to npm with the `beta` tag. Under the hood changesets will create a file in the `.changeset` folder called `.pre.json`, to indicate that the release is a pre-release. When it's time to release the pre-release, a pull request should be created to merge `development` into `main`. This should include the `.pre.json` file. The `exit-prerelease` workflow will make sure that changesets exits pre-release mode, and the file will be deleted once the `Version Packages` pull request on `main` is merged.
 
+### Canary releases
+Canary releases (snapshots) are not done automatically. However, you can create a canary release from a pull request simply
+by adding a comment to the PR with the text `/canary`, or `/canary-release`. This will trigger the `canary-release` GitHub action, which will publish a canary release to npm with the `canary` tag for all the packages that have a changeset in the PR. 
+
 
 ## Contact
 Join our [discord server](https://discord.gg/yWrAhZdvDG) to get in touch with us.


### PR DESCRIPTION
### Description
Adds workflow for canary releases. It's not done automatically, but on demand. You can simply add a changeset like normal, and comment `/canary` or `/canary-release` on the PR to create one.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
