### PR TITLE
media: Handles recovering after trying to produce an ended track

### DIFF
--- a/.changeset/rare-jars-listen.md
+++ b/.changeset/rare-jars-listen.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+media: Handles recovering after trying to produce an ended track


### PR DESCRIPTION
### Description

**Summary:**

This handles a part of the close/open lid issue and possibly other cases. When trying to produce an ended track, mediasoup client will throw and the producer would not be created. Whenever this happens, it will usually be replaced by a working track later - so we need to make sure the producer is created then. 

When closing the lid on some/all machines/browsers, the track will end, and the SFU websocket will be closed. After opening the lid again, if the websocket is re-established before the track is replaced (always on my chrome@mac), it would fail.

**Related Issue:**

[<!-- Link to the GitHub issue that this PR addresses, if applicable. -->](https://linear.app/whereby/issue/COB-517/handle-closing-and-opening-lid)

### Testing

Testing instruction will be in PWA PR, as some changes are needed there as well.

