### PR TITLE
core: use getTrack().some() to tell if screenshare has audio and use fallback id

### DIFF
--- a/.changeset/fresh-steaks-arrive.md
+++ b/.changeset/fresh-steaks-arrive.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": patch
+---
+
+Use MediaStream.getTracks() to tell if a screenshare has audio enabled or not. `.getAudioTracks()` is not implemented in some WebRTC implementations.

--- a/.changeset/small-trains-tan.md
+++ b/.changeset/small-trains-tan.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": patch
+---
+
+Use `pres-` prefixed clientId as screenshare id for remote participants and "local-screenshare" for local screenshares as a fallback, if the MediaStream has no `id`.

--- a/packages/core/src/redux/slices/__tests__/remoteParticipants.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/remoteParticipants.unit.ts
@@ -279,9 +279,9 @@ describe("remoteParticipantsSlice", () => {
             it.each`
                 localScreenshareStream    | remoteParticipants    | expected
                 ${null}                   | ${[]}                 | ${[]}
-                ${null}                   | ${[client1, client2]} | ${[{ id: "", hasAudioTrack: false, isLocal: false, participantId: client2.id, stream: client2.presentationStream }]}
-                ${localScreenshareStream} | ${[]}                 | ${[{ id: "", hasAudioTrack: false, isLocal: true, participantId: "local", stream: localScreenshareStream }]}
-                ${localScreenshareStream} | ${[client3]}          | ${[{ id: "", hasAudioTrack: false, isLocal: true, participantId: "local", stream: localScreenshareStream }, { id: "", hasAudioTrack: false, isLocal: false, participantId: client3.id, stream: client3.presentationStream }]}
+                ${null}                   | ${[client1, client2]} | ${[{ id: `pres-${client2.id}`, hasAudioTrack: false, isLocal: false, participantId: client2.id, stream: client2.presentationStream }]}
+                ${localScreenshareStream} | ${[]}                 | ${[{ id: "local-screenshare", hasAudioTrack: false, isLocal: true, participantId: "local", stream: localScreenshareStream }]}
+                ${localScreenshareStream} | ${[client3]}          | ${[{ id: "local-screenshare", hasAudioTrack: false, isLocal: true, participantId: "local", stream: localScreenshareStream }, { id: `pres-${client3.id}`, hasAudioTrack: false, isLocal: false, participantId: client3.id, stream: client3.presentationStream }]}
             `(
                 "should return $expected when localScreenshareStream=$localScreenshareStream, remoteParticipants=$remoteParticipants",
                 ({ localScreenshareStream, remoteParticipants, expected }) => {

--- a/packages/core/src/redux/slices/remoteParticipants.ts
+++ b/packages/core/src/redux/slices/remoteParticipants.ts
@@ -286,7 +286,7 @@ export const selectScreenshares = createSelector(
             screenshares.push({
                 id: localScreenshareStream.id,
                 participantId: "local",
-                hasAudioTrack: localScreenshareStream.getAudioTracks().length > 0,
+                hasAudioTrack: localScreenshareStream.getTracks().some((track) => track.kind === "audio"),
                 stream: localScreenshareStream,
                 isLocal: true,
             });
@@ -297,7 +297,7 @@ export const selectScreenshares = createSelector(
                 screenshares.push({
                     id: participant.presentationStream.id,
                     participantId: participant.id,
-                    hasAudioTrack: participant.presentationStream.getAudioTracks().length > 0,
+                    hasAudioTrack: participant.presentationStream.getTracks().some((track) => track.kind === "audio"),
                     stream: participant.presentationStream,
                     isLocal: false,
                 });

--- a/packages/core/src/redux/slices/remoteParticipants.ts
+++ b/packages/core/src/redux/slices/remoteParticipants.ts
@@ -284,7 +284,7 @@ export const selectScreenshares = createSelector(
 
         if (localScreenshareStream) {
             screenshares.push({
-                id: localScreenshareStream.id,
+                id: localScreenshareStream.id || "local-screenshare",
                 participantId: "local",
                 hasAudioTrack: localScreenshareStream.getTracks().some((track) => track.kind === "audio"),
                 stream: localScreenshareStream,
@@ -295,7 +295,7 @@ export const selectScreenshares = createSelector(
         for (const participant of remoteParticipants) {
             if (participant.presentationStream) {
                 screenshares.push({
-                    id: participant.presentationStream.id,
+                    id: participant.presentationStream.id || `pres-${participant.id}`,
                     participantId: participant.id,
                     hasAudioTrack: participant.presentationStream.getTracks().some((track) => track.kind === "audio"),
                     stream: participant.presentationStream,


### PR DESCRIPTION
### Description

**Summary:**

* Replace the `MediaStream.getAudioTracks().length > 0` with a `MediaStream.getTrack().some()` function, as some WebRTC implementation does not have `.getAudioTracks()` implemented.
* Use fallback ids if the MediaStream has no `id` for screenshares: `pres-<clientId>` for remote participants and `local-screenshare` for local participant.

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

1. Start screenshare with and without audio
2. They should work as before

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
