### PR TITLE
browser-sdk: Redux hooks

### DIFF
--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -76,7 +76,8 @@
   "dependencies": {
     "@reduxjs/toolkit": "^2.2.3",
     "@whereby.com/core": "0.13.0",
-    "heresy": "^1.0.4"
+    "heresy": "^1.0.4",
+    "react-redux": "^9.1.1"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/packages/browser-sdk/src/lib/react/Grid/index.tsx
+++ b/packages/browser-sdk/src/lib/react/Grid/index.tsx
@@ -5,6 +5,7 @@ import { setAspectRatio, debounce } from "@whereby.com/core";
 import { CellView, Bounds, Origin } from "./layout/types";
 import { VideoStageLayout } from "./VideoStageLayout";
 import { useGrid } from "./useGrid";
+import { useAppDispatch } from "../Provider/hooks";
 
 interface RenderCellViewProps {
     cellView: CellView;
@@ -78,16 +79,11 @@ interface GridProps {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function Grid({ renderParticipant }: GridProps) {
+    const dispatch = useAppDispatch();
     const gridRef = React.useRef<HTMLDivElement>(null);
 
-    const {
-        store,
-        cellViewsVideoGrid,
-        cellViewsInPresentationGrid,
-        cellViewsInSubgrid,
-        videoStage,
-        setContainerBounds,
-    } = useGrid();
+    const { cellViewsVideoGrid, cellViewsInPresentationGrid, cellViewsInSubgrid, videoStage, setContainerBounds } =
+        useGrid();
 
     const presentationGridContent = React.useMemo(
         () =>
@@ -95,7 +91,7 @@ function Grid({ renderParticipant }: GridProps) {
                 renderCellView({
                     cellView,
                     onSetClientAspectRatio: ({ aspectRatio, clientId }) =>
-                        store.dispatch(setAspectRatio({ clientId, aspectRatio })),
+                        dispatch(setAspectRatio({ clientId, aspectRatio })),
                 }),
             ),
         [cellViewsInPresentationGrid],
@@ -107,7 +103,7 @@ function Grid({ renderParticipant }: GridProps) {
                 renderCellView({
                     cellView,
                     onSetClientAspectRatio: ({ aspectRatio, clientId }) =>
-                        store.dispatch(setAspectRatio({ clientId, aspectRatio })),
+                        dispatch(setAspectRatio({ clientId, aspectRatio })),
                 }),
             ),
         [cellViewsVideoGrid],
@@ -119,7 +115,7 @@ function Grid({ renderParticipant }: GridProps) {
                 renderCellView({
                     cellView,
                     onSetClientAspectRatio: ({ aspectRatio, clientId }) =>
-                        store.dispatch(setAspectRatio({ clientId, aspectRatio })),
+                        dispatch(setAspectRatio({ clientId, aspectRatio })),
                 }),
             ),
         [cellViewsInSubgrid],

--- a/packages/browser-sdk/src/lib/react/Grid/useGrid.ts
+++ b/packages/browser-sdk/src/lib/react/Grid/useGrid.ts
@@ -1,32 +1,12 @@
 import * as React from "react";
-import { WherebyContext } from "../Provider";
-import { observeStore } from "@whereby.com/core";
-import { VideoGridState, selectVideoGridState } from "./selector";
+import { selectVideoGridState } from "./selector";
 import { makeFrame } from "./layout/helpers";
 import { calculateLayout } from "./layout/stageLayout";
-
-const initialState: VideoGridState = {
-    cellViewsVideoGrid: [],
-    cellViewsInPresentationGrid: [],
-    cellViewsInSubgrid: [],
-};
+import { useAppSelector } from "../Provider/hooks";
 
 function useGrid() {
-    const store = React.useContext(WherebyContext);
-    const [videoGridState, setVideoViewState] = React.useState(initialState);
     const [containerBounds, setContainerBounds] = React.useState({ width: 0, height: 0 });
-
-    if (!store) {
-        throw new Error("useGrid must be used within a WherebyProvider");
-    }
-
-    React.useEffect(() => {
-        const unsubscribe = observeStore(store, selectVideoGridState, setVideoViewState);
-
-        return () => {
-            unsubscribe();
-        };
-    }, [store]);
+    const videoGridState = useAppSelector(selectVideoGridState);
 
     const { cellViewsVideoGrid, cellViewsInPresentationGrid, cellViewsInSubgrid } = videoGridState;
 
@@ -48,7 +28,6 @@ function useGrid() {
     }, [containerFrame, cellViewsVideoGrid, cellViewsInPresentationGrid, cellViewsInSubgrid]);
 
     return {
-        store,
         cellViewsVideoGrid,
         cellViewsInPresentationGrid,
         cellViewsInSubgrid,

--- a/packages/browser-sdk/src/lib/react/Provider/hooks.ts
+++ b/packages/browser-sdk/src/lib/react/Provider/hooks.ts
@@ -1,0 +1,5 @@
+import { useDispatch, useSelector } from "react-redux";
+import { RootState, AppDispatch } from "@whereby.com/core";
+
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
+export const useAppSelector = useSelector.withTypes<RootState>();

--- a/packages/browser-sdk/src/lib/react/Provider/index.tsx
+++ b/packages/browser-sdk/src/lib/react/Provider/index.tsx
@@ -1,19 +1,16 @@
 import * as React from "react";
-import { Store, createServices, createStore } from "@whereby.com/core";
+import { Provider as ReduxProvider } from "react-redux";
+import { createServices, createStore } from "@whereby.com/core";
 
 export interface ProviderProps {
     children: React.ReactNode;
 }
 
-const WherebyContext = React.createContext<Store | null>(null);
-
 function Provider({ children }: ProviderProps) {
-    const [store] = React.useState<Store>(() => {
-        const services = createServices();
-        return createStore({ injectServices: services });
-    });
+    const services = createServices();
+    const store = createStore({ injectServices: services });
 
-    return <WherebyContext.Provider value={store}>{children}</WherebyContext.Provider>;
+    return <ReduxProvider store={store}>{children}</ReduxProvider>;
 }
 
-export { Provider, WherebyContext };
+export { Provider };

--- a/packages/browser-sdk/src/lib/react/useLocalMedia/index.ts
+++ b/packages/browser-sdk/src/lib/react/useLocalMedia/index.ts
@@ -1,6 +1,5 @@
 import * as React from "react";
 import {
-    observeStore,
     setCurrentCameraDeviceId,
     setCurrentMicrophoneDeviceId,
     setCurrentSpeakerDeviceId,
@@ -10,68 +9,48 @@ import {
     toggleMicrophoneEnabled,
     toggleLowDataModeEnabled,
 } from "@whereby.com/core";
-
-import { LocalMediaState, UseLocalMediaOptions, UseLocalMediaResult } from "./types";
+import { useAppDispatch, useAppSelector } from "../Provider/hooks";
+import { UseLocalMediaOptions, UseLocalMediaResult } from "./types";
 import { selectLocalMediaState } from "./selector";
-import { WherebyContext } from "../Provider";
-
-const initialState: LocalMediaState = {
-    cameraDeviceError: null,
-    cameraDevices: [],
-    isSettingCameraDevice: false,
-    isSettingMicrophoneDevice: false,
-    isStarting: false,
-    microphoneDeviceError: null,
-    microphoneDevices: [],
-    speakerDevices: [],
-    startError: null,
-};
 
 export function useLocalMedia(
     optionsOrStream: UseLocalMediaOptions | MediaStream = { audio: true, video: true },
 ): UseLocalMediaResult {
-    const store = React.useContext(WherebyContext);
-
-    if (!store) {
-        throw new Error("useLocalMedia must be used within a WherebyProvider");
-    }
-
-    const [localMediaState, setLocalMediaState] = React.useState(initialState);
+    const dispatch = useAppDispatch();
+    const localMediaState = useAppSelector(selectLocalMediaState);
 
     React.useEffect(() => {
-        const unsubscribe = observeStore(store, selectLocalMediaState, setLocalMediaState);
-        store.dispatch(doStartLocalMedia(optionsOrStream));
+        dispatch(doStartLocalMedia(optionsOrStream));
 
         return () => {
-            unsubscribe();
-            store.dispatch(doStopLocalMedia());
+            dispatch(doStopLocalMedia());
         };
     }, []);
 
     const setCameraDevice = React.useCallback(
-        (deviceId: string) => store.dispatch(setCurrentCameraDeviceId({ deviceId })),
-        [store],
+        (deviceId: string) => dispatch(setCurrentCameraDeviceId({ deviceId })),
+        [dispatch],
     );
     const setMicrophoneDevice = React.useCallback(
-        (deviceId: string) => store.dispatch(setCurrentMicrophoneDeviceId({ deviceId })),
-        [store],
+        (deviceId: string) => dispatch(setCurrentMicrophoneDeviceId({ deviceId })),
+        [dispatch],
     );
     const setSpeakerDevice = React.useCallback(
-        (deviceId: string) => store.dispatch(setCurrentSpeakerDeviceId({ deviceId })),
-        [store],
+        (deviceId: string) => dispatch(setCurrentSpeakerDeviceId({ deviceId })),
+        [dispatch],
     );
     const toggleCamera = React.useCallback(
-        (enabled?: boolean) => store.dispatch(toggleCameraEnabled({ enabled })),
-        [store],
+        (enabled?: boolean) => dispatch(toggleCameraEnabled({ enabled })),
+        [dispatch],
     );
     const toggleMicrophone = React.useCallback(
-        (enabled?: boolean) => store.dispatch(toggleMicrophoneEnabled({ enabled })),
-        [store],
+        (enabled?: boolean) => dispatch(toggleMicrophoneEnabled({ enabled })),
+        [dispatch],
     );
 
     const toggleLowDataMode = React.useCallback(
-        (enabled?: boolean) => store.dispatch(toggleLowDataModeEnabled({ enabled })),
-        [store],
+        (enabled?: boolean) => dispatch(toggleLowDataModeEnabled({ enabled })),
+        [dispatch],
     );
     return {
         state: localMediaState,
@@ -83,6 +62,5 @@ export function useLocalMedia(
             toggleMicrophoneEnabled: toggleMicrophone,
             toggleLowDataModeEnabled: toggleLowDataMode,
         },
-        store,
     };
 }

--- a/packages/browser-sdk/src/lib/react/useLocalMedia/types.ts
+++ b/packages/browser-sdk/src/lib/react/useLocalMedia/types.ts
@@ -1,4 +1,4 @@
-import { Store, LocalMediaOptions } from "@whereby.com/core";
+import { LocalMediaOptions } from "@whereby.com/core";
 
 export interface LocalMediaState {
     currentCameraDeviceId?: string;
@@ -25,6 +25,6 @@ interface LocalMediaActions {
     toggleLowDataModeEnabled: (enabled?: boolean) => void;
 }
 
-export type UseLocalMediaResult = { state: LocalMediaState; actions: LocalMediaActions; store: Store };
+export type UseLocalMediaResult = { state: LocalMediaState; actions: LocalMediaActions };
 
 export type UseLocalMediaOptions = LocalMediaOptions;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4339,6 +4339,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.2.tgz#6dd61e43ef60b34086287f83683a5c1b2dc53d20"
   integrity sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==
 
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
+
 "@types/uuid-validate@^0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@types/uuid-validate/-/uuid-validate-0.0.3.tgz#33f95a33ea776606862cc6eea3a8d49ccb90cba6"
@@ -9420,6 +9425,14 @@ react-qr-code@^2.0.11:
     prop-types "^15.8.1"
     qr.js "0.0.0"
 
+react-redux@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-9.1.1.tgz#852ec13084bd7375e26db697d2fc9027ffada204"
+  integrity sha512-5ynfGDzxxsoV73+4czQM56qF43vsmgJsO22rmAvU5tZT2z5Xow/A2uhhxwXuGTxgdReF3zcp7A80gma2onRs1A==
+  dependencies:
+    "@types/use-sync-external-store" "^0.0.3"
+    use-sync-external-store "^1.0.0"
+
 react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
@@ -10934,6 +10947,11 @@ use-sidecar@^1.1.2:
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
+
+use-sync-external-store@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
+  integrity sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
### Description
Use `react-redux` hooks instead of the custom `observeStore` setup we have currently. This is a more traditional redux setup, and since we now have a provider, it allows us to do this instead. 

Instead of calling `observeStore()` and passing in selectors, we can now simply use `useAppSelector` and `useAppDispatch` with full store access in any component.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
Regression testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
