### PR TITLE
core: Fix signal reconnect flow

### DIFF
--- a/.changeset/new-eels-tease.md
+++ b/.changeset/new-eels-tease.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": minor
+---
+
+Fix signal reconnect flow


### PR DESCRIPTION
### Description

During testing we discovered that the process of reconnecting to a room after network disconnect/reconnect was broken.

This PR fixes the reconnect flow and reuses the existing device credentials from the original signal connection.

### Testing

1. Join the room URL configured in the SDK from the room URL (not using the SDK) to observe the following steps.
2. **Using `master` branch**, run `yarn dev`
3. Navigate to the "Room Connection Only" storybook page in the browser. SDK should join the configured room.
4. In the Developer Tools, simulate a network disconnect and network reconnect (i.e. switch from "No throttling" to "Offline" and then after a couple of seconds switch back to "No throttling")
5. The SDK is unable to reconnect to the room on network reconnect and `RTCPeerConnection` warnings are displayed in the developer console.
6. Check out this branch and run `yarn build && yarn dev`
7. Navigate back to the "Room Connection Only" storybook page in the browser. SDK should join the configured room.
8. In the Developer Tools, simulate a network disconnect and network reconnect (i.e. switch from "No throttling" to "Offline" and then after a couple of seconds switch back to "No throttling")
9. The SDK is now able to reconnect to the room and no warnings are displayed in the developer console.

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
