### PR TITLE
Add kick participant and end meeting actions for meeting hosts

### DIFF
--- a/.changeset/wicked-goats-notice.md
+++ b/.changeset/wicked-goats-notice.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/browser-sdk": minor
+"@whereby.com/core": minor
+---
+
+Allow room hosts to kick clients and end the meeting

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -160,10 +160,9 @@ export function useRoomConnection(
     );
     const kickParticipant = React.useCallback(
         (clientId: string) => store.dispatch(doKickParticipant({ clientId })),
-    const endMeeting = React.useCallback(
-        (stayBehind: boolean = false) => store.dispatch(doEndMeeting({ stayBehind })),
         [store],
     );
+    const endMeeting = React.useCallback(() => store.dispatch(doEndMeeting()), [store]);
 
     return {
         state: roomConnectionState,

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -20,6 +20,7 @@ import {
     doKnockRoom,
     doLockRoom,
     doKickParticipant,
+    doEndMeeting,
     doRtcReportStreamResolution,
 } from "@whereby.com/core";
 
@@ -159,6 +160,8 @@ export function useRoomConnection(
     );
     const kickParticipant = React.useCallback(
         (clientId: string) => store.dispatch(doKickParticipant({ clientId })),
+    const endMeeting = React.useCallback(
+        (stayBehind: boolean = false) => store.dispatch(doEndMeeting({ stayBehind })),
         [store],
     );
 
@@ -170,6 +173,7 @@ export function useRoomConnection(
             lockRoom,
             muteParticipants,
             kickParticipant,
+            endMeeting,
             rejectWaitingParticipant,
             sendChatMessage,
             setDisplayName,

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -19,6 +19,7 @@ import {
     doAppJoin,
     doKnockRoom,
     doLockRoom,
+    doKickParticipant,
     doRtcReportStreamResolution,
 } from "@whereby.com/core";
 
@@ -156,6 +157,10 @@ export function useRoomConnection(
         },
         [store],
     );
+    const kickParticipant = React.useCallback(
+        (clientId: string) => store.dispatch(doKickParticipant({ clientId })),
+        [store],
+    );
 
     return {
         state: roomConnectionState,
@@ -164,6 +169,7 @@ export function useRoomConnection(
             knock,
             lockRoom,
             muteParticipants,
+            kickParticipant,
             rejectWaitingParticipant,
             sendChatMessage,
             setDisplayName,

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -73,6 +73,7 @@ export interface RoomConnectionActions {
     lockRoom(locked: boolean): void;
     muteParticipants(clientIds: string[]): void;
     kickParticipant(clientId: string): void;
+    endMeeting(stayBehind?: boolean): void;
     rejectWaitingParticipant(participantId: string): void;
     sendChatMessage(text: string): void;
     setDisplayName(displayName: string): void;

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -72,6 +72,7 @@ export interface RoomConnectionActions {
     knock(): void;
     lockRoom(locked: boolean): void;
     muteParticipants(clientIds: string[]): void;
+    kickParticipant(clientId: string): void;
     rejectWaitingParticipant(participantId: string): void;
     sendChatMessage(text: string): void;
     setDisplayName(displayName: string): void;

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -73,7 +73,7 @@ export interface RoomConnectionActions {
     lockRoom(locked: boolean): void;
     muteParticipants(clientIds: string[]): void;
     kickParticipant(clientId: string): void;
-    endMeeting(stayBehind?: boolean): void;
+    endMeeting(): void;
     rejectWaitingParticipant(participantId: string): void;
     sendChatMessage(text: string): void;
     setDisplayName(displayName: string): void;

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -40,6 +40,7 @@ export default function VideoExperience({
         lockRoom,
         muteParticipants,
         kickParticipant,
+        endMeeting,
         toggleCamera,
         toggleMicrophone,
         acceptWaitingParticipant,
@@ -100,6 +101,12 @@ export default function VideoExperience({
                                 className={localParticipant?.roleName !== "host" ? "hostControlActionDisallowed" : ""}
                             >
                                 Unlock room
+                            </button>
+                            <button
+                                onClick={() => endMeeting()}
+                                className={localParticipant?.roleName !== "host" ? "hostControlActionDisallowed" : ""}
+                            >
+                                End meeting
                             </button>
                         </div>
                     )}

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -37,14 +37,15 @@ export default function VideoExperience({
         knock,
         sendChatMessage,
         setDisplayName,
+        lockRoom,
         muteParticipants,
+        kickParticipant,
         toggleCamera,
         toggleMicrophone,
         acceptWaitingParticipant,
         rejectWaitingParticipant,
         startScreenshare,
         stopScreenshare,
-        lockRoom,
     } = actions;
     const { VideoView } = components;
 
@@ -154,6 +155,18 @@ export default function VideoExperience({
                                                         }
                                                     >
                                                         Mute
+                                                    </button>{" "}
+                                                    <button
+                                                        onClick={() => {
+                                                            kickParticipant(participant.id);
+                                                        }}
+                                                        className={
+                                                            localParticipant?.roleName !== "host"
+                                                                ? "hostControlActionDisallowed"
+                                                                : ""
+                                                        }
+                                                    >
+                                                        Kick
                                                     </button>
                                                 </>
                                             ) : null}

--- a/packages/browser-sdk/vite.config.mts
+++ b/packages/browser-sdk/vite.config.mts
@@ -8,6 +8,7 @@ export default defineConfig({
             REACT_APP_API_BASE_URL: process.env.REACT_APP_API_BASE_URL || "https://api.appearin.net",
             REACT_APP_SIGNAL_BASE_URL: process.env.REACT_APP_SIGNAL_BASE_URL || "wss://signal.appearin.net",
             STORYBOOK_ROOM: process.env.STORYBOOK_ROOM,
+            STORYBOOK_ROOM_HOST_ROOMKEY: process.env.STORYBOOK_ROOM_HOST_ROOMKEY,
             REACT_APP_IS_DEV: process.env.REACT_APP_IS_DEV || "false",
         },
     },

--- a/packages/core/src/redux/index.ts
+++ b/packages/core/src/redux/index.ts
@@ -13,6 +13,7 @@ export * from "./slices/localParticipant";
 export * from "./slices/localScreenshare";
 export * from "./slices/organization";
 export * from "./slices/remoteParticipants";
+export * from "./slices/room";
 export * from "./slices/roomConnection";
 export * from "./slices/rtcAnalytics";
 export * from "./slices/streaming";

--- a/packages/core/src/redux/slices/__tests__/authorization.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/authorization.unit.ts
@@ -2,6 +2,7 @@ import {
     authorizationSlice,
     selectIsAuthorizedToLockRoom,
     selectIsAuthorizedToKickClient,
+    selectIsAuthorizedToEndMeeting,
     selectIsAuthorizedToRequestAudioEnable,
 } from "../authorization";
 
@@ -37,6 +38,19 @@ describe("authorizationSlice", () => {
                 "should return $expectedResult when localParticipantRole=$localParticipantRole",
                 ({ localParticipantRole, expectedResult }) => {
                     expect(selectIsAuthorizedToKickClient.resultFunc(localParticipantRole)).toEqual(expectedResult);
+                },
+            );
+        });
+
+        describe("selectIsAuthorizedToEndMeeting", () => {
+            it.each`
+                localParticipantRole | expectedResult
+                ${"visitor"}         | ${false}
+                ${"host"}            | ${true}
+            `(
+                "should return $expectedResult when localParticipantRole=$localParticipantRole",
+                ({ localParticipantRole, expectedResult }) => {
+                    expect(selectIsAuthorizedToEndMeeting.resultFunc(localParticipantRole)).toEqual(expectedResult);
                 },
             );
         });

--- a/packages/core/src/redux/slices/__tests__/authorization.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/authorization.unit.ts
@@ -6,9 +6,29 @@ import {
     selectIsAuthorizedToRequestAudioEnable,
 } from "../authorization";
 import { signalEvents } from "../signalConnection/actions";
+import { doAppJoin } from "../app";
 
 describe("authorizationSlice", () => {
     describe("reducers", () => {
+        it("setRoomKey", () => {
+            const result = authorizationSlice.reducer(undefined, authorizationSlice.actions.setRoomKey("roomKey"));
+
+            expect(result.roomKey).toEqual("roomKey");
+        });
+
+        it("doAppJoin", () => {
+            const result = authorizationSlice.reducer(
+                undefined,
+                doAppJoin({
+                    roomUrl: "https://some.url/roomName",
+                    roomKey: "roomKey",
+                    displayName: "displayName",
+                    externalId: "externalId",
+                }),
+            );
+            expect(result.roomKey).toEqual("roomKey");
+        });
+
         it("signalEvents.roomJoined", () => {
             const result = authorizationSlice.reducer(
                 undefined,

--- a/packages/core/src/redux/slices/__tests__/authorization.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/authorization.unit.ts
@@ -5,13 +5,38 @@ import {
     selectIsAuthorizedToEndMeeting,
     selectIsAuthorizedToRequestAudioEnable,
 } from "../authorization";
+import { signalEvents } from "../signalConnection/actions";
 
 describe("authorizationSlice", () => {
     describe("reducers", () => {
-        it("setRoomKey", () => {
-            const result = authorizationSlice.reducer(undefined, authorizationSlice.actions.setRoomKey("roomKey"));
-
-            expect(result.roomKey).toEqual("roomKey");
+        it("signalEvents.roomJoined", () => {
+            const result = authorizationSlice.reducer(
+                undefined,
+                signalEvents.roomJoined({
+                    selfId: "selfId",
+                    clientClaim: "clientClaim",
+                    isLocked: false,
+                    room: {
+                        clients: [
+                            {
+                                displayName: "displayName",
+                                id: "selfId",
+                                streams: [],
+                                isAudioEnabled: true,
+                                isVideoEnabled: true,
+                                role: {
+                                    roleName: "host",
+                                },
+                                startedCloudRecordingAt: null,
+                                externalId: null,
+                            },
+                        ],
+                        knockers: [],
+                        session: null,
+                    },
+                }),
+            );
+            expect(result.roleName).toEqual("host");
         });
     });
 

--- a/packages/core/src/redux/slices/__tests__/authorization.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/authorization.unit.ts
@@ -1,6 +1,7 @@
 import {
     authorizationSlice,
     selectIsAuthorizedToLockRoom,
+    selectIsAuthorizedToKickClient,
     selectIsAuthorizedToRequestAudioEnable,
 } from "../authorization";
 
@@ -23,6 +24,19 @@ describe("authorizationSlice", () => {
                 "should return $expectedResult when localParticipantRole=$localParticipantRole",
                 ({ localParticipantRole, expectedResult }) => {
                     expect(selectIsAuthorizedToLockRoom.resultFunc(localParticipantRole)).toEqual(expectedResult);
+                },
+            );
+        });
+
+        describe("selectIsAuthorizedToKickClient", () => {
+            it.each`
+                localParticipantRole | expectedResult
+                ${"visitor"}         | ${false}
+                ${"host"}            | ${true}
+            `(
+                "should return $expectedResult when localParticipantRole=$localParticipantRole",
+                ({ localParticipantRole, expectedResult }) => {
+                    expect(selectIsAuthorizedToKickClient.resultFunc(localParticipantRole)).toEqual(expectedResult);
                 },
             );
         });

--- a/packages/core/src/redux/slices/__tests__/room.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/room.unit.ts
@@ -1,0 +1,48 @@
+import { roomSlice } from "../room";
+import { doAppJoin } from "../app";
+import { signalEvents } from "../signalConnection/actions";
+
+describe("roomSlice", () => {
+    describe("reducers", () => {
+        it("setRoomKey", () => {
+            const result = roomSlice.reducer(undefined, roomSlice.actions.setRoomKey("roomKey"));
+
+            expect(result.roomKey).toEqual("roomKey");
+        });
+
+        it("doAppJoin", () => {
+            const result = roomSlice.reducer(
+                undefined,
+                doAppJoin({
+                    roomUrl: "https://some.url/roomName",
+                    roomKey: "roomKey",
+                    displayName: "displayName",
+                    externalId: "externalId",
+                }),
+            );
+            expect(result.roomKey).toEqual("roomKey");
+        });
+
+        it("signalEvents.roomJoined", () => {
+            const result = roomSlice.reducer(
+                undefined,
+                signalEvents.roomJoined({
+                    selfId: "selfId",
+                    clientClaim: "clientClaim",
+                    isLocked: true,
+                }),
+            );
+            expect(result.isLocked).toEqual(true);
+        });
+
+        it("signalEvents.roomLocked", () => {
+            const result = roomSlice.reducer(
+                undefined,
+                signalEvents.roomLocked({
+                    isLocked: true,
+                }),
+            );
+            expect(result.isLocked).toEqual(true);
+        });
+    });
+});

--- a/packages/core/src/redux/slices/__tests__/room.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/room.unit.ts
@@ -1,28 +1,8 @@
 import { roomSlice } from "../room";
-import { doAppJoin } from "../app";
 import { signalEvents } from "../signalConnection/actions";
 
 describe("roomSlice", () => {
     describe("reducers", () => {
-        it("setRoomKey", () => {
-            const result = roomSlice.reducer(undefined, roomSlice.actions.setRoomKey("roomKey"));
-
-            expect(result.roomKey).toEqual("roomKey");
-        });
-
-        it("doAppJoin", () => {
-            const result = roomSlice.reducer(
-                undefined,
-                doAppJoin({
-                    roomUrl: "https://some.url/roomName",
-                    roomKey: "roomKey",
-                    displayName: "displayName",
-                    externalId: "externalId",
-                }),
-            );
-            expect(result.roomKey).toEqual("roomKey");
-        });
-
         it("signalEvents.roomJoined", () => {
             const result = roomSlice.reducer(
                 undefined,

--- a/packages/core/src/redux/slices/authorization.ts
+++ b/packages/core/src/redux/slices/authorization.ts
@@ -100,7 +100,7 @@ export const doKickParticipant = createAppAuthorizedThunk(
 
 export const doEndMeeting = createAppAuthorizedThunk(
     (state) => selectIsAuthorizedToEndMeeting(state),
-    (payload: { stayBehind?: boolean }) => (dispatch, getState) => {
+    () => (_, getState) => {
         const state = getState();
 
         const clientsToKick = selectRemoteParticipants(state).map((c) => c.id);
@@ -108,16 +108,6 @@ export const doEndMeeting = createAppAuthorizedThunk(
         const { socket } = selectSignalConnectionRaw(state);
 
         socket?.emit("kick_client", { clientIds: clientsToKick, reasonId: "end-meeting" });
-
-        dispatch({
-            type: "END_MEETING",
-            payload: { requestedByClientId: payload.stayBehind ? null : selectSelfId(state) },
-        });
-
-        // TODO: need to first implement leave room action
-        // if (!stayBehind) {
-        //     doLeaveRoom();
-        // }
     },
 );
 

--- a/packages/core/src/redux/slices/authorization.ts
+++ b/packages/core/src/redux/slices/authorization.ts
@@ -10,6 +10,7 @@ import { selectLocalParticipantRole } from "./localParticipant";
 const ACTION_PERMISSIONS_BY_ROLE: { [permissionKey: string]: Array<RoleName> } = {
     canLockRoom: ["host"],
     canRequestAudioEnable: ["host"],
+    canKickClient: ["host"],
 };
 
 /**
@@ -85,6 +86,16 @@ export const doLockRoom = createAppAuthorizedThunk(
     },
 );
 
+export const doKickParticipant = createAppAuthorizedThunk(
+    (state) => selectIsAuthorizedToKickClient(state),
+    (payload: { clientId: string }) => (_, getState) => {
+        const state = getState();
+
+        const { socket } = selectSignalConnectionRaw(state);
+        socket?.emit("kick_client", { clientId: payload.clientId, reasonId: "kick" });
+    },
+);
+
 /**
  * Selectors
  */
@@ -97,4 +108,7 @@ export const selectIsAuthorizedToLockRoom = createSelector(selectLocalParticipan
 export const selectIsAuthorizedToRequestAudioEnable = createSelector(
     selectLocalParticipantRole,
     (localParticipantRole) => ACTION_PERMISSIONS_BY_ROLE.canRequestAudioEnable.includes(localParticipantRole),
+);
+export const selectIsAuthorizedToKickClient = createSelector(selectLocalParticipantRole, (localParticipantRole) =>
+    ACTION_PERMISSIONS_BY_ROLE.canKickClient.includes(localParticipantRole),
 );

--- a/packages/core/src/redux/slices/localParticipant.ts
+++ b/packages/core/src/redux/slices/localParticipant.ts
@@ -120,7 +120,6 @@ export const { doSetLocalParticipant } = localParticipantSlice.actions;
 export const selectLocalParticipantRaw = (state: RootState) => state.localParticipant;
 export const selectSelfId = (state: RootState) => state.localParticipant.id;
 export const selectLocalParticipantClientClaim = (state: RootState) => state.localParticipant.clientClaim;
-export const selectLocalParticipantRole = (state: RootState) => state.localParticipant.roleName;
 export const selectLocalParticipantIsScreenSharing = (state: RootState) => state.localParticipant.isScreenSharing;
 
 startAppListening({

--- a/packages/core/src/redux/slices/room.ts
+++ b/packages/core/src/redux/slices/room.ts
@@ -1,0 +1,116 @@
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+import { RootState } from "../store";
+import { createAppAuthorizedThunk } from "../thunk";
+import { signalEvents } from "./signalConnection/actions";
+import {
+    selectIsAuthorizedToLockRoom,
+    selectIsAuthorizedToKickClient,
+    selectIsAuthorizedToEndMeeting,
+} from "./authorization";
+import { selectSignalConnectionRaw } from "./signalConnection";
+import { selectRemoteParticipants } from "./remoteParticipants";
+import { doAppJoin } from "./app";
+
+/**
+ * Reducer
+ */
+
+export interface RoomState {
+    roomKey: string | null;
+    isLocked: boolean;
+}
+
+const initialState: RoomState = {
+    roomKey: null,
+    isLocked: false,
+};
+
+export const roomSlice = createSlice({
+    name: "room",
+    initialState,
+    reducers: {
+        setRoomKey: (state, action: PayloadAction<string | null>) => {
+            return {
+                ...state,
+                roomKey: action.payload,
+            };
+        },
+    },
+    extraReducers: (builder) => {
+        builder.addCase(doAppJoin, (state, action) => {
+            return {
+                ...state,
+                roomKey: action.payload.roomKey,
+            };
+        });
+
+        builder.addCase(signalEvents.roomJoined, (state, action) => {
+            const { error, isLocked } = action.payload;
+
+            if (error) {
+                return state;
+            }
+
+            return {
+                ...state,
+                isLocked: Boolean(isLocked),
+            };
+        });
+
+        builder.addCase(signalEvents.roomLocked, (state, action) => {
+            const { isLocked } = action.payload;
+
+            return {
+                ...state,
+                isLocked: Boolean(isLocked),
+            };
+        });
+    },
+});
+
+/**
+ * Action creators
+ */
+
+export const { setRoomKey } = roomSlice.actions;
+
+export const doLockRoom = createAppAuthorizedThunk(
+    (state) => selectIsAuthorizedToLockRoom(state),
+    (payload: { locked: boolean }) => (_, getState) => {
+        const state = getState();
+
+        const { socket } = selectSignalConnectionRaw(state);
+        socket?.emit("set_lock", { locked: payload.locked });
+    },
+);
+
+export const doKickParticipant = createAppAuthorizedThunk(
+    (state) => selectIsAuthorizedToKickClient(state),
+    (payload: { clientId: string }) => (_, getState) => {
+        const state = getState();
+
+        const { socket } = selectSignalConnectionRaw(state);
+        socket?.emit("kick_client", { clientId: payload.clientId, reasonId: "kick" });
+    },
+);
+
+export const doEndMeeting = createAppAuthorizedThunk(
+    (state) => selectIsAuthorizedToEndMeeting(state),
+    () => (_, getState) => {
+        const state = getState();
+
+        const clientsToKick = selectRemoteParticipants(state).map((c) => c.id);
+
+        const { socket } = selectSignalConnectionRaw(state);
+
+        socket?.emit("kick_client", { clientIds: clientsToKick, reasonId: "end-meeting" });
+    },
+);
+
+/**
+ * Selectors
+ */
+
+export const selectRoomKey = (state: RootState) => state.room.roomKey;
+
+export const selectRoomIsLocked = (state: RootState) => state.room.isLocked;

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -10,7 +10,7 @@ import {
     selectAppExternalId,
     selectAppIsNodeSdk,
 } from "./app";
-import { selectRoomKey, setRoomKey } from "./room";
+import { selectRoomKey, setRoomKey } from "./authorization";
 
 import { selectOrganizationId } from "./organization";
 import { signalEvents } from "./signalConnection/actions";

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -10,7 +10,7 @@ import {
     selectAppExternalId,
     selectAppIsNodeSdk,
 } from "./app";
-import { selectAuthorizationRoomKey, setRoomKey } from "./authorization";
+import { selectRoomKey, setRoomKey } from "./room";
 
 import { selectOrganizationId } from "./organization";
 import { signalEvents } from "./signalConnection/actions";
@@ -133,7 +133,7 @@ export const doKnockRoom = createAppThunk(() => (dispatch, getState) => {
     const state = getState();
     const socket = selectSignalConnectionRaw(state).socket;
     const roomName = selectAppRoomName(state);
-    const roomKey = selectAuthorizationRoomKey(state);
+    const roomKey = selectRoomKey(state);
     const displayName = selectAppDisplayName(state);
     const userAgent = selectAppUserAgent(state);
     const externalId = selectAppExternalId(state);
@@ -164,7 +164,7 @@ export const doConnectRoom = createAppThunk(() => (dispatch, getState) => {
     const state = getState();
     const socket = selectSignalConnectionRaw(state).socket;
     const roomName = selectAppRoomName(state);
-    const roomKey = selectAuthorizationRoomKey(state);
+    const roomKey = selectRoomKey(state);
     const displayName = selectAppDisplayName(state);
     const userAgent = selectAppUserAgent(state);
     const externalId = selectAppExternalId(state);

--- a/packages/core/src/redux/slices/rtcAnalytics.ts
+++ b/packages/core/src/redux/slices/rtcAnalytics.ts
@@ -6,13 +6,8 @@ import { createReactor, startAppListening } from "../listenerMiddleware";
 import { selectRtcConnectionRaw, selectRtcManagerInitialized, selectRtcStatus } from "./rtcConnection";
 import { selectAppDisplayName, selectAppExternalId } from "./app";
 import { selectOrganizationId } from "./organization";
-import {
-    doEnableAudio,
-    doEnableVideo,
-    doSetDisplayName,
-    selectLocalParticipantRole,
-    selectSelfId,
-} from "./localParticipant";
+import { doEnableAudio, doEnableVideo, doSetDisplayName, selectSelfId } from "./localParticipant";
+import { selectAuthorizationRoleName } from "./authorization";
 import { selectSignalStatus } from "./signalConnection";
 import { selectDeviceId } from "./deviceCredentials";
 import { doSetDevice, selectIsCameraEnabled, selectIsMicrophoneEnabled, selectLocalMediaStream } from "./localMedia";
@@ -121,7 +116,7 @@ export const rtcAnalyticsCustomEvents: { [key: string]: RtcAnalyticsCustomEvent 
     userRole: {
         actions: null,
         rtcEventName: "userRole",
-        getValue: (state: RootState) => selectLocalParticipantRole(state),
+        getValue: (state: RootState) => selectAuthorizationRoleName(state),
         getOutput: (value) => ({ userRole: value }),
     },
 };

--- a/packages/core/src/redux/store.ts
+++ b/packages/core/src/redux/store.ts
@@ -12,6 +12,7 @@ import { localParticipantSlice } from "./slices/localParticipant";
 import { localScreenshareSlice } from "./slices/localScreenshare";
 import { organizationSlice } from "./slices/organization";
 import { remoteParticipantsSlice } from "./slices/remoteParticipants";
+import { roomSlice } from "./slices/room";
 import { roomConnectionSlice } from "./slices/roomConnection";
 import { signalConnectionSlice } from "./slices/signalConnection";
 import { rtcAnalyticsSlice } from "./slices/rtcAnalytics";
@@ -32,6 +33,7 @@ export const rootReducer = combineReducers({
     localScreenshare: localScreenshareSlice.reducer,
     organization: organizationSlice.reducer,
     remoteParticipants: remoteParticipantsSlice.reducer,
+    room: roomSlice.reducer,
     roomConnection: roomConnectionSlice.reducer,
     rtcAnalytics: rtcAnalyticsSlice.reducer,
     rtcConnection: rtcConnectionSlice.reducer,

--- a/packages/core/src/redux/tests/store/authorization.spec.ts
+++ b/packages/core/src/redux/tests/store/authorization.spec.ts
@@ -91,7 +91,7 @@ describe("actions", () => {
                     withSignalConnection: true,
                 });
 
-                expect(() => store.dispatch(doEndMeeting({ stayBehind: false }))).not.toThrow();
+                expect(() => store.dispatch(doEndMeeting())).not.toThrow();
 
                 expect(mockSignalEmit).toHaveBeenCalledWith("kick_client", {
                     clientIds: remoteParticipants.map(({ id }) => id),
@@ -110,9 +110,7 @@ describe("actions", () => {
                     withSignalConnection: true,
                 });
 
-                expect(() => store.dispatch(doEndMeeting({ stayBehind: false }))).toThrow(
-                    `Not authorized to perform this action`,
-                );
+                expect(() => store.dispatch(doEndMeeting())).toThrow(`Not authorized to perform this action`);
 
                 expect(mockSignalEmit).not.toHaveBeenCalled();
             });

--- a/packages/core/src/redux/tests/store/remoteParticipants.spec.ts
+++ b/packages/core/src/redux/tests/store/remoteParticipants.spec.ts
@@ -1,12 +1,12 @@
 import { doRequestAudioEnable } from "../../slices/remoteParticipants";
 import { createStore, mockSignalEmit } from "../store.setup";
-import { randomLocalParticipant, randomString } from "../../../__mocks__/appMocks";
+import { randomString } from "../../../__mocks__/appMocks";
 
 describe("actions", () => {
     describe("when authorized", () => {
         it("should request audio enable", () => {
             const store = createStore({
-                initialState: { localParticipant: randomLocalParticipant({ roleName: "host" }) },
+                initialState: { authorization: { roleName: "host" } },
                 withSignalConnection: true,
             });
             const clientId = randomString();
@@ -23,7 +23,7 @@ describe("actions", () => {
     describe("when not authorized", () => {
         it("should not request audio enable", () => {
             const store = createStore({
-                initialState: { localParticipant: randomLocalParticipant({ roleName: "visitor" }) },
+                initialState: { authorization: { roleName: "visitor" } },
                 withSignalConnection: true,
             });
             const clientId = randomString();

--- a/packages/core/src/redux/tests/store/remoteParticipants.spec.ts
+++ b/packages/core/src/redux/tests/store/remoteParticipants.spec.ts
@@ -6,7 +6,7 @@ describe("actions", () => {
     describe("when authorized", () => {
         it("should request audio enable", () => {
             const store = createStore({
-                initialState: { authorization: { roleName: "host" } },
+                initialState: { authorization: { roomKey: null, roleName: "host" } },
                 withSignalConnection: true,
             });
             const clientId = randomString();
@@ -23,7 +23,7 @@ describe("actions", () => {
     describe("when not authorized", () => {
         it("should not request audio enable", () => {
             const store = createStore({
-                initialState: { authorization: { roleName: "visitor" } },
+                initialState: { authorization: { roomKey: null, roleName: "visitor" } },
                 withSignalConnection: true,
             });
             const clientId = randomString();

--- a/packages/core/src/redux/tests/store/room.spec.ts
+++ b/packages/core/src/redux/tests/store/room.spec.ts
@@ -7,7 +7,7 @@ describe("actions", () => {
         describe("when authorized", () => {
             it("should lock room", () => {
                 const store = createStore({
-                    initialState: { authorization: { roleName: "host" } },
+                    initialState: { authorization: { roomKey: null, roleName: "host" } },
                     withSignalConnection: true,
                 });
 
@@ -20,7 +20,7 @@ describe("actions", () => {
         describe("when not authorized", () => {
             it("should not lock room", () => {
                 const store = createStore({
-                    initialState: { authorization: { roleName: "visitor" } },
+                    initialState: { authorization: { roomKey: null, roleName: "visitor" } },
                     withSignalConnection: true,
                 });
 
@@ -40,7 +40,7 @@ describe("actions", () => {
 
                 const store = createStore({
                     initialState: {
-                        authorization: { roleName: "host" },
+                        authorization: { roomKey: null, roleName: "host" },
                         remoteParticipants: { remoteParticipants: [remoteParticipant] },
                     },
                     withSignalConnection: true,
@@ -61,7 +61,7 @@ describe("actions", () => {
 
                 const store = createStore({
                     initialState: {
-                        authorization: { roleName: "visitor" },
+                        authorization: { roomKey: null, roleName: "visitor" },
                         remoteParticipants: { remoteParticipants: [remoteParticipant] },
                     },
                     withSignalConnection: true,
@@ -83,7 +83,7 @@ describe("actions", () => {
             it("should end the meeting for all remote participants", () => {
                 const store = createStore({
                     initialState: {
-                        authorization: { roleName: "host" },
+                        authorization: { roomKey: null, roleName: "host" },
                         remoteParticipants: {
                             remoteParticipants,
                         },
@@ -104,7 +104,7 @@ describe("actions", () => {
             it("should not end the meeting for any participants", () => {
                 const store = createStore({
                     initialState: {
-                        authorization: { roleName: "visitor" },
+                        authorization: { roomKey: null, roleName: "visitor" },
                         remoteParticipants: { remoteParticipants },
                     },
                     withSignalConnection: true,

--- a/packages/core/src/redux/tests/store/room.spec.ts
+++ b/packages/core/src/redux/tests/store/room.spec.ts
@@ -1,13 +1,13 @@
 import { createStore, mockSignalEmit } from "../store.setup";
-import { randomLocalParticipant, randomRemoteParticipant } from "../../../__mocks__/appMocks";
-import { doLockRoom, doKickParticipant, doEndMeeting } from "../../slices/authorization";
+import { randomRemoteParticipant } from "../../../__mocks__/appMocks";
+import { doLockRoom, doKickParticipant, doEndMeeting } from "../../slices/room";
 
 describe("actions", () => {
     describe("doLockRoom", () => {
         describe("when authorized", () => {
             it("should lock room", () => {
                 const store = createStore({
-                    initialState: { localParticipant: randomLocalParticipant({ roleName: "host" }) },
+                    initialState: { authorization: { roleName: "host" } },
                     withSignalConnection: true,
                 });
 
@@ -20,7 +20,7 @@ describe("actions", () => {
         describe("when not authorized", () => {
             it("should not lock room", () => {
                 const store = createStore({
-                    initialState: { localParticipant: randomLocalParticipant({ roleName: "visitor" }) },
+                    initialState: { authorization: { roleName: "visitor" } },
                     withSignalConnection: true,
                 });
 
@@ -40,7 +40,7 @@ describe("actions", () => {
 
                 const store = createStore({
                     initialState: {
-                        localParticipant: randomLocalParticipant({ roleName: "host" }),
+                        authorization: { roleName: "host" },
                         remoteParticipants: { remoteParticipants: [remoteParticipant] },
                     },
                     withSignalConnection: true,
@@ -61,7 +61,7 @@ describe("actions", () => {
 
                 const store = createStore({
                     initialState: {
-                        localParticipant: randomLocalParticipant({ roleName: "visitor" }),
+                        authorization: { roleName: "visitor" },
                         remoteParticipants: { remoteParticipants: [remoteParticipant] },
                     },
                     withSignalConnection: true,
@@ -83,7 +83,7 @@ describe("actions", () => {
             it("should end the meeting for all remote participants", () => {
                 const store = createStore({
                     initialState: {
-                        localParticipant: randomLocalParticipant({ roleName: "host" }),
+                        authorization: { roleName: "host" },
                         remoteParticipants: {
                             remoteParticipants,
                         },
@@ -104,7 +104,7 @@ describe("actions", () => {
             it("should not end the meeting for any participants", () => {
                 const store = createStore({
                     initialState: {
-                        localParticipant: randomLocalParticipant({ roleName: "visitor" }),
+                        authorization: { roleName: "visitor" },
                         remoteParticipants: { remoteParticipants },
                     },
                     withSignalConnection: true,


### PR DESCRIPTION
### Description

Allow participants joining with the `host` role to kick a remote participant and/or end the meeting for all remote participants.

### Testing

1. Run local-stack and join a room with 1 or more participants via PWA.
2. Check out this branch
3. Ensure that STORYBOOK_ROOM is the same URL as the joined room in step 1.
4. In the `/.env` file add a valid _host_ `roomKey` for the configured `STORYBOOK_ROOM` in following line:

```
STORYBOOK_ROOM_HOST_ROOMKEY=[host_roomKey_here]
```

5. Run `yarn build && yarn dev`
6. Open the storybook story: "Custom UI" > "Room Connection With Host Controls" ([direct localhost link](http://localhost:6006/?path=/story/examples-custom-ui--room-connection-with-host-controls))
7. Check that the `roomKey` is filled with the host room key added in step 4.
8. Clicking on the "End meeting" button and individual "Kick" buttons should now perform the respective actions in the connected room [Screenshot 1].
9. In the storybook controls panel, remove the `roomKey` parameter and reload the story
10. The "End meeting" button and individual "Kick" buttons shown in the UI should now be in red [Screenshot 2]
11. Clicking on the "End meeting" button or any of the individual "Kick" buttons should not perform the action in the connected room (not connected as a "host" now).
12. Additionally, a warning should be displayed in the console whenever these actions are invoked by a non-"host" user.

### Screenshots/GIFs (if applicable)

#### Screenshot 1: "host" `roomKey` provided

<img width="520" alt="Screenshot 2024-04-17 at 15 47 04" src="https://github.com/whereby/sdk/assets/119658286/45a2257f-d052-4311-9a98-f4792e9913eb">


#### Screenshot 2: "host" `roomKey` not provided

<img width="554" alt="Screenshot 2024-04-17 at 15 47 17" src="https://github.com/whereby/sdk/assets/119658286/9e05e684-c010-48a4-8d00-a168fa9a5e8f">

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
