### PR TITLE
common: toggle low data mode

### DIFF
--- a/.changeset/moody-mice-behave.md
+++ b/.changeset/moody-mice-behave.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/browser-sdk": minor
+"@whereby.com/core": minor
+---
+
+enable toggling low data mode

--- a/packages/browser-sdk/src/lib/react/useLocalMedia/index.ts
+++ b/packages/browser-sdk/src/lib/react/useLocalMedia/index.ts
@@ -10,6 +10,7 @@ import {
     doStopLocalMedia,
     toggleCameraEnabled,
     toggleMicrophoneEnabled,
+    toggleLowDataModeEnabled,
 } from "@whereby.com/core";
 
 import { LocalMediaState, UseLocalMediaOptions, UseLocalMediaResult } from "./types";
@@ -59,6 +60,11 @@ export function useLocalMedia(
         (enabled?: boolean) => store.dispatch(toggleMicrophoneEnabled({ enabled })),
         [store],
     );
+
+    const toggleLowDataMode = useCallback(
+        (enabled?: boolean) => store.dispatch(toggleLowDataModeEnabled({ enabled })),
+        [store],
+    );
     return {
         state: localMediaState,
         actions: {
@@ -66,6 +72,7 @@ export function useLocalMedia(
             setMicrophoneDevice,
             toggleCameraEnabled: toggleCamera,
             toggleMicrophoneEnabled: toggleMicrophone,
+            toggleLowDataModeEnabled: toggleLowDataMode,
         },
         store,
     };

--- a/packages/browser-sdk/src/lib/react/useLocalMedia/types.ts
+++ b/packages/browser-sdk/src/lib/react/useLocalMedia/types.ts
@@ -20,6 +20,7 @@ interface LocalMediaActions {
     setMicrophoneDevice: (deviceId: string) => void;
     toggleCameraEnabled: (enabled?: boolean) => void;
     toggleMicrophoneEnabled: (enabled?: boolean) => void;
+    toggleLowDataModeEnabled: (enabled?: boolean) => void;
 }
 
 export type UseLocalMediaResult = { state: LocalMediaState; actions: LocalMediaActions; store: Store };

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -13,6 +13,7 @@ import {
     doSetDisplayName,
     toggleCameraEnabled,
     toggleMicrophoneEnabled,
+    toggleLowDataModeEnabled,
     doStartScreenshare,
     doStopScreenshare,
     appLeft,
@@ -136,6 +137,10 @@ export function useRoomConnection(
         (enabled?: boolean) => store.dispatch(toggleMicrophoneEnabled({ enabled })),
         [store],
     );
+    const toggleLowDataMode = React.useCallback(
+        (enabled?: boolean) => store.dispatch(toggleLowDataModeEnabled({ enabled })),
+        [store],
+    );
     const acceptWaitingParticipant = React.useCallback(
         (participantId: string) => store.dispatch(doAcceptWaitingParticipant({ participantId })),
         [store],
@@ -160,6 +165,7 @@ export function useRoomConnection(
     return {
         state: roomConnectionState,
         actions: {
+            toggleLowDataMode,
             acceptWaitingParticipant,
             knock,
             lockRoom,

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -68,6 +68,7 @@ export interface UseRoomConnectionOptions extends Omit<RoomConnectionOptions, "l
 }
 
 export interface RoomConnectionActions {
+    toggleLowDataMode(enabled?: boolean): void;
     acceptWaitingParticipant(participantId: string): void;
     knock(): void;
     lockRoom(locked: boolean): void;

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -40,6 +40,7 @@ export default function VideoExperience({
         muteParticipants,
         toggleCamera,
         toggleMicrophone,
+        toggleLowDataMode,
         acceptWaitingParticipant,
         rejectWaitingParticipant,
         startScreenshare,
@@ -172,6 +173,7 @@ export default function VideoExperience({
                     <div className="controls">
                         <button onClick={() => toggleCamera()}>Toggle camera</button>
                         <button onClick={() => toggleMicrophone()}>Toggle microphone</button>
+                        <button onClick={() => toggleLowDataMode()}>Toggle low data mode</button>
                         <button
                             onClick={() => {
                                 if (isLocalScreenshareActive) {

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -20,6 +20,7 @@ import {
     selectLocalMediaStream,
     selectLocalMediaStatus,
     doSetDevice,
+    doSwitchLocalStream,
 } from "../localMedia";
 import { rtcEvents } from "./actions";
 import { StreamStatusUpdate } from "./types";
@@ -345,6 +346,24 @@ startAppListening({
         const { rtcManager } = selectRtcConnectionRaw(getState());
 
         rtcManager?.removeStream(stream.id, stream, null);
+    },
+});
+
+startAppListening({
+    actionCreator: doSwitchLocalStream.fulfilled,
+    effect: ({ payload }, { getState }) => {
+        const stream = selectLocalMediaStream(getState());
+        const { rtcManager } = selectRtcConnectionRaw(getState());
+
+        if (stream && rtcManager) {
+            const replace = (kind: string, oldTrack: MediaStreamTrack) => {
+                const track = stream.getTracks().find((t) => t.kind === kind);
+                return track && rtcManager.replaceTrack(oldTrack, track);
+            };
+            payload?.replacedTracks?.forEach((t) => {
+                replace(t.kind, t);
+            });
+        }
     },
 });
 

--- a/packages/core/src/redux/tests/store/localMedia.spec.ts
+++ b/packages/core/src/redux/tests/store/localMedia.spec.ts
@@ -123,6 +123,7 @@ describe("actions", () => {
                         isSettingCameraDevice: false,
                         isSettingMicrophoneDevice: false,
                         isTogglingCamera: false,
+                        lowDataMode: false,
                         microphoneEnabled: true,
                         status: "started",
                         stream: new MockMediaStream([audioTrack, videoTrack]),
@@ -175,6 +176,7 @@ describe("actions", () => {
                         isSettingCameraDevice: false,
                         isSettingMicrophoneDevice: false,
                         isTogglingCamera: false,
+                        lowDataMode: false,
                         microphoneEnabled: true,
                         status: "started",
                         stream: localStream,
@@ -228,6 +230,7 @@ describe("actions", () => {
                         isSettingCameraDevice: false,
                         isSettingMicrophoneDevice: false,
                         isTogglingCamera: false,
+                        lowDataMode: false,
                         microphoneEnabled: true,
                         status: "started",
                         stream: localStream,
@@ -272,6 +275,42 @@ describe("actions", () => {
         });
     });
 
+    describe("doToggleLowDataMode", () => {
+        describe("when low data mode is enabled", () => {
+            let initialState: Partial<RootState>;
+            beforeEach(() => {
+                initialState = {
+                    localMedia: {
+                        busyDeviceIds: [],
+                        cameraEnabled: true,
+                        devices: [],
+                        isSettingCameraDevice: false,
+                        isSettingMicrophoneDevice: false,
+                        isTogglingCamera: false,
+                        lowDataMode: false,
+                        microphoneEnabled: true,
+                        status: "started",
+                        stream: new MockMediaStream(),
+                        isSwitchingStream: false,
+                    },
+                };
+            });
+
+            it("should call doSwitchLocalStream", () => {
+                jest.spyOn(localMediaSlice, "doSwitchLocalStream");
+                const store = createStore({ initialState });
+                const before = store.getState().localMedia;
+
+                store.dispatch(localMediaSlice.doToggleLowDataMode());
+
+                expect(localMediaSlice.doSwitchLocalStream).toHaveBeenCalledTimes(1);
+                const after = store.getState().localMedia;
+
+                expect(diff(before, after)).toMatchObject({ isSwitchingStream: true });
+            });
+        });
+    });
+
     describe("doUpdateDeviceList", () => {
         it("should switch to the next video device if current cam is unplugged", async () => {
             const dev1 = {
@@ -299,6 +338,7 @@ describe("actions", () => {
                         isSettingCameraDevice: false,
                         isSettingMicrophoneDevice: false,
                         isTogglingCamera: false,
+                        lowDataMode: false,
                         microphoneEnabled: true,
                         status: "started",
                         stream: new MockMediaStream(),
@@ -372,6 +412,7 @@ describe("actions", () => {
                         isSettingCameraDevice: false,
                         isSettingMicrophoneDevice: false,
                         isTogglingCamera: false,
+                        lowDataMode: false,
                         microphoneEnabled: true,
                         status: "started",
                         stream,


### PR DESCRIPTION
### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->
Enable toggling low data mode ✨ 

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

- Run yarn build && yarn dev
- Connect to http://localhost:6006/?path=/story/examples-custom-ui--room-connection-with-local-media
- Join the room in another tab as well so you can check the video stream
- Toggle low data mode
- Check that the stream is still active in the other tab! 
- In redux tab of dev tools, you can check that low data mode is toggling on / off properly
### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
