### PR TITLE
Provide correct userAgent data

### DIFF
--- a/.changeset/curly-mangos-press.md
+++ b/.changeset/curly-mangos-press.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": patch
+---
+
+Provide correct value for `userAgent` when connecting using `browser-sdk`.

--- a/.changeset/warm-peaches-thank.md
+++ b/.changeset/warm-peaches-thank.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": minor
+---
+
+Rename `sdkVersion` param in `doAppJoin` to `userAgent`, make it optional with a fallback to core module version and stop exporting the `sdkVersion`

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -18,12 +18,12 @@ import {
     doAppJoin,
     doKnockRoom,
     doRtcReportStreamResolution,
-    sdkVersion,
 } from "@whereby.com/core";
 
 import VideoView from "../VideoView";
 import { selectRoomConnectionState } from "./selector";
 import { RoomConnectionState, RoomConnectionActions, UseRoomConnectionOptions } from "./types";
+import { browserSdkVersion } from "../version";
 
 const initialState: RoomConnectionState = {
     chatMessages: [],
@@ -81,7 +81,7 @@ export function useRoomConnection(
                     : roomConnectionOptions.localMediaOptions,
                 roomKey,
                 roomUrl,
-                sdkVersion: sdkVersion,
+                userAgent: `browser-sdk:${browserSdkVersion}`,
                 externalId: roomConnectionOptions.externalId || null,
             }),
         );

--- a/packages/browser-sdk/src/lib/react/version.ts
+++ b/packages/browser-sdk/src/lib/react/version.ts
@@ -1,0 +1,1 @@
+export const browserSdkVersion = "__PKG_VERSION__";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,4 @@
 export * from "./redux";
 export * from "./api";
 export * from "./RoomParticipant";
-export * from "./version";
 export { createServices } from "./services";

