### PR TITLE
media: Fix broken issue detectors

### DIFF
--- a/.changeset/wise-crabs-refuse.md
+++ b/.changeset/wise-crabs-refuse.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Fix broken issue detectors when audio-only mode is enabled

--- a/packages/media/jest.config.js
+++ b/packages/media/jest.config.js
@@ -3,7 +3,7 @@ const buildConfig = require("../../jest.base.config");
 
 module.exports = buildConfig(__dirname, {
     testEnvironment: "jsdom",
-    testMatch: ["<rootDir>/tests/**/?(*.)+(spec|test).[jt]s?(x)"],
+    testMatch: ["<rootDir>/tests/**/?(*.)+(spec|test).[jt]s?(x)", "<rootDir>/src/**/?(*.)+(spec|test|unit).[jt]s?(x)"],
     transform: {
         "^.+\\.(j|t)sx?$": "ts-jest",
     },

--- a/packages/media/src/webrtc/stats/IssueMonitor/__tests__/index.spec.ts
+++ b/packages/media/src/webrtc/stats/IssueMonitor/__tests__/index.spec.ts
@@ -1,13 +1,13 @@
-import { subscribeIssues } from "../../../src/webrtc/stats/IssueMonitor";
-import { setClientProvider } from "../../../src/webrtc/stats/StatsMonitor";
-import { setPeerConnectionsForTests } from "../../../src/webrtc/stats/StatsMonitor/peerConnectionTracker";
+import { subscribeIssues } from "..";
+import { setClientProvider } from "../../StatsMonitor";
+import { setPeerConnectionsForTests } from "../../StatsMonitor/peerConnectionTracker";
 
-function createMockPeerConnection(clients: any) {
+function createMockPeerConnection(clients: ReturnType<typeof createMockClient>[]) {
     return {
         getStats() {
             return new Map(
                 clients
-                    .flatMap((client: any) => [
+                    .flatMap((client) => [
                         client.audio.enabled && { ...client.audio.stats, timestamp: Date.now() },
                         client.video.enabled && { ...client.video.stats, timestamp: Date.now() },
                     ])
@@ -18,7 +18,7 @@ function createMockPeerConnection(clients: any) {
     };
 }
 
-function createMockClient(id: any, isLocal: any) {
+function createMockClient(id: string, isLocal: boolean) {
     return {
         id,
         isLocalClient: !!isLocal,
@@ -57,10 +57,10 @@ function createMockClient(id: any, isLocal: any) {
 }
 
 describe("IssueMonitor", () => {
-    let stopSubscription: any;
-    let localCam: any;
-    let remoteCam1: any;
-    let remoteCam2: any;
+    let stopSubscription: () => void;
+    let localCam: ReturnType<typeof createMockClient>;
+    let remoteCam1: ReturnType<typeof createMockClient>;
+    let remoteCam2: ReturnType<typeof createMockClient>;
 
     beforeAll(() => {
         jest.useFakeTimers();

--- a/packages/media/src/webrtc/stats/IssueMonitor/__tests__/issueDetectors.spec.ts
+++ b/packages/media/src/webrtc/stats/IssueMonitor/__tests__/issueDetectors.spec.ts
@@ -1,0 +1,238 @@
+import { StatsClient } from "../../types";
+import {
+    badNetworkIssueDetector,
+    dryTrackIssueDetector,
+    noTrackIssueDetector,
+    IssueCheckData,
+    noTrackStatsIssueDetector,
+} from "../issueDetectors";
+
+function makeStatsClient(args?: Partial<StatsClient>): StatsClient {
+    return {
+        isLocalClient: true,
+        isAudioOnlyModeEnabled: false,
+        audio: { enabled: true },
+        video: { enabled: true },
+        clientId: "local",
+        id: "local",
+        isPresentation: false,
+        ...args,
+    };
+}
+
+function makeCheckData(args?: Partial<IssueCheckData>): IssueCheckData {
+    return {
+        client: makeStatsClient(),
+        clients: [makeStatsClient(), makeStatsClient()],
+        kind: "audio",
+        track: undefined,
+        trackStats: {},
+        stats: {},
+        hasLiveTrack: true,
+        ssrc0: {},
+        ssrcs: {},
+        issues: {},
+        metrics: {},
+        ...args,
+    };
+}
+
+describe("badNetworkIssueDetector", () => {
+    describe("enabled", () => {
+        it.each`
+            hasLiveTrack | ssrcs   | expected
+            ${false}     | ${[]}   | ${false}
+            ${true}      | ${[]}   | ${false}
+            ${false}     | ${[{}]} | ${false}
+            ${true}      | ${[{}]} | ${true}
+        `("expected $expected when hasLiveTrack:$hasLiveTrack, ssrcs:$ssrcs", ({ hasLiveTrack, ssrcs, expected }) => {
+            const checkData = makeCheckData({
+                hasLiveTrack,
+                ssrcs,
+            });
+
+            expect(badNetworkIssueDetector.enabled(checkData)).toEqual(expected);
+        });
+    });
+
+    describe("check", () => {
+        const client = makeStatsClient({ isLocalClient: true });
+
+        it.each`
+            client    | clients                                                              | kind       | ssrcs                                     | expected
+            ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"audio"} | ${[{ bitrate: 222 }]}                     | ${false}
+            ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"audio"} | ${[{ bitrate: 0 }]}                       | ${true}
+            ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"video"} | ${[{ bitrate: 0 }]}                       | ${true}
+            ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: true }]}  | ${"video"} | ${[{ bitrate: 0 }]}                       | ${false}
+            ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"video"} | ${[{ bitrate: 123, lossRatio: 0.04 }]}    | ${true}
+            ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"video"} | ${[{ bitrate: 123, fractionLost: 0.04 }]} | ${true}
+        `(
+            "expected $expected when client:$client, clients:$clients, kind:$kind, ssrcs:$ssrcs",
+            ({ client, clients, kind, ssrcs, expected }) => {
+                const checkData = makeCheckData({
+                    client,
+                    clients,
+                    kind,
+                    ssrcs,
+                });
+
+                expect(badNetworkIssueDetector.check(checkData)).toEqual(expected);
+            }
+        );
+    });
+});
+
+describe("dryTrackIssueDetector", () => {
+    describe("enabled", () => {
+        it.each`
+            hasLiveTrack | ssrcs   | expected
+            ${false}     | ${null} | ${false}
+            ${true}      | ${null} | ${false}
+            ${false}     | ${{}}   | ${false}
+            ${true}      | ${{}}   | ${true}
+        `("expected $expected when hasLiveTrack:$hasLiveTrack, ssrcs:$ssrcs", ({ hasLiveTrack, ssrcs, expected }) => {
+            const checkData = makeCheckData({
+                hasLiveTrack,
+                ssrcs,
+            });
+
+            expect(dryTrackIssueDetector.enabled(checkData)).toEqual(expected);
+        });
+    });
+
+    describe("check", () => {
+        describe("local client", () => {
+            const client = makeStatsClient({ isLocalClient: true });
+
+            it.each`
+                client    | clients                                                              | ssrcs                                 | expected
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${[{ bitrate: 222 }]}                 | ${false}
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${[{ bitrate: 0 }]}                   | ${true}
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${[{ bitrate: 222 }, { bitrate: 0 }]} | ${false}
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${[{ bitrate: 0 }, { bitrate: 0 }]}   | ${true}
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: true }]}  | ${[{ bitrate: 0 }, { bitrate: 0 }]}   | ${false}
+            `(
+                "expected $expected when client:$client, clients:$clients, ssrcs:$ssrcs",
+                ({ client, clients, ssrcs, expected }) => {
+                    const checkData = makeCheckData({
+                        client,
+                        clients,
+                        ssrcs,
+                    });
+
+                    expect(dryTrackIssueDetector.check(checkData)).toEqual(expected);
+                }
+            );
+        });
+    });
+});
+
+describe("noTrackIssueDetector", () => {
+    describe("check", () => {
+        describe("local client", () => {
+            const client = makeStatsClient({ isLocalClient: true });
+            it.each`
+                client    | clients                                                              | kind       | track        | expected
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"audio"} | ${{}}        | ${false}
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"audio"} | ${undefined} | ${true}
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"video"} | ${undefined} | ${true}
+            `(
+                "expected $expected when client:$client, clients:$clients, kind:$kind, track:$track",
+                ({ client, clients, kind, track, expected }) => {
+                    const checkData = makeCheckData({
+                        client,
+                        clients,
+                        kind,
+                        track,
+                    });
+
+                    expect(noTrackIssueDetector.check(checkData)).toEqual(expected);
+                }
+            );
+        });
+
+        describe("remote client", () => {
+            const client = makeStatsClient({ isLocalClient: false });
+            it.each`
+                client    | clients                                                              | kind       | track        | expected
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"audio"} | ${{}}        | ${false}
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"audio"} | ${undefined} | ${true}
+                ${client} | ${[client, { isLocalClient: true, isAudioOnlyModeEnabled: true }]}   | ${"video"} | ${undefined} | ${false}
+            `(
+                "expected $expected when client:$client, clients:$clients, kind:$kind, track:$track",
+                ({ client, clients, kind, track, expected }) => {
+                    const checkData = makeCheckData({
+                        client,
+                        clients,
+                        kind,
+                        track,
+                    });
+
+                    expect(noTrackIssueDetector.check(checkData)).toEqual(expected);
+                }
+            );
+        });
+    });
+});
+
+describe("noTrackStatsIssueDetector", () => {
+    describe("enabled", () => {
+        it.each`
+            hasLiveTrack | expected
+            ${false}     | ${false}
+            ${true}      | ${true}
+        `("expected $expected when hasLiveTrack:$hasLiveTrack", ({ hasLiveTrack, expected }) => {
+            const checkData = makeCheckData({
+                hasLiveTrack,
+            });
+
+            expect(noTrackStatsIssueDetector.enabled(checkData)).toEqual(expected);
+        });
+    });
+
+    describe("check", () => {
+        describe("local client", () => {
+            const client = makeStatsClient({ isLocalClient: true });
+            it.each`
+                client    | clients                                                              | kind       | ssrcs   | expected
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"audio"} | ${[{}]} | ${false}
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"audio"} | ${[]}   | ${true}
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"video"} | ${[]}   | ${true}
+            `(
+                "expected $expected when client:$client, clients:$clients, kind:$kind, ssrcs:$ssrcs",
+                ({ client, clients, kind, ssrcs, expected }) => {
+                    const checkData = makeCheckData({
+                        client,
+                        clients,
+                        kind,
+                        ssrcs,
+                    });
+
+                    expect(noTrackStatsIssueDetector.check(checkData)).toEqual(expected);
+                }
+            );
+        });
+
+        describe("remote client", () => {
+            const client = makeStatsClient({ isLocalClient: false });
+            it.each`
+                client    | clients                                                              | kind       | ssrcs   | expected
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"audio"} | ${[{}]} | ${false}
+                ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"audio"} | ${[]}   | ${true}
+                ${client} | ${[client, { isLocalClient: true, isAudioOnlyModeEnabled: true }]}   | ${"video"} | ${[]}   | ${false}
+            `(
+                "expected $expected when client:$client, clients:$clients, kind:$kind, ssrcs:$ssrcs",
+                ({ client, clients, kind, ssrcs, expected }) => {
+                    const checkData = makeCheckData({
+                        client,
+                        clients,
+                        kind,
+                        ssrcs,
+                    });
+
+                    expect(noTrackStatsIssueDetector.check(checkData)).toEqual(expected);
+                }
+            );
+        });
+    });
+});

--- a/packages/media/src/webrtc/stats/IssueMonitor/issueDetectors.ts
+++ b/packages/media/src/webrtc/stats/IssueMonitor/issueDetectors.ts
@@ -1,0 +1,267 @@
+import { StatsClient } from "../types";
+
+interface IssueDetector {
+    id: string;
+    global?: boolean;
+    enabled: (args: IssueCheckData) => boolean;
+    check: (args: IssueCheckData) => boolean;
+}
+
+export interface IssueCheckData {
+    client: StatsClient;
+    clients: StatsClient[];
+    kind: string;
+    track: MediaStreamTrack | undefined;
+    trackStats: any;
+    stats: any;
+    hasLiveTrack: boolean;
+    ssrc0: any;
+    ssrcs: any;
+    issues: any;
+    metrics: any;
+}
+
+export const badNetworkIssueDetector: IssueDetector = {
+    id: "bad-network",
+    enabled: ({ hasLiveTrack, ssrcs }) => hasLiveTrack && ssrcs.length > 0,
+    check: ({ client, clients, kind, ssrcs }) => {
+        const hasPositiveBitrate = ssrcs.some((ssrc: any) => ssrc.bitrate > 0);
+
+        if (!hasPositiveBitrate && client.isLocalClient && kind === "video") {
+            const remoteClients = clients.filter((c) => !c.isLocalClient);
+
+            if (remoteClients.length > 0) {
+                return !remoteClients.every((c: any) => c.isAudioOnlyModeEnabled);
+            }
+        }
+
+        const ssrc0 = ssrcs[0];
+        if (!ssrc0) {
+            return false;
+        }
+
+        return (
+            ssrc0.bitrate === 0 ||
+            ssrc0.lossRatio > 0.03 ||
+            (ssrc0.fractionLost || 0) > 0.03 ||
+            (!client.isPresentation && kind === "video" && ssrc0.bitrate < 30000) ||
+            (ssrc0.direction === "in" && ssrc0.pliRate > 2)
+        );
+    },
+};
+
+/**
+ * A dry-track indicates that no media is being sent or received, which might indicata a problem.
+ */
+export const dryTrackIssueDetector: IssueDetector = {
+    id: "dry-track",
+    enabled: ({ hasLiveTrack, ssrcs }) => !!(hasLiveTrack && ssrcs),
+    check: ({ client, clients, ssrcs }) => {
+        /**
+         * A client can be a remote one or the local one.
+         *
+         * Remote clients only have ssrcs for incoming rtp streams,
+         * whereas the local client only has ssrcs for outgoing rtp streams
+         *    |
+         *    |--> In the case of p2p -> one ssrc per remote client
+         *    |--> In the case of SFU -> one ssrc per simulcast layer
+         *
+         * In either case, we only detect "dry-track" if ALL ssrcs for one specific client
+         * have bitrate 0, meaning no media is being sent/received.
+         *
+         * The exception is when the reason for zero bitrate is audio-only mode, meaning we
+         * need to check the other clients.
+         */
+        let hasPositiveBitrate = false;
+
+        ssrcs.forEach((ssrc: any) => {
+            hasPositiveBitrate = hasPositiveBitrate || ssrc.bitrate > 0;
+        });
+
+        if (!hasPositiveBitrate && client.isLocalClient) {
+            const remoteClients = clients.filter((c) => !c.isLocalClient);
+
+            if (remoteClients.length > 0) {
+                return !remoteClients.every((c) => c.isAudioOnlyModeEnabled);
+            }
+        }
+
+        return !hasPositiveBitrate;
+    },
+};
+
+export const noTrackIssueDetector: IssueDetector = {
+    id: "no-track",
+    enabled: () => true,
+    check: ({ client, clients, kind, track }) => {
+        if (!track && !client.isLocalClient && kind === "video") {
+            const localClient = clients.find((c) => c.isLocalClient);
+            if (localClient) {
+                return !localClient.isAudioOnlyModeEnabled;
+            }
+        }
+
+        return !track;
+    },
+};
+
+export const noTrackStatsIssueDetector: IssueDetector = {
+    id: "no-track-stats",
+    enabled: ({ hasLiveTrack }) => hasLiveTrack,
+    check: ({ client, clients, kind, ssrcs }) => {
+        if (ssrcs.length === 0 && !client.isLocalClient && kind === "video") {
+            const localClient = clients.find((c) => c.isLocalClient);
+            if (localClient) {
+                return !localClient.isAudioOnlyModeEnabled;
+            }
+        }
+
+        return ssrcs.length === 0;
+    },
+};
+
+export const issueDetectors: IssueDetector[] = [
+    {
+        id: "desync",
+        enabled: ({ client, track, stats }) => {
+            return (
+                !client.isLocalClient &&
+                track?.kind === "audio" &&
+                typeof stats?.tracks === "object" &&
+                Object.keys(stats.tracks).length > 1
+            );
+        },
+        check: ({ stats: { tracks } }) => {
+            const jitter = {
+                audio: 0,
+                video: 0,
+            };
+
+            Object.values(tracks)
+                .flatMap((t: any) => Object.values(t.ssrcs))
+                .forEach((ssrc: any) => {
+                    if (ssrc.kind === "audio" && ssrc.jitter > jitter.audio) jitter.audio = ssrc.jitter;
+                    if (ssrc.kind === "video" && ssrc.jitter > jitter.video) jitter.video = ssrc.jitter;
+                });
+            const diff = Math.abs(jitter.audio * 1000 - jitter.video * 1000); // diff in ms
+            return diff > 500;
+        },
+    },
+    noTrackIssueDetector,
+    {
+        id: "ended-track",
+        enabled: ({ track }) => !!track,
+        check: ({ track }) => track?.readyState === "ended",
+    },
+    noTrackStatsIssueDetector,
+    dryTrackIssueDetector,
+    {
+        id: "low-layer0-bitrate",
+        enabled: ({ hasLiveTrack, ssrc0, kind, client }) =>
+            hasLiveTrack && kind === "video" && ssrc0 && ssrc0.height && !client.isPresentation,
+        check: ({ ssrc0 }) => ssrc0.height < 200 && ssrc0.bitrate < 30000,
+    },
+    {
+        id: "quality-limitation-bw",
+        enabled: ({ hasLiveTrack, stats, client, kind }) =>
+            hasLiveTrack && client.isLocalClient && kind === "video" && stats,
+        check: ({ stats }) =>
+            !!Object.values(stats.tracks).find((track: any) =>
+                Object.values(track.ssrcs).find((ssrc: any) => ssrc.qualityLimitationReason === "bandwidth"),
+            ),
+    },
+    {
+        id: "quality-limitation-cpu",
+        enabled: ({ hasLiveTrack, stats, client, kind }) =>
+            hasLiveTrack && client.isLocalClient && kind === "video" && stats,
+        check: ({ stats }) =>
+            !!Object.values(stats.tracks).find((track: any) =>
+                Object.values(track.ssrcs).find((ssrc: any) => ssrc.qualityLimitationReason === "cpu"),
+            ),
+    },
+    {
+        id: "high-plirate",
+        enabled: ({ hasLiveTrack, ssrc0 }) => hasLiveTrack && ssrc0 && ssrc0.height,
+        check: ({ ssrc0 }) => ssrc0.pliRate > 2,
+    },
+    {
+        id: "extreme-plirate",
+        enabled: ({ hasLiveTrack, ssrc0 }) => hasLiveTrack && ssrc0 && ssrc0.height,
+        check: ({ ssrc0 }) => ssrc0.pliRate > 5,
+    },
+    {
+        id: "high-packetloss",
+        enabled: ({ hasLiveTrack, ssrc0 }) => hasLiveTrack && ssrc0 && ssrc0.direction === "in",
+        check: ({ ssrc0 }) => ssrc0.lossRatio > 0.02,
+    },
+    {
+        id: "extreme-packetloss",
+        enabled: ({ hasLiveTrack, ssrc0 }) => hasLiveTrack && ssrc0 && ssrc0.direction === "in",
+        check: ({ ssrc0 }) => ssrc0.lossRatio > 0.1,
+    },
+    {
+        id: "high-packetloss",
+        enabled: ({ hasLiveTrack, ssrc0 }) => hasLiveTrack && ssrc0 && ssrc0.direction === "out",
+        check: ({ ssrc0 }) => (ssrc0.fractionLost || 0) > 0.02,
+    },
+    {
+        id: "extreme-packetloss",
+        enabled: ({ hasLiveTrack, ssrc0 }) => hasLiveTrack && ssrc0 && ssrc0.direction === "out",
+        check: ({ ssrc0 }) => (ssrc0.fractionLost || 0) > 0.1,
+    },
+    {
+        id: "fps-below-20",
+        enabled: ({ hasLiveTrack, ssrc0, kind, client }) =>
+            hasLiveTrack && ssrc0 && ssrc0.height && kind === "video" && !client.isPresentation,
+        check: ({ ssrc0 }) => ssrc0.height > 180 && ssrc0.fps < 20,
+    },
+    {
+        id: "fps-below-10",
+        enabled: ({ hasLiveTrack, ssrc0, kind, client }) =>
+            hasLiveTrack && ssrc0 && ssrc0.height && kind === "video" && !client.isPresentation,
+        check: ({ ssrc0 }) => ssrc0.fps < 10,
+    },
+    badNetworkIssueDetector,
+    {
+        id: "cpu-pressure-serious",
+        global: true,
+        enabled: ({ stats }) => stats?.pressure?.source === "cpu",
+        check: ({ stats }) => stats.pressure.state === "serious",
+    },
+    {
+        id: "cpu-pressure-critical",
+        global: true,
+        enabled: ({ stats }) => stats?.pressure?.source === "cpu",
+        check: ({ stats }) => stats.pressure.state === "critical",
+    },
+    {
+        id: "concealed",
+        enabled: ({ hasLiveTrack, ssrc0, kind }) => hasLiveTrack && ssrc0 && kind === "audio",
+        check: ({ ssrc0 }) =>
+            ssrc0.bitrate && ssrc0.direction === "in" && ssrc0.audioLevel >= 0.001 && ssrc0.audioConcealment >= 0.1,
+    },
+    {
+        id: "decelerated",
+        enabled: ({ hasLiveTrack, ssrc0, kind }) => hasLiveTrack && ssrc0 && kind === "audio",
+        check: ({ ssrc0 }) =>
+            ssrc0.bitrate && ssrc0.direction === "in" && ssrc0.audioLevel >= 0.001 && ssrc0.audioDeceleration >= 0.1,
+    },
+    {
+        id: "accelerated",
+        enabled: ({ hasLiveTrack, ssrc0, kind }) => hasLiveTrack && ssrc0 && kind === "audio",
+        check: ({ ssrc0 }) =>
+            ssrc0.bitrate && ssrc0.direction === "in" && ssrc0.audioLevel >= 0.001 && ssrc0.audioAcceleration >= 0.1,
+    },
+    // todo:
+    // jitter/congestion - increasing jitter for several "ticks"
+    // encodeTime?
+    // low audio (energy)?
+    // keyframe rate?
+    // canidate-pair switches
+    // RTT?
+    // stun req/res
+    // available bitrates
+    // probes? low media bitrate?
+    // match with wanted resolution/layer (updateStreamResolution)
+    // might want to take window focus into consideration
+];

--- a/packages/media/src/webrtc/stats/types.ts
+++ b/packages/media/src/webrtc/stats/types.ts
@@ -1,0 +1,15 @@
+export interface StatsClient {
+    id: string;
+    clientId: string;
+    isLocalClient: boolean;
+    isAudioOnlyModeEnabled: boolean;
+    audio: {
+        enabled: boolean;
+        track?: MediaStreamTrack;
+    };
+    video: {
+        enabled: boolean;
+        track?: MediaStreamTrack;
+    };
+    isPresentation: boolean;
+}


### PR DESCRIPTION
### Description
With audio-only mode, this issue detector incorrectly detected dry-track, bad-network, no-track, and no-track-stats when in p2p. This fixes the issue by taking the audio-only mode state of other clients into account.

Also extracted the issue detectors into their own file and added a test suite, along with some initial types.

### Testing
Check out the following branches and restart local-stack:

- https://github.com/whereby/video-conference/pull/14844
- https://github.com/whereby/pwa/pull/4024

For both a P2P and SFU room, check the following
1. Join <room-url>?audioOnlyExperimentOn x 2
2. For both participants, start `!stats` in chat
3. For one particpant, enable audio-only mode
4. For the other participant, verify you DONT have `bad-network`, `dry-track`, `no-track`, `no-track-stats` issues
5. Test in various browsers

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
