### PR TITLE
e2e: Change e2e test runner to macos-12

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ on:
 jobs:
     test:
         timeout-minutes: 60
-        runs-on: macos-latest
+        runs-on: macos-12
         steps:
             - uses: actions/checkout@v4
 


### PR DESCRIPTION
### Description
An attempt to fix the e2e tests. The only difference from the previous passing tests is the `macos-latest` has changed from `macos-12` to `macos-14-arm64`. Let's see if reverting back to 12 fixes the issues 

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

e2e tests should pass

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