--- a/packages/core/src/redux/slices/__tests__/app.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/app.unit.ts
@@ -2,28 +2,54 @@ import { appSlice } from "../app";
 
 describe("appSlice", () => {
     describe("reducers", () => {
-        it("doAppJoin", () => {
-            const result = appSlice.reducer(
-                undefined,
-                appSlice.actions.doAppJoin({
-                    isNodeSdk: true,
+        describe("doAppJoin", () => {
+            it("should change the state", () => {
+                const result = appSlice.reducer(
+                    undefined,
+                    appSlice.actions.doAppJoin({
+                        isNodeSdk: true,
+                        roomUrl: "https://some.url/roomName",
+                        roomKey: "roomKey",
+                        displayName: "displayName",
+                        userAgent: "userAgent",
+                        externalId: "externalId",
+                    }),
+                );
+    
+                expect(result).toEqual({
+                    wantsToJoin: true,
+                    roomName: "/roomName",
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",
                     displayName: "displayName",
-                    sdkVersion: "sdkVersion",
+                    userAgent: "userAgent",
                     externalId: "externalId",
-                }),
-            );
+                    isNodeSdk: true,
+                });
+            });
 
-            expect(result).toEqual({
-                wantsToJoin: true,
-                roomName: "/roomName",
-                roomUrl: "https://some.url/roomName",
-                roomKey: "roomKey",
-                displayName: "displayName",
-                sdkVersion: "sdkVersion",
-                externalId: "externalId",
-                isNodeSdk: true,
+            it("should change the state with default userAgent", () => {
+                const result = appSlice.reducer(
+                    undefined,
+                    appSlice.actions.doAppJoin({
+                        isNodeSdk: true,
+                        roomUrl: "https://some.url/roomName",
+                        roomKey: "roomKey",
+                        displayName: "displayName",
+                        externalId: "externalId",
+                    }),
+                );
+    
+                expect(result).toEqual({
+                    wantsToJoin: true,
+                    roomName: "/roomName",
+                    roomUrl: "https://some.url/roomName",
+                    roomKey: "roomKey",
+                    displayName: "displayName",
+                    userAgent: "core:__PKG_VERSION__",
+                    externalId: "externalId",
+                    isNodeSdk: true,
+                });
             });
         });
 

--- a/packages/core/src/redux/slices/app.ts
+++ b/packages/core/src/redux/slices/app.ts
@@ -1,6 +1,7 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { RootState } from "../store";
 import type { LocalMediaOptions } from "./localMedia";
+import { coreVersion } from "../../version";
 
 /**
  * Reducer
@@ -12,7 +13,7 @@ export interface AppState {
     roomName: string | null;
     roomKey: string | null;
     displayName: string | null;
-    sdkVersion: string | null;
+    userAgent: string | null;
     externalId: string | null;
 }
 
@@ -23,7 +24,7 @@ const initialState: AppState = {
     roomKey: null,
     roomUrl: null,
     displayName: null,
-    sdkVersion: null,
+    userAgent: `core:${coreVersion}`,
     externalId: null,
 };
 
@@ -39,7 +40,7 @@ export const appSlice = createSlice({
                 localMediaOptions?: LocalMediaOptions;
                 roomKey: string | null;
                 roomUrl: string;
-                sdkVersion: string;
+                userAgent?: string;
                 externalId: string | null;
             }>,
         ) => {
@@ -78,6 +79,6 @@ export const selectAppRoomName = (state: RootState) => state.app.roomName;
 export const selectAppRoomUrl = (state: RootState) => state.app.roomUrl;
 export const selectAppRoomKey = (state: RootState) => state.app.roomKey;
 export const selectAppDisplayName = (state: RootState) => state.app.displayName;
-export const selectAppSdkVersion = (state: RootState) => state.app.sdkVersion;
+export const selectAppUserAgent = (state: RootState) => state.app.userAgent;
 export const selectAppExternalId = (state: RootState) => state.app.externalId;
 export const selectAppIsNodeSdk = (state: RootState) => state.app.isNodeSdk;

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -7,7 +7,7 @@ import {
     selectAppDisplayName,
     selectAppRoomKey,
     selectAppRoomName,
-    selectAppSdkVersion,
+    selectAppUserAgent,
     selectAppExternalId,
     setRoomKey,
     selectAppIsNodeSdk,
@@ -136,7 +136,7 @@ export const doKnockRoom = createAppThunk(() => (dispatch, getState) => {
     const roomName = selectAppRoomName(state);
     const roomKey = selectAppRoomKey(state);
     const displayName = selectAppDisplayName(state);
-    const sdkVersion = selectAppSdkVersion(state);
+    const userAgent = selectAppUserAgent(state);
     const externalId = selectAppExternalId(state);
     const organizationId = selectOrganizationId(state);
 
@@ -155,7 +155,7 @@ export const doKnockRoom = createAppThunk(() => (dispatch, getState) => {
         roomKey,
         roomName,
         selfId: "",
-        userAgent: `browser-sdk:${sdkVersion || "unknown"}`,
+        userAgent,
         externalId,
     });
 
@@ -168,7 +168,7 @@ export const doConnectRoom = createAppThunk(() => (dispatch, getState) => {
     const roomName = selectAppRoomName(state);
     const roomKey = selectAppRoomKey(state);
     const displayName = selectAppDisplayName(state);
-    const sdkVersion = selectAppSdkVersion(state);
+    const userAgent = selectAppUserAgent(state);
     const externalId = selectAppExternalId(state);
     const organizationId = selectOrganizationId(state);
     const isCameraEnabled = selectIsCameraEnabled(getState());
@@ -192,7 +192,7 @@ export const doConnectRoom = createAppThunk(() => (dispatch, getState) => {
         roomName,
         selfId,
         ...(!!clientClaim && { clientClaim }),
-        userAgent: `browser-sdk:${sdkVersion || "unknown"}`,
+        userAgent,
         externalId,
     });
 

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const sdkVersion = "__SDK_VERSION__";
+export const coreVersion = "__PKG_VERSION__";

--- a/rollup.base.config.js
+++ b/rollup.base.config.js
@@ -6,7 +6,7 @@ module.exports = function buildConfig(packageDirectory, pkgConfig) {
         replaceValues: {
             preventAssignment: true,
             values: {
-                __SDK_VERSION__: pkg.version,
+                __PKG_VERSION__: pkg.version,
                 "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
                 "process.env.NODE_DEBUG": JSON.stringify(process.env.NODE_DEBUG),
                 "process.env.AWF_BASE_URL": JSON.stringify(process.env.AWF_BASE_URL),


### PR DESCRIPTION
Code that uses `core` directly will provide `core:${coreVersion}` unless specified differently. Code that uses `browser-sdk` will provide `browser-sdk:${sdkVersion}.

Additionally `doAppJoin`.`sdkVersion` got renamed to `userAgent` and is now an optional parameter.

### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
