### PR TITLE
browser-sdk: Add endMeeting() command to embed element

### DIFF
--- a/.changeset/pink-fireants-shout.md
+++ b/.changeset/pink-fireants-shout.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": minor
+---
+
+Add `endMeeting()` command on embed element

--- a/packages/browser-sdk/src/lib/embed/index.ts
+++ b/packages/browser-sdk/src/lib/embed/index.ts
@@ -98,6 +98,7 @@ interface WherebyEmbedElementEventMap {
 }
 
 interface WherebyEmbedElementCommands {
+    endMeeting: () => void;
     startRecording: () => void;
     stopRecording: () => void;
     startStreaming: () => void;
@@ -209,6 +210,9 @@ define("WherebyEmbed", {
         if (this.iframe.current) {
             this.iframe.current.contentWindow.postMessage({ command, args }, this.roomUrl.origin);
         }
+    },
+    endMeeting() {
+        this._postCommand("end_meeting");
     },
     startRecording() {
         this._postCommand("start_recording");


### PR DESCRIPTION
### Description

**Summary:**

Updates Embed element portion of the SDK to allow for an end_meeting command/browser method

Local user must be a host

**Related PR:**
https://github.com/whereby/pwa/pull/4067

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->


