### PR TITLE
core: Implement joinRoom/leaveRoom actions

### DIFF
--- a/.changeset/nasty-ways-dream.md
+++ b/.changeset/nasty-ways-dream.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/browser-sdk": minor
+"@whereby.com/core": minor
+---
+
+Add actions to join and leave Whereby rooms on-demand

--- a/apps/sample-app/src/App.tsx
+++ b/apps/sample-app/src/App.tsx
@@ -67,6 +67,8 @@ const Room = ({ roomUrl, localMedia, displayName, isHost }: RoomProps) => {
         toggleMicrophone,
         startScreenshare,
         stopScreenshare,
+        joinRoom,
+        leaveRoom,
     } = roomConnection.actions;
     const { VideoView } = roomConnection.components;
 
@@ -77,6 +79,14 @@ const Room = ({ roomUrl, localMedia, displayName, isHost }: RoomProps) => {
     useEffect(() => {
         setIsMicrophoneEnabled(localParticipant?.isAudioEnabled || false);
     }, [localParticipant?.isAudioEnabled]);
+
+    if (connectionStatus === "ready") {
+        return (
+            <button data-testid="joinRoomBtn" onClick={() => joinRoom()}>
+                Re-join room
+            </button>
+        );
+    }
 
     if (connectionStatus === "room_locked") {
         return <WaitingArea knock={knock} />;
@@ -129,6 +139,9 @@ const Room = ({ roomUrl, localMedia, displayName, isHost }: RoomProps) => {
                         </button>
                     </>
                 )}
+                <button data-testid="leaveRoomBtn" onClick={() => leaveRoom()}>
+                    Leave room
+                </button>
             </div>
             {isHost && waitingParticipants.length > 0 && (
                 <div>

--- a/apps/sample-app/test/testsuites/connect.spec.ts
+++ b/apps/sample-app/test/testsuites/connect.spec.ts
@@ -16,10 +16,18 @@ test.describe("unlocked room", () => {
         await deleteTransientRoom(meetingId);
     });
 
-    test("join room", async ({ page }) => {
+    test("join room => leave room => re-join room => re-leave room", async ({ page }) => {
         await joinRoom({ page, roomUrl });
 
-        await expect(page.locator("h1")).toContainText(/Room/);
+        await page.click('[data-testid="leaveRoomBtn"]');
+        await expect(page.locator("dd[data-testid='connectionStatus']")).toContainText("leaving");
+        await expect(page.locator('[data-testid="joinRoomBtn"]')).toHaveCount(1);
+
+        await page.click('[data-testid="joinRoomBtn"]');
         await expect(page.locator("dd[data-testid='connectionStatus']")).toContainText("connected");
+
+        await page.click('[data-testid="leaveRoomBtn"]');
+        await expect(page.locator("dd[data-testid='connectionStatus']")).toContainText("leaving");
+        await expect(page.locator('[data-testid="joinRoomBtn"]')).toHaveCount(1);
     });
 });

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -16,9 +16,9 @@ import {
     toggleLowDataModeEnabled,
     doStartScreenshare,
     doStopScreenshare,
-    appLeft,
     doAppJoin,
     doKnockRoom,
+    doLeaveRoom,
     doLockRoom,
     doKickParticipant,
     doEndMeeting,
@@ -91,8 +91,11 @@ export function useRoomConnection(
             }),
         );
         return () => {
+            if (roomConnectionState.connectionStatus === "connected") {
+                store.dispatch(doLeaveRoom());
+            }
+
             unsubscribe();
-            store.dispatch(appLeft());
         };
     }, []);
 
@@ -156,6 +159,7 @@ export function useRoomConnection(
     const stopCloudRecording = React.useCallback(() => store.dispatch(doStopCloudRecording()), [store]);
     const stopScreenshare = React.useCallback(() => store.dispatch(doStopScreenshare()), [store]);
 
+    const leaveRoom = React.useCallback(() => store.dispatch(doLeaveRoom()), [store]);
     const lockRoom = React.useCallback((locked: boolean) => store.dispatch(doLockRoom({ locked })), [store]);
     const muteParticipants = React.useCallback(
         (clientIds: string[]) => {
@@ -175,6 +179,7 @@ export function useRoomConnection(
             toggleLowDataMode,
             acceptWaitingParticipant,
             knock,
+            leaveRoom,
             lockRoom,
             muteParticipants,
             kickParticipant,

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -16,8 +16,8 @@ import {
     toggleLowDataModeEnabled,
     doStartScreenshare,
     doStopScreenshare,
-    doAppJoin,
-    doAppLeft,
+    doAppConfigure,
+    doAppStop,
     doJoinRoom,
     doKnockRoom,
     doLeaveRoom,
@@ -81,7 +81,7 @@ export function useRoomConnection(
         const roomKey = roomConnectionOptions.roomKey || searchParams.get("roomKey");
 
         store.dispatch(
-            doAppJoin({
+            doAppConfigure({
                 displayName: roomConnectionOptions.displayName || "Guest",
                 localMediaOptions: roomConnectionOptions.localMedia
                     ? undefined
@@ -97,7 +97,7 @@ export function useRoomConnection(
         store.dispatch(doJoinRoom());
 
         return () => {
-            store.dispatch(doAppLeft());
+            store.dispatch(doAppStop());
             unsubscribe();
         };
     }, []);

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -17,6 +17,7 @@ import {
     doStartScreenshare,
     doStopScreenshare,
     doAppJoin,
+    doSignalDisconnect,
     doJoinRoom,
     doKnockRoom,
     doLeaveRoom,
@@ -34,7 +35,7 @@ import { browserSdkVersion } from "../version";
 const initialState: RoomConnectionState = {
     chatMessages: [],
     remoteParticipants: [],
-    connectionStatus: "initializing",
+    connectionStatus: "ready",
     screenshares: [],
     waitingParticipants: [],
 };
@@ -96,11 +97,8 @@ export function useRoomConnection(
         store.dispatch(doJoinRoom());
 
         return () => {
-            if (roomConnectionState.connectionStatus === "connected") {
-                store.dispatch(doLeaveRoom());
-            }
-
             unsubscribe();
+            store.dispatch(doSignalDisconnect());
         };
     }, []);
 

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -17,7 +17,7 @@ import {
     doStartScreenshare,
     doStopScreenshare,
     doAppJoin,
-    doSignalDisconnect,
+    doAppLeft,
     doJoinRoom,
     doKnockRoom,
     doLeaveRoom,
@@ -97,8 +97,8 @@ export function useRoomConnection(
         store.dispatch(doJoinRoom());
 
         return () => {
+            store.dispatch(doAppLeft());
             unsubscribe();
-            store.dispatch(doSignalDisconnect());
         };
     }, []);
 

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -17,6 +17,7 @@ import {
     doStartScreenshare,
     doStopScreenshare,
     doAppJoin,
+    doJoinRoom,
     doKnockRoom,
     doLeaveRoom,
     doLockRoom,
@@ -90,6 +91,10 @@ export function useRoomConnection(
                 externalId: roomConnectionOptions.externalId || null,
             }),
         );
+
+        // TODO: move this out of initial useEffect and trigger manually
+        store.dispatch(doJoinRoom());
+
         return () => {
             if (roomConnectionState.connectionStatus === "connected") {
                 store.dispatch(doLeaveRoom());
@@ -158,7 +163,7 @@ export function useRoomConnection(
     const startScreenshare = React.useCallback(() => store.dispatch(doStartScreenshare()), [store]);
     const stopCloudRecording = React.useCallback(() => store.dispatch(doStopCloudRecording()), [store]);
     const stopScreenshare = React.useCallback(() => store.dispatch(doStopScreenshare()), [store]);
-
+    const joinRoom = React.useCallback(() => store.dispatch(doJoinRoom()), [store]);
     const leaveRoom = React.useCallback(() => store.dispatch(doLeaveRoom()), [store]);
     const lockRoom = React.useCallback((locked: boolean) => store.dispatch(doLockRoom({ locked })), [store]);
     const muteParticipants = React.useCallback(
@@ -179,6 +184,7 @@ export function useRoomConnection(
             toggleLowDataMode,
             acceptWaitingParticipant,
             knock,
+            joinRoom,
             leaveRoom,
             lockRoom,
             muteParticipants,

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -17,10 +17,9 @@ import {
     doStartScreenshare,
     doStopScreenshare,
     doAppConfigure,
+    doAppStart,
     doAppStop,
-    doJoinRoom,
     doKnockRoom,
-    doLeaveRoom,
     doLockRoom,
     doKickParticipant,
     doEndMeeting,
@@ -93,8 +92,8 @@ export function useRoomConnection(
             }),
         );
 
-        // TODO: move this out of initial useEffect and trigger manually
-        store.dispatch(doJoinRoom());
+        // TODO: remove this in SDK v3. Require developers to call joinRoom() API explicitly instead.
+        store.dispatch(doAppStart());
 
         return () => {
             store.dispatch(doAppStop());
@@ -161,8 +160,8 @@ export function useRoomConnection(
     const startScreenshare = React.useCallback(() => store.dispatch(doStartScreenshare()), [store]);
     const stopCloudRecording = React.useCallback(() => store.dispatch(doStopCloudRecording()), [store]);
     const stopScreenshare = React.useCallback(() => store.dispatch(doStopScreenshare()), [store]);
-    const joinRoom = React.useCallback(() => store.dispatch(doJoinRoom()), [store]);
-    const leaveRoom = React.useCallback(() => store.dispatch(doLeaveRoom()), [store]);
+    const joinRoom = React.useCallback(() => store.dispatch(doAppStart()), [store]);
+    const leaveRoom = React.useCallback(() => store.dispatch(doAppStop()), [store]);
     const lockRoom = React.useCallback((locked: boolean) => store.dispatch(doLockRoom({ locked })), [store]);
     const muteParticipants = React.useCallback(
         (clientIds: string[]) => {

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -71,6 +71,7 @@ export interface RoomConnectionActions {
     toggleLowDataMode(enabled?: boolean): void;
     acceptWaitingParticipant(participantId: string): void;
     knock(): void;
+    leaveRoom(): void;
     lockRoom(locked: boolean): void;
     muteParticipants(clientIds: string[]): void;
     kickParticipant(clientId: string): void;

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -71,6 +71,7 @@ export interface RoomConnectionActions {
     toggleLowDataMode(enabled?: boolean): void;
     acceptWaitingParticipant(participantId: string): void;
     knock(): void;
+    joinRoom(): void;
     leaveRoom(): void;
     lockRoom(locked: boolean): void;
     muteParticipants(clientIds: string[]): void;

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -55,9 +55,8 @@ export default function VideoExperience({
 
     return (
         <div>
+            {connectionStatus === "ready" && <button onClick={() => joinRoom()}>Join room</button>}
             {connectionStatus === "connecting" && <span>Connecting...</span>}
-            {connectionStatus === "leaving" && <span>Leaving...</span>}
-            {connectionStatus === "disconnected" && <button onClick={() => joinRoom()}>Join room</button>}
             {connectionStatus === "room_locked" && (
                 <div style={{ color: "red" }}>
                     <span>Room locked, please knock....</span>
@@ -215,6 +214,8 @@ export default function VideoExperience({
                     </div>
                 </>
             )}
+            {connectionStatus === "leaving" && <span>Leaving...</span>}
+            {connectionStatus === "disconnected" && <span>Disconnected</span>}
         </div>
     );
 }

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -37,6 +37,7 @@ export default function VideoExperience({
         knock,
         sendChatMessage,
         setDisplayName,
+        leaveRoom,
         lockRoom,
         muteParticipants,
         kickParticipant,
@@ -54,6 +55,17 @@ export default function VideoExperience({
     return (
         <div>
             {connectionStatus === "connecting" && <span>Connecting...</span>}
+            {connectionStatus === "leaving" && <span>Leaving...</span>}
+            {connectionStatus === "disconnected" && (
+                <button
+                    onClick={() => {
+                        // TODO
+                        // joinRoom()
+                    }}
+                >
+                    Join room
+                </button>
+            )}
             {connectionStatus === "room_locked" && (
                 <div style={{ color: "red" }}>
                     <span>Room locked, please knock....</span>
@@ -191,6 +203,7 @@ export default function VideoExperience({
                         )}
                     </div>
                     <div className="controls">
+                        <button onClick={() => leaveRoom()}>Leave</button>
                         <button onClick={() => toggleCamera()}>Toggle camera</button>
                         <button onClick={() => toggleMicrophone()}>Toggle microphone</button>
                         <button onClick={() => toggleLowDataMode()}>Toggle low data mode</button>

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -37,6 +37,7 @@ export default function VideoExperience({
         knock,
         sendChatMessage,
         setDisplayName,
+        joinRoom,
         leaveRoom,
         lockRoom,
         muteParticipants,
@@ -56,16 +57,7 @@ export default function VideoExperience({
         <div>
             {connectionStatus === "connecting" && <span>Connecting...</span>}
             {connectionStatus === "leaving" && <span>Leaving...</span>}
-            {connectionStatus === "disconnected" && (
-                <button
-                    onClick={() => {
-                        // TODO
-                        // joinRoom()
-                    }}
-                >
-                    Join room
-                </button>
-            )}
+            {connectionStatus === "disconnected" && <button onClick={() => joinRoom()}>Join room</button>}
             {connectionStatus === "room_locked" && (
                 <div style={{ color: "red" }}>
                     <span>Room locked, please knock....</span>

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -75,7 +75,7 @@
 ### Minor Changes
 
 - 6fc07f5: Expose `RemoteParticipant.externalId`
-- 300f6ac: Rename `sdkVersion` param in `doAppJoin` to `userAgent`, make it optional with a fallback to core module version and stop exporting the `sdkVersion`
+- 300f6ac: Rename `sdkVersion` param in `doAppConfigure` to `userAgent`, make it optional with a fallback to core module version and stop exporting the `sdkVersion`
 
 ### Patch Changes
 

--- a/packages/core/src/redux/listenerMiddleware.ts
+++ b/packages/core/src/redux/listenerMiddleware.ts
@@ -21,9 +21,9 @@ type SelectorResults<Selectors extends Selector<RootState, unknown>[]> = {
  * example:
  * ```ts
  * createReactor(
- *    [selectAppWantsToJoin, selectDeviceCredentialsRaw],
- *   ({ dispatch }, wantsToJoin, deviceCredentialsRaw) => {
- *      if (wantsToJoin && deviceCredentialsRaw.data) {
+ *    [selectAppIsActive, selectDeviceCredentialsRaw],
+ *   ({ dispatch }, appIsActive, deviceCredentialsRaw) => {
+ *      if (appIsActive && deviceCredentialsRaw.data) {
  *         dispatch(doSignalIdentifyDevice({ deviceCredentials: deviceCredentialsRaw.data }));
  *    }
  * });

--- a/packages/core/src/redux/slices/__tests__/app.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/app.unit.ts
@@ -4,20 +4,19 @@ describe("appSlice", () => {
     describe("reducers", () => {
         describe("doAppJoin", () => {
             it("should change the state", () => {
-                const result = appSlice.reducer(
-                    undefined,
-                    appSlice.actions.doAppJoin({
-                        isNodeSdk: true,
-                        roomUrl: "https://some.url/roomName",
-                        roomKey: "roomKey",
-                        displayName: "displayName",
-                        userAgent: "userAgent",
-                        externalId: "externalId",
-                    }),
-                );
-    
+                const initialConfig = {
+                    isNodeSdk: true,
+                    roomUrl: "https://some.url/roomName",
+                    roomKey: "roomKey",
+                    displayName: "displayName",
+                    userAgent: "userAgent",
+                    externalId: "externalId",
+                };
+
+                const result = appSlice.reducer(undefined, appSlice.actions.doAppJoin(initialConfig));
+
                 expect(result).toEqual({
-                    wantsToJoin: true,
+                    wantsToJoin: false,
                     roomName: "/roomName",
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",
@@ -25,23 +24,24 @@ describe("appSlice", () => {
                     userAgent: "userAgent",
                     externalId: "externalId",
                     isNodeSdk: true,
+                    initialConfig,
+                    isLoaded: true,
                 });
             });
 
             it("should change the state with default userAgent", () => {
-                const result = appSlice.reducer(
-                    undefined,
-                    appSlice.actions.doAppJoin({
-                        isNodeSdk: true,
-                        roomUrl: "https://some.url/roomName",
-                        roomKey: "roomKey",
-                        displayName: "displayName",
-                        externalId: "externalId",
-                    }),
-                );
-    
+                const initialConfig = {
+                    isNodeSdk: true,
+                    roomUrl: "https://some.url/roomName",
+                    roomKey: "roomKey",
+                    displayName: "displayName",
+                    externalId: "externalId",
+                };
+
+                const result = appSlice.reducer(undefined, appSlice.actions.doAppJoin(initialConfig));
+
                 expect(result).toEqual({
-                    wantsToJoin: true,
+                    wantsToJoin: false,
                     roomName: "/roomName",
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",
@@ -49,6 +49,8 @@ describe("appSlice", () => {
                     userAgent: "core:__PKG_VERSION__",
                     externalId: "externalId",
                     isNodeSdk: true,
+                    initialConfig,
+                    isLoaded: true,
                 });
             });
         });

--- a/packages/core/src/redux/slices/__tests__/app.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/app.unit.ts
@@ -2,7 +2,7 @@ import { appSlice } from "../app";
 
 describe("appSlice", () => {
     describe("reducers", () => {
-        describe("doAppJoin", () => {
+        describe("doAppConfigure", () => {
             it("should change the state", () => {
                 const initialConfig = {
                     isNodeSdk: true,
@@ -13,10 +13,11 @@ describe("appSlice", () => {
                     externalId: "externalId",
                 };
 
-                const result = appSlice.reducer(undefined, appSlice.actions.doAppJoin(initialConfig));
+                const result = appSlice.reducer(undefined, appSlice.actions.doAppConfigure(initialConfig));
 
                 expect(result).toEqual({
-                    wantsToJoin: false,
+                    isLoaded: true,
+                    isActive: false,
                     roomName: "/roomName",
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",
@@ -25,7 +26,6 @@ describe("appSlice", () => {
                     externalId: "externalId",
                     isNodeSdk: true,
                     initialConfig,
-                    isLoaded: true,
                 });
             });
 
@@ -38,10 +38,11 @@ describe("appSlice", () => {
                     externalId: "externalId",
                 };
 
-                const result = appSlice.reducer(undefined, appSlice.actions.doAppJoin(initialConfig));
+                const result = appSlice.reducer(undefined, appSlice.actions.doAppConfigure(initialConfig));
 
                 expect(result).toEqual({
-                    wantsToJoin: false,
+                    isLoaded: true,
+                    isActive: false,
                     roomName: "/roomName",
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",
@@ -50,7 +51,6 @@ describe("appSlice", () => {
                     externalId: "externalId",
                     isNodeSdk: true,
                     initialConfig,
-                    isLoaded: true,
                 });
             });
         });

--- a/packages/core/src/redux/slices/__tests__/authorization.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/authorization.unit.ts
@@ -6,7 +6,7 @@ import {
     selectIsAuthorizedToRequestAudioEnable,
 } from "../authorization";
 import { signalEvents } from "../signalConnection/actions";
-import { doAppJoin } from "../app";
+import { doAppConfigure } from "../app";
 
 describe("authorizationSlice", () => {
     describe("reducers", () => {
@@ -16,10 +16,10 @@ describe("authorizationSlice", () => {
             expect(result.roomKey).toEqual("roomKey");
         });
 
-        it("doAppJoin", () => {
+        it("doAppConfigure", () => {
             const result = authorizationSlice.reducer(
                 undefined,
-                doAppJoin({
+                doAppConfigure({
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",
                     displayName: "displayName",

--- a/packages/core/src/redux/slices/__tests__/deviceCredentials.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/deviceCredentials.unit.ts
@@ -7,7 +7,7 @@ describe("deviceCredentialsSlice", () => {
             const credentials = randomDeviceCredentials();
 
             it.each`
-                wantsToJoin | isFetching | deviceCredentialsData | expected
+                appIsActive | isFetching | deviceCredentialsData | expected
                 ${true}     | ${false}   | ${undefined}          | ${true}
                 ${true}     | ${false}   | ${null}               | ${true}
                 ${true}     | ${false}   | ${credentials}        | ${false}
@@ -15,14 +15,14 @@ describe("deviceCredentialsSlice", () => {
                 ${true}     | ${true}    | ${null}               | ${false}
                 ${true}     | ${true}    | ${credentials}        | ${false}
             `(
-                "expected $expected when wantsToJoin=$wantsToJoin, isFetching=$isFetching, deviceCredentialsData=$deviceCredentialsData",
-                ({ wantsToJoin, isFetching, deviceCredentialsData, expected }) => {
+                "expected $expected when appIsActive=$appIsActive, isFetching=$isFetching, deviceCredentialsData=$deviceCredentialsData",
+                ({ appIsActive, isFetching, deviceCredentialsData, expected }) => {
                     const deviceCredentials = {
                         isFetching,
                         data: deviceCredentialsData,
                     };
 
-                    expect(selectShouldFetchDeviceCredentials.resultFunc(wantsToJoin, deviceCredentials)).toBe(
+                    expect(selectShouldFetchDeviceCredentials.resultFunc(appIsActive, deviceCredentials)).toBe(
                         expected,
                     );
                 },

--- a/packages/core/src/redux/slices/__tests__/localMedia.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/localMedia.unit.ts
@@ -4,20 +4,20 @@ describe("localMediaSlice", () => {
     describe("reactors", () => {
         describe("reactLocalMediaStart", () => {
             it.each`
-                appWantsToJoin | localMediaStatus | localMediaOptions               | isNodeSdk | expected
-                ${false}       | ${""}            | ${undefined}                    | ${false}  | ${undefined}
-                ${false}       | ${"started"}     | ${undefined}                    | ${false}  | ${undefined}
-                ${false}       | ${"started"}     | ${{ audio: true, video: true }} | ${false}  | ${undefined}
-                ${true}        | ${"started"}     | ${{ audio: true, video: true }} | ${false}  | ${undefined}
-                ${true}        | ${""}            | ${undefined}                    | ${false}  | ${undefined}
-                ${true}        | ${""}            | ${{ audio: true, video: true }} | ${true}   | ${undefined}
-                ${true}        | ${""}            | ${{ audio: true, video: true }} | ${false}  | ${{ audio: true, video: true }}
+                appIsActive | localMediaStatus | localMediaOptions               | isNodeSdk | expected
+                ${false}    | ${""}            | ${undefined}                    | ${false}  | ${undefined}
+                ${false}    | ${"started"}     | ${undefined}                    | ${false}  | ${undefined}
+                ${false}    | ${"started"}     | ${{ audio: true, video: true }} | ${false}  | ${undefined}
+                ${true}     | ${"started"}     | ${{ audio: true, video: true }} | ${false}  | ${undefined}
+                ${true}     | ${""}            | ${undefined}                    | ${false}  | ${undefined}
+                ${true}     | ${""}            | ${{ audio: true, video: true }} | ${true}   | ${undefined}
+                ${true}     | ${""}            | ${{ audio: true, video: true }} | ${false}  | ${{ audio: true, video: true }}
             `(
-                "expected $expected when appWantsToJoin=$appWantsToJoin, localMediaStatus=$localMediaStatus, localMediaOptions=$localMediaOptions, isNodeSdk=$isNodeSdk",
-                ({ appWantsToJoin, localMediaStatus, localMediaOptions, isNodeSdk, expected }) => {
+                "expected $expected when appIsActive=$appIsActive, localMediaStatus=$localMediaStatus, localMediaOptions=$localMediaOptions, isNodeSdk=$isNodeSdk",
+                ({ appIsActive, localMediaStatus, localMediaOptions, isNodeSdk, expected }) => {
                     expect(
                         selectLocalMediaShouldStartWithOptions.resultFunc(
-                            appWantsToJoin,
+                            appIsActive,
                             localMediaStatus,
                             localMediaOptions,
                             isNodeSdk,
@@ -29,17 +29,17 @@ describe("localMediaSlice", () => {
 
         describe("reactLocalMediaStop", () => {
             it.each`
-                appWantsToJoin | localMediaStatus | localMediaOptions               | expected
-                ${true}        | ${"started"}     | ${undefined}                    | ${false}
-                ${true}        | ${"started"}     | ${{ audio: true, video: true }} | ${false}
-                ${false}       | ${""}            | ${{ audio: true, video: true }} | ${false}
-                ${false}       | ${"started"}     | ${undefined}                    | ${false}
-                ${false}       | ${"started"}     | ${{ audio: true, video: true }} | ${true}
+                appIsActive | localMediaStatus | localMediaOptions               | expected
+                ${true}     | ${"started"}     | ${undefined}                    | ${false}
+                ${true}     | ${"started"}     | ${{ audio: true, video: true }} | ${false}
+                ${false}    | ${""}            | ${{ audio: true, video: true }} | ${false}
+                ${false}    | ${"started"}     | ${undefined}                    | ${false}
+                ${false}    | ${"started"}     | ${{ audio: true, video: true }} | ${true}
             `(
-                "expected $expected when appWantsToJoin=$appWantsToJoin, localMediaStatus=$localMediaStatus, localMediaOptions=$localMediaOptions",
-                ({ appWantsToJoin, localMediaStatus, localMediaOptions, expected }) => {
+                "expected $expected when appIsActive=$appIsActive, localMediaStatus=$localMediaStatus, localMediaOptions=$localMediaOptions",
+                ({ appIsActive, localMediaStatus, localMediaOptions, expected }) => {
                     expect(
-                        selectLocalMediaShouldStop.resultFunc(appWantsToJoin, localMediaStatus, localMediaOptions),
+                        selectLocalMediaShouldStop.resultFunc(appIsActive, localMediaStatus, localMediaOptions),
                     ).toEqual(expected);
                 },
             );

--- a/packages/core/src/redux/slices/__tests__/localMedia.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/localMedia.unit.ts
@@ -5,13 +5,13 @@ describe("localMediaSlice", () => {
         describe("reactLocalMediaStart", () => {
             it.each`
                 appIsActive | localMediaStatus | localMediaOptions               | isNodeSdk | expected
-                ${false}    | ${""}            | ${undefined}                    | ${false}  | ${undefined}
+                ${false}    | ${"inactive"}    | ${undefined}                    | ${false}  | ${undefined}
                 ${false}    | ${"started"}     | ${undefined}                    | ${false}  | ${undefined}
                 ${false}    | ${"started"}     | ${{ audio: true, video: true }} | ${false}  | ${undefined}
                 ${true}     | ${"started"}     | ${{ audio: true, video: true }} | ${false}  | ${undefined}
-                ${true}     | ${""}            | ${undefined}                    | ${false}  | ${undefined}
-                ${true}     | ${""}            | ${{ audio: true, video: true }} | ${true}   | ${undefined}
-                ${true}     | ${""}            | ${{ audio: true, video: true }} | ${false}  | ${{ audio: true, video: true }}
+                ${true}     | ${"inactive"}    | ${undefined}                    | ${false}  | ${undefined}
+                ${true}     | ${"inactive"}    | ${{ audio: true, video: true }} | ${true}   | ${undefined}
+                ${true}     | ${"inactive"}    | ${{ audio: true, video: true }} | ${false}  | ${{ audio: true, video: true }}
             `(
                 "expected $expected when appIsActive=$appIsActive, localMediaStatus=$localMediaStatus, localMediaOptions=$localMediaOptions, isNodeSdk=$isNodeSdk",
                 ({ appIsActive, localMediaStatus, localMediaOptions, isNodeSdk, expected }) => {
@@ -32,7 +32,7 @@ describe("localMediaSlice", () => {
                 appIsActive | localMediaStatus | localMediaOptions               | expected
                 ${true}     | ${"started"}     | ${undefined}                    | ${false}
                 ${true}     | ${"started"}     | ${{ audio: true, video: true }} | ${false}
-                ${false}    | ${""}            | ${{ audio: true, video: true }} | ${false}
+                ${false}    | ${"inactive"}    | ${{ audio: true, video: true }} | ${false}
                 ${false}    | ${"started"}     | ${undefined}                    | ${false}
                 ${false}    | ${"started"}     | ${{ audio: true, video: true }} | ${true}
             `(

--- a/packages/core/src/redux/slices/__tests__/organization.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/organization.unit.ts
@@ -8,7 +8,7 @@ describe("deviceCredentialsSlice", () => {
             const x = () => oneOf(true, false);
 
             it.each`
-                wantsToJoin | organizationData | isFetchingOrganization | organizationError | isFetchingDeviceCredentials | expected
+                appIsActive | organizationData | isFetchingOrganization | organizationError | isFetchingDeviceCredentials | expected
                 ${true}     | ${undefined}     | ${false}               | ${false}          | ${false}                    | ${true}
                 ${true}     | ${null}          | ${false}               | ${false}          | ${false}                    | ${true}
                 ${x()}      | ${organization}  | ${x()}                 | ${x()}            | ${x()}                      | ${false}
@@ -16,9 +16,9 @@ describe("deviceCredentialsSlice", () => {
                 ${x()}      | ${organization}  | ${x()}                 | ${true}           | ${x()}                      | ${false}
                 ${x()}      | ${organization}  | ${x()}                 | ${x()}            | ${true}                     | ${false}
             `(
-                "should return $expected when wantsToJoin=$wantsToJoin, organizationData=$organizationData, isFetchingOrganization=$isFetchingOrganization, organizationError=$organizationError, isFetchingDeviceCredentials=$isFetchingDeviceCredentials",
+                "should return $expected when appIsActive=$appIsActive, organizationData=$organizationData, isFetchingOrganization=$isFetchingOrganization, organizationError=$organizationError, isFetchingDeviceCredentials=$isFetchingDeviceCredentials",
                 ({
-                    wantsToJoin,
+                    appIsActive,
                     organizationData,
                     isFetchingOrganization,
                     organizationError,
@@ -35,7 +35,7 @@ describe("deviceCredentialsSlice", () => {
                     };
 
                     expect(
-                        selectShouldFetchOrganization.resultFunc(wantsToJoin, organizationRaw, deviceCredentialsRaw),
+                        selectShouldFetchOrganization.resultFunc(appIsActive, organizationRaw, deviceCredentialsRaw),
                     ).toEqual(expected);
                 },
             );

--- a/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
@@ -93,17 +93,17 @@ describe("roomConnectionSlice", () => {
             const x = () => oneOf(true, false);
 
             it.each`
-                appWantsToJoin | organizationId | roomConnectionStatus | signalIdentified | localMediaStatus | isNodeSdk | expected
-                ${true}        | ${undefined}   | ${"ready"}           | ${x()}           | ${"started"}     | ${x()}    | ${false}
-                ${true}        | ${"orgId"}     | ${"ready"}           | ${true}          | ${"started"}     | ${false}  | ${true}
-                ${true}        | ${"orgId"}     | ${"connected"}       | ${x()}           | ${"started"}     | ${x()}    | ${false}
-                ${true}        | ${"orgId"}     | ${"ready"}           | ${false}         | ${"starting"}    | ${x()}    | ${false}
-                ${true}        | ${"orgId"}     | ${"ready"}           | ${x()}           | ${"error"}       | ${false}  | ${false}
-                ${true}        | ${"orgId"}     | ${"ready"}           | ${true}          | ${"error"}       | ${true}   | ${true}
+                appIsActive | organizationId | roomConnectionStatus | signalIdentified | localMediaStatus | isNodeSdk | expected
+                ${true}     | ${undefined}   | ${"ready"}           | ${x()}           | ${"started"}     | ${x()}    | ${false}
+                ${true}     | ${"orgId"}     | ${"ready"}           | ${true}          | ${"started"}     | ${false}  | ${true}
+                ${true}     | ${"orgId"}     | ${"connected"}       | ${x()}           | ${"started"}     | ${x()}    | ${false}
+                ${true}     | ${"orgId"}     | ${"ready"}           | ${false}         | ${"starting"}    | ${x()}    | ${false}
+                ${true}     | ${"orgId"}     | ${"ready"}           | ${x()}           | ${"error"}       | ${false}  | ${false}
+                ${true}     | ${"orgId"}     | ${"ready"}           | ${true}          | ${"error"}       | ${true}   | ${true}
             `(
-                "Should return $expected when appWantsToJoin=$appWantsToJoin, organizationId=$organizationId, roomConnectionStatus=$roomConnectionStatus, signalIdentified=$signalIdentified, localMediaStatus=$localMediaStatus, isNodeSdk=$isNodeSdk",
+                "Should return $expected when appIsActive=$appIsActive, organizationId=$organizationId, roomConnectionStatus=$roomConnectionStatus, signalIdentified=$signalIdentified, localMediaStatus=$localMediaStatus, isNodeSdk=$isNodeSdk",
                 ({
-                    appWantsToJoin,
+                    appIsActive,
                     organizationId,
                     roomConnectionStatus,
                     signalIdentified,
@@ -113,7 +113,7 @@ describe("roomConnectionSlice", () => {
                 }) => {
                     expect(
                         selectShouldConnectRoom.resultFunc(
-                            appWantsToJoin,
+                            appIsActive,
                             organizationId,
                             roomConnectionStatus,
                             signalIdentified,

--- a/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
@@ -93,18 +93,27 @@ describe("roomConnectionSlice", () => {
             const x = () => oneOf(true, false);
 
             it.each`
-                organizationId | roomConnectionStatus | signalIdentified | localMediaStatus | isNodeSdk | expected
-                ${undefined}   | ${"initializing"}    | ${x()}           | ${"started"}     | ${x()}    | ${false}
-                ${"orgId"}     | ${"initializing"}    | ${true}          | ${"started"}     | ${false}  | ${true}
-                ${"orgId"}     | ${"connected"}       | ${x()}           | ${"started"}     | ${x()}    | ${false}
-                ${"orgId"}     | ${"initializing"}    | ${false}         | ${"starting"}    | ${x()}    | ${false}
-                ${"orgId"}     | ${"initializing"}    | ${x()}           | ${"error"}       | ${false}  | ${false}
-                ${"orgId"}     | ${"initializing"}    | ${true}          | ${"error"}       | ${true}   | ${true}
+                appWantsToJoin | organizationId | roomConnectionStatus | signalIdentified | localMediaStatus | isNodeSdk | expected
+                ${true}        | ${undefined}   | ${"ready"}           | ${x()}           | ${"started"}     | ${x()}    | ${false}
+                ${true}        | ${"orgId"}     | ${"ready"}           | ${true}          | ${"started"}     | ${false}  | ${true}
+                ${true}        | ${"orgId"}     | ${"connected"}       | ${x()}           | ${"started"}     | ${x()}    | ${false}
+                ${true}        | ${"orgId"}     | ${"ready"}           | ${false}         | ${"starting"}    | ${x()}    | ${false}
+                ${true}        | ${"orgId"}     | ${"ready"}           | ${x()}           | ${"error"}       | ${false}  | ${false}
+                ${true}        | ${"orgId"}     | ${"ready"}           | ${true}          | ${"error"}       | ${true}   | ${true}
             `(
-                "Should return $expected when organizationId=$organizationId, roomConnectionStatus=$roomConnectionStatus, signalIdentified=$signalIdentified, localMediaStatus=$localMediaStatus, isNodeSdk=$isNodeSdk",
-                ({ organizationId, roomConnectionStatus, signalIdentified, localMediaStatus, isNodeSdk, expected }) => {
+                "Should return $expected when appWantsToJoin=$appWantsToJoin, organizationId=$organizationId, roomConnectionStatus=$roomConnectionStatus, signalIdentified=$signalIdentified, localMediaStatus=$localMediaStatus, isNodeSdk=$isNodeSdk",
+                ({
+                    appWantsToJoin,
+                    organizationId,
+                    roomConnectionStatus,
+                    signalIdentified,
+                    localMediaStatus,
+                    isNodeSdk,
+                    expected,
+                }) => {
                     expect(
                         selectShouldConnectRoom.resultFunc(
+                            appWantsToJoin,
                             organizationId,
                             roomConnectionStatus,
                             signalIdentified,

--- a/packages/core/src/redux/slices/__tests__/rtcConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/rtcConnection.unit.ts
@@ -51,15 +51,15 @@ describe("rtcConnectionSlice", () => {
             const x = () => oneOf(true, false);
 
             it.each`
-                rtcStatus         | wantsToJoin | expected
+                rtcStatus         | appIsActive | expected
                 ${"ready"}        | ${true}     | ${false}
                 ${"ready"}        | ${false}    | ${true}
                 ${""}             | ${x()}      | ${false}
                 ${"disconnected"} | ${x()}      | ${false}
             `(
-                "should return $expected when rtcStatus=$rtcStatus, wantsToJoin=$wantsToJoin",
-                ({ rtcStatus, wantsToJoin, expected }) => {
-                    expect(selectShouldDisconnectRtc.resultFunc(rtcStatus, wantsToJoin)).toEqual(expected);
+                "should return $expected when rtcStatus=$rtcStatus, appIsActive=$appIsActive",
+                ({ rtcStatus, appIsActive, expected }) => {
+                    expect(selectShouldDisconnectRtc.resultFunc(rtcStatus, appIsActive)).toEqual(expected);
                 },
             );
         });

--- a/packages/core/src/redux/slices/__tests__/rtcConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/rtcConnection.unit.ts
@@ -54,7 +54,7 @@ describe("rtcConnectionSlice", () => {
                 rtcStatus         | appIsActive | expected
                 ${"ready"}        | ${true}     | ${false}
                 ${"ready"}        | ${false}    | ${true}
-                ${""}             | ${x()}      | ${false}
+                ${"inactive"}     | ${x()}      | ${false}
                 ${"disconnected"} | ${x()}      | ${false}
             `(
                 "should return $expected when rtcStatus=$rtcStatus, appIsActive=$appIsActive",
@@ -73,15 +73,15 @@ describe("rtcConnectionSlice", () => {
                 });
 
             it.each`
-                rtcStatus  | remoteParticipants                                      | expected
-                ${""}      | ${[x(), x()]}                                           | ${[]}
-                ${"ready"} | ${[c("id0", ["to_accept"])]}                            | ${[{ clientId: "id0", streamId: "0", state: "to_accept" }]}
-                ${""}      | ${[c("id1", ["to_accept"])]}                            | ${[]}
-                ${"ready"} | ${[c("id2", ["to_unaccept"])]}                          | ${[{ clientId: "id2", streamId: "0", state: "to_accept" }]}
-                ${"ready"} | ${[c("id3", ["done_accept"])]}                          | ${[]}
-                ${"ready"} | ${[c("id4", ["to_accept", "done_accept"])]}             | ${[{ clientId: "id4", streamId: "0", state: "to_accept" }]}
-                ${"ready"} | ${[c("id5", ["to_accept"]), c("id6", ["done_accept"])]} | ${[{ clientId: "id5", streamId: "0", state: "to_accept" }]}
-                ${"ready"} | ${[c("id7", ["to_accept", "to_accept"])]}               | ${[{ clientId: "id7", streamId: "0", state: "to_accept" }, { clientId: "id7", streamId: "1", state: "to_accept" }]}
+                rtcStatus     | remoteParticipants                                      | expected
+                ${"inactive"} | ${[x(), x()]}                                           | ${[]}
+                ${"ready"}    | ${[c("id0", ["to_accept"])]}                            | ${[{ clientId: "id0", streamId: "0", state: "to_accept" }]}
+                ${"inactive"} | ${[c("id1", ["to_accept"])]}                            | ${[]}
+                ${"ready"}    | ${[c("id2", ["to_unaccept"])]}                          | ${[{ clientId: "id2", streamId: "0", state: "to_accept" }]}
+                ${"ready"}    | ${[c("id3", ["done_accept"])]}                          | ${[]}
+                ${"ready"}    | ${[c("id4", ["to_accept", "done_accept"])]}             | ${[{ clientId: "id4", streamId: "0", state: "to_accept" }]}
+                ${"ready"}    | ${[c("id5", ["to_accept"]), c("id6", ["done_accept"])]} | ${[{ clientId: "id5", streamId: "0", state: "to_accept" }]}
+                ${"ready"}    | ${[c("id7", ["to_accept", "to_accept"])]}               | ${[{ clientId: "id7", streamId: "0", state: "to_accept" }, { clientId: "id7", streamId: "1", state: "to_accept" }]}
             `(
                 "should return $expected when rtcStatus=$rtcStatus, remoteParticipants=$remoteParticipants",
                 ({ rtcStatus, remoteParticipants, expected }) => {

--- a/packages/core/src/redux/slices/__tests__/signalConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/signalConnection.unit.ts
@@ -23,8 +23,8 @@ describe("signalConnectionSlice", () => {
 
             it.each`
                 appIsActive | signalStatus   | expected
-                ${true}     | ${""}          | ${true}
-                ${false}    | ${""}          | ${false}
+                ${true}     | ${"ready"}     | ${true}
+                ${false}    | ${"ready"}     | ${false}
                 ${x()}      | ${"connected"} | ${false}
             `(
                 "should return $expected when appIsActive=$appIsActive, signalStatus=$signalStatus",
@@ -43,10 +43,10 @@ describe("signalConnectionSlice", () => {
                 ${{}}                 | ${"connected"} | ${true}          | ${x()}              | ${false}
                 ${{}}                 | ${"connected"} | ${false}         | ${true}             | ${false}
                 ${{}}                 | ${"connected"} | ${false}         | ${false}            | ${true}
-                ${undefined}          | ${""}          | ${x()}           | ${x()}              | ${false}
-                ${{}}                 | ${""}          | ${true}          | ${x()}              | ${false}
-                ${{}}                 | ${""}          | ${false}         | ${true}             | ${false}
-                ${{}}                 | ${""}          | ${false}         | ${false}            | ${false}
+                ${undefined}          | ${"ready"}     | ${x()}           | ${x()}              | ${false}
+                ${{}}                 | ${"ready"}     | ${true}          | ${x()}              | ${false}
+                ${{}}                 | ${"ready"}     | ${false}         | ${true}             | ${false}
+                ${{}}                 | ${"ready"}     | ${false}         | ${false}            | ${false}
             `(
                 "should return $expected when deviceCredentialsData=$deviceCredentialsData, signalStatus=$signalStatus, deviceIdentified=$deviceIdentified, isIdentifyingDevice=$isIdentifyingDevice",
                 ({ deviceCredentialsData, signalStatus, deviceIdentified, isIdentifyingDevice, expected }) => {

--- a/packages/core/src/redux/slices/__tests__/signalConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/signalConnection.unit.ts
@@ -22,14 +22,14 @@ describe("signalConnectionSlice", () => {
             const x = () => oneOf(true, false);
 
             it.each`
-                appWantsToJoin | signalStatus   | expected
-                ${true}        | ${""}          | ${true}
-                ${false}       | ${""}          | ${false}
-                ${x()}         | ${"connected"} | ${false}
+                appIsActive | signalStatus   | expected
+                ${true}     | ${""}          | ${true}
+                ${false}    | ${""}          | ${false}
+                ${x()}      | ${"connected"} | ${false}
             `(
-                "should return $expected when appWantsToJoin=$appWantsToJoin, signalStatus=$signalStatus",
-                ({ appWantsToJoin, signalStatus, expected }) => {
-                    expect(selectShouldConnectSignal.resultFunc(appWantsToJoin, signalStatus)).toEqual(expected);
+                "should return $expected when appIsActive=$appIsActive, signalStatus=$signalStatus",
+                ({ appIsActive, signalStatus, expected }) => {
+                    expect(selectShouldConnectSignal.resultFunc(appIsActive, signalStatus)).toEqual(expected);
                 },
             );
         });

--- a/packages/core/src/redux/slices/app.ts
+++ b/packages/core/src/redux/slices/app.ts
@@ -2,7 +2,7 @@ import { PayloadAction, createSelector, createSlice } from "@reduxjs/toolkit";
 import { RootState } from "../store";
 import type { LocalMediaOptions } from "./localMedia";
 import { coreVersion } from "../../version";
-import { createReactor } from "../listenerMiddleware";
+import { startAppListening } from "../listenerMiddleware";
 
 /**
  * Reducer
@@ -97,13 +97,18 @@ export const selectShouldReloadApp = createSelector(
     },
 );
 
-createReactor([selectShouldReloadApp], ({ dispatch, getState }, shouldReloadApp) => {
-    if (shouldReloadApp) {
+/**
+ * Reactors
+ */
+
+startAppListening({
+    actionCreator: doAppReset,
+    effect: (_, { dispatch, getState }) => {
         const state = getState();
         const appInitialConfig = selectAppInitialConfig(state);
 
         if (appInitialConfig) {
             dispatch(doAppConfigure(appInitialConfig));
         }
-    }
+    },
 });

--- a/packages/core/src/redux/slices/app.ts
+++ b/packages/core/src/redux/slices/app.ts
@@ -20,7 +20,7 @@ interface AppConfig {
 
 export interface AppState {
     isNodeSdk: boolean;
-    wantsToJoin: boolean;
+    isActive: boolean;
     roomUrl: string | null;
     roomName: string | null;
     displayName: string | null;
@@ -32,7 +32,7 @@ export interface AppState {
 
 const initialState: AppState = {
     isNodeSdk: false,
-    wantsToJoin: false,
+    isActive: false,
     roomName: null,
     roomUrl: null,
     displayName: null,
@@ -45,7 +45,7 @@ export const appSlice = createSlice({
     name: "app",
     initialState,
     reducers: {
-        doAppJoin: (state, action: PayloadAction<AppConfig>) => {
+        doAppConfigure: (state, action: PayloadAction<AppConfig>) => {
             const url = new URL(action.payload.roomUrl);
 
             return {
@@ -56,11 +56,11 @@ export const appSlice = createSlice({
                 isLoaded: true,
             };
         },
-        doAppLeft: (state) => {
-            return { ...state, wantsToJoin: false };
+        doAppStart: (state) => {
+            return { ...state, isActive: true };
         },
-        doWantsToJoin: (state) => {
-            return { ...state, wantsToJoin: true };
+        doAppStop: (state) => {
+            return { ...state, isActive: false };
         },
         doAppReset: (state) => {
             return { ...state, isLoaded: false };
@@ -72,14 +72,14 @@ export const appSlice = createSlice({
  * Action creators
  */
 
-export const { doAppJoin, doAppLeft, doAppReset, doWantsToJoin } = appSlice.actions;
+export const { doAppConfigure, doAppStop, doAppReset, doAppStart } = appSlice.actions;
 
 /**
  * Selectors
  */
 
 export const selectAppRaw = (state: RootState) => state.app;
-export const selectAppWantsToJoin = (state: RootState) => state.app.wantsToJoin;
+export const selectAppIsActive = (state: RootState) => state.app.isActive;
 export const selectAppRoomName = (state: RootState) => state.app.roomName;
 export const selectAppRoomUrl = (state: RootState) => state.app.roomUrl;
 export const selectAppDisplayName = (state: RootState) => state.app.displayName;
@@ -103,7 +103,7 @@ createReactor([selectShouldReloadApp], ({ dispatch, getState }, shouldReloadApp)
         const appInitialConfig = selectAppInitialConfig(state);
 
         if (appInitialConfig) {
-            dispatch(doAppJoin(appInitialConfig));
+            dispatch(doAppConfigure(appInitialConfig));
         }
     }
 });

--- a/packages/core/src/redux/slices/app.ts
+++ b/packages/core/src/redux/slices/app.ts
@@ -48,11 +48,13 @@ export const appSlice = createSlice({
                 ...state,
                 ...action.payload,
                 roomName: url.pathname,
-                wantsToJoin: true,
             };
         },
         appLeft: (state) => {
             return { ...state, wantsToJoin: false };
+        },
+        doWantsToJoin: (state) => {
+            return { ...state, wantsToJoin: true };
         },
     },
 });
@@ -60,7 +62,7 @@ export const appSlice = createSlice({
 /**
  * Action creators
  */
-export const { doAppJoin, appLeft } = appSlice.actions;
+export const { doAppJoin, appLeft, doWantsToJoin } = appSlice.actions;
 
 /**
  * Selectors

--- a/packages/core/src/redux/slices/authorization.ts
+++ b/packages/core/src/redux/slices/authorization.ts
@@ -2,7 +2,7 @@ import { PayloadAction, createSelector, createSlice } from "@reduxjs/toolkit";
 import { RoleName } from "@whereby.com/media";
 import { RootState } from "../store";
 import { signalEvents } from "./signalConnection/actions";
-import { doAppJoin } from "./app";
+import { doAppConfigure } from "./app";
 
 const ROOM_ACTION_PERMISSIONS_BY_ROLE: { [permissionKey: string]: Array<RoleName> } = {
     canLockRoom: ["host"],
@@ -37,7 +37,7 @@ export const authorizationSlice = createSlice({
         },
     },
     extraReducers: (builder) => {
-        builder.addCase(doAppJoin, (state, action) => {
+        builder.addCase(doAppConfigure, (state, action) => {
             return {
                 ...state,
                 roomKey: action.payload.roomKey,

--- a/packages/core/src/redux/slices/deviceCredentials.ts
+++ b/packages/core/src/redux/slices/deviceCredentials.ts
@@ -2,7 +2,7 @@ import { createSelector, createSlice } from "@reduxjs/toolkit";
 import { RootState } from "../store";
 import { createAppAsyncThunk } from "../thunk";
 import { createReactor } from "../listenerMiddleware";
-import { selectAppWantsToJoin } from "./app";
+import { selectAppIsActive } from "./app";
 import { Credentials } from "../../api";
 
 /**
@@ -77,10 +77,10 @@ export const selectDeviceId = (state: RootState) => state.deviceCredentials.data
  */
 
 export const selectShouldFetchDeviceCredentials = createSelector(
-    selectAppWantsToJoin,
+    selectAppIsActive,
     selectDeviceCredentialsRaw,
-    (wantsToJoin, deviceCredentials) => {
-        if (wantsToJoin && !deviceCredentials.isFetching && !deviceCredentials.data) {
+    (appIsActive, deviceCredentials) => {
+        if (appIsActive && !deviceCredentials.isFetching && !deviceCredentials.data) {
             return true;
         }
         return false;

--- a/packages/core/src/redux/slices/localMedia.ts
+++ b/packages/core/src/redux/slices/localMedia.ts
@@ -602,7 +602,7 @@ export const selectLocalMediaShouldStartWithOptions = createSelector(
     selectLocalMediaOptions,
     selectAppIsNodeSdk,
     (appWantsToJoin, localMediaStatus, localMediaOptions, isNodeSdk) => {
-        if (appWantsToJoin && localMediaStatus === "" && !isNodeSdk && localMediaOptions) {
+        if (appWantsToJoin && ["", "stopped"].includes(localMediaStatus) && !isNodeSdk && localMediaOptions) {
             return localMediaOptions;
         }
     },
@@ -615,20 +615,20 @@ createReactor([selectLocalMediaShouldStartWithOptions], ({ dispatch }, options) 
 });
 
 // Stop localMedia when roomConnection is no longer wanted and media was started when joining
-// export const selectLocalMediaShouldStop = createSelector(
-//     selectAppWantsToJoin,
-//     selectLocalMediaStatus,
-//     selectLocalMediaOptions,
-//     (appWantsToJoin, localMediaStatus, localMediaOptions) => {
-//         return !appWantsToJoin && localMediaStatus !== "" && !!localMediaOptions;
-//     },
-// );
+export const selectLocalMediaShouldStop = createSelector(
+    selectAppWantsToJoin,
+    selectLocalMediaStatus,
+    selectLocalMediaOptions,
+    (appWantsToJoin, localMediaStatus, localMediaOptions) => {
+        return !appWantsToJoin && localMediaStatus !== "" && !!localMediaOptions;
+    },
+);
 
-// createReactor([selectLocalMediaShouldStop], ({ dispatch }, localMediaShouldStop) => {
-//     if (localMediaShouldStop) {
-//         dispatch(doStopLocalMedia());
-//     }
-// });
+createReactor([selectLocalMediaShouldStop], ({ dispatch }, localMediaShouldStop) => {
+    if (localMediaShouldStop) {
+        dispatch(doStopLocalMedia());
+    }
+});
 
 startAppListening({
     predicate: (_action, currentState, previousState) => {

--- a/packages/core/src/redux/slices/localMedia.ts
+++ b/packages/core/src/redux/slices/localMedia.ts
@@ -46,6 +46,7 @@ export const initialLocalMediaState: LocalMediaState = {
     lowDataMode: false,
     microphoneEnabled: false,
     status: "",
+    stream: undefined,
     isSwitchingStream: false,
 };
 
@@ -614,20 +615,20 @@ createReactor([selectLocalMediaShouldStartWithOptions], ({ dispatch }, options) 
 });
 
 // Stop localMedia when roomConnection is no longer wanted and media was started when joining
-export const selectLocalMediaShouldStop = createSelector(
-    selectAppWantsToJoin,
-    selectLocalMediaStatus,
-    selectLocalMediaOptions,
-    (appWantsToJoin, localMediaStatus, localMediaOptions) => {
-        return !appWantsToJoin && localMediaStatus !== "" && !!localMediaOptions;
-    },
-);
+// export const selectLocalMediaShouldStop = createSelector(
+//     selectAppWantsToJoin,
+//     selectLocalMediaStatus,
+//     selectLocalMediaOptions,
+//     (appWantsToJoin, localMediaStatus, localMediaOptions) => {
+//         return !appWantsToJoin && localMediaStatus !== "" && !!localMediaOptions;
+//     },
+// );
 
-createReactor([selectLocalMediaShouldStop], ({ dispatch }, localMediaShouldStop) => {
-    if (localMediaShouldStop) {
-        dispatch(doStopLocalMedia());
-    }
-});
+// createReactor([selectLocalMediaShouldStop], ({ dispatch }, localMediaShouldStop) => {
+//     if (localMediaShouldStop) {
+//         dispatch(doStopLocalMedia());
+//     }
+// });
 
 startAppListening({
     predicate: (_action, currentState, previousState) => {

--- a/packages/core/src/redux/slices/localMedia.ts
+++ b/packages/core/src/redux/slices/localMedia.ts
@@ -29,7 +29,7 @@ export interface LocalMediaState {
     microphoneDeviceError?: unknown;
     microphoneEnabled: boolean;
     options?: LocalMediaOptions;
-    status: "" | "stopped" | "starting" | "started" | "error";
+    status: "inactive" | "stopped" | "starting" | "started" | "error";
     startError?: unknown;
     stream?: MediaStream;
     isSwitchingStream: boolean;
@@ -45,7 +45,7 @@ export const initialLocalMediaState: LocalMediaState = {
     isTogglingCamera: false,
     lowDataMode: false,
     microphoneEnabled: false,
-    status: "",
+    status: "inactive",
     stream: undefined,
     isSwitchingStream: false,
 };
@@ -602,7 +602,7 @@ export const selectLocalMediaShouldStartWithOptions = createSelector(
     selectLocalMediaOptions,
     selectAppIsNodeSdk,
     (appIsActive, localMediaStatus, localMediaOptions, isNodeSdk) => {
-        if (appIsActive && ["", "stopped"].includes(localMediaStatus) && !isNodeSdk && localMediaOptions) {
+        if (appIsActive && ["inactive", "stopped"].includes(localMediaStatus) && !isNodeSdk && localMediaOptions) {
             return localMediaOptions;
         }
     },
@@ -620,7 +620,7 @@ export const selectLocalMediaShouldStop = createSelector(
     selectLocalMediaStatus,
     selectLocalMediaOptions,
     (appIsActive, localMediaStatus, localMediaOptions) => {
-        return !appIsActive && localMediaStatus !== "" && !!localMediaOptions;
+        return !appIsActive && localMediaStatus !== "inactive" && !!localMediaOptions;
     },
 );
 

--- a/packages/core/src/redux/slices/localMedia.ts
+++ b/packages/core/src/redux/slices/localMedia.ts
@@ -3,7 +3,7 @@ import { getStream, getUpdatedDevices, getDeviceData } from "@whereby.com/media"
 import { createAppAsyncThunk, createAppThunk } from "../thunk";
 import { RootState } from "../store";
 import { createReactor, startAppListening } from "../listenerMiddleware";
-import { doAppJoin, selectAppIsNodeSdk, selectAppWantsToJoin } from "./app";
+import { doAppConfigure, selectAppIsNodeSdk, selectAppIsActive } from "./app";
 import { debounce } from "../../utils";
 import { signalEvents } from "./signalConnection/actions";
 
@@ -130,7 +130,7 @@ export const localMediaSlice = createSlice({
         },
     },
     extraReducers: (builder) => {
-        builder.addCase(doAppJoin, (state, action) => {
+        builder.addCase(doAppConfigure, (state, action) => {
             return {
                 ...state,
                 options: action.payload.localMediaOptions,
@@ -597,12 +597,12 @@ export const selectSpeakerDevices = createSelector(selectLocalMediaDevices, (dev
 
 // Start localMedia unless started when roomConnection is wanted
 export const selectLocalMediaShouldStartWithOptions = createSelector(
-    selectAppWantsToJoin,
+    selectAppIsActive,
     selectLocalMediaStatus,
     selectLocalMediaOptions,
     selectAppIsNodeSdk,
-    (appWantsToJoin, localMediaStatus, localMediaOptions, isNodeSdk) => {
-        if (appWantsToJoin && ["", "stopped"].includes(localMediaStatus) && !isNodeSdk && localMediaOptions) {
+    (appIsActive, localMediaStatus, localMediaOptions, isNodeSdk) => {
+        if (appIsActive && ["", "stopped"].includes(localMediaStatus) && !isNodeSdk && localMediaOptions) {
             return localMediaOptions;
         }
     },
@@ -616,11 +616,11 @@ createReactor([selectLocalMediaShouldStartWithOptions], ({ dispatch }, options) 
 
 // Stop localMedia when roomConnection is no longer wanted and media was started when joining
 export const selectLocalMediaShouldStop = createSelector(
-    selectAppWantsToJoin,
+    selectAppIsActive,
     selectLocalMediaStatus,
     selectLocalMediaOptions,
-    (appWantsToJoin, localMediaStatus, localMediaOptions) => {
-        return !appWantsToJoin && localMediaStatus !== "" && !!localMediaOptions;
+    (appIsActive, localMediaStatus, localMediaOptions) => {
+        return !appIsActive && localMediaStatus !== "" && !!localMediaOptions;
     },
 );
 

--- a/packages/core/src/redux/slices/localParticipant.ts
+++ b/packages/core/src/redux/slices/localParticipant.ts
@@ -4,7 +4,7 @@ import { RootState } from "../store";
 import { createAppAsyncThunk } from "../thunk";
 import { LocalParticipant } from "../../RoomParticipant";
 import { selectSignalConnectionRaw } from "./signalConnection";
-import { doAppJoin } from "./app";
+import { doAppConfigure } from "./app";
 import { toggleCameraEnabled, toggleMicrophoneEnabled } from "./localMedia";
 import { startAppListening } from "../listenerMiddleware";
 import { signalEvents } from "./signalConnection/actions";
@@ -78,7 +78,7 @@ export const localParticipantSlice = createSlice({
         },
     },
     extraReducers: (builder) => {
-        builder.addCase(doAppJoin, (state, action) => {
+        builder.addCase(doAppConfigure, (state, action) => {
             return {
                 ...state,
                 displayName: action.payload.displayName,

--- a/packages/core/src/redux/slices/localScreenshare.ts
+++ b/packages/core/src/redux/slices/localScreenshare.ts
@@ -5,13 +5,13 @@ import { startAppListening } from "../listenerMiddleware";
 import { localMediaStopped } from "./localMedia";
 
 export interface LocalScreenshareState {
-    status: "" | "starting" | "active";
+    status: "inactive" | "starting" | "active";
     stream: MediaStream | null;
     error: unknown | null;
 }
 
 const initialState: LocalScreenshareState = {
-    status: "",
+    status: "inactive",
     stream: null,
     error: null,
 };
@@ -28,7 +28,7 @@ export const localScreenshareSlice = createSlice({
         stopScreenshare(state, action: PayloadAction<{ stream: MediaStream }>) {
             return {
                 ...state,
-                status: "",
+                status: "inactive",
                 stream: null,
             };
         },
@@ -51,7 +51,7 @@ export const localScreenshareSlice = createSlice({
             return {
                 ...state,
                 error: payload,
-                status: "",
+                status: "inactive",
                 stream: null,
             };
         });

--- a/packages/core/src/redux/slices/organization.ts
+++ b/packages/core/src/redux/slices/organization.ts
@@ -3,7 +3,7 @@ import { RootState } from "../store";
 import { createAppAsyncThunk } from "../thunk";
 import Organization from "../../api/models/Organization";
 import { createReactor } from "../listenerMiddleware";
-import { selectAppRoomUrl, selectAppWantsToJoin } from "./app";
+import { selectAppRoomUrl, selectAppIsActive } from "./app";
 import { selectDeviceCredentialsRaw } from "./deviceCredentials";
 
 /**
@@ -86,12 +86,12 @@ export const selectOrganizationId = (state: RootState) => state.organization.dat
  */
 
 export const selectShouldFetchOrganization = createSelector(
-    selectAppWantsToJoin,
+    selectAppIsActive,
     selectOrganizationRaw,
     selectDeviceCredentialsRaw,
-    (wantsToJoin, organization, deviceCredentials) => {
+    (appIsActive, organization, deviceCredentials) => {
         if (
-            wantsToJoin &&
+            appIsActive &&
             !organization.data &&
             !organization.isFetching &&
             !organization.error &&

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -35,9 +35,8 @@ export type ConnectionStatus =
     | "kicked"
     | "leaving"
     | "left"
-    | "reconnect"
-    | "disconnecting"
-    | "disconnected";
+    | "disconnected"
+    | "reconnecting";
 
 /**
  * Reducer
@@ -128,7 +127,7 @@ export const roomConnectionSlice = createSlice({
         builder.addCase(socketReconnecting, (state) => {
             return {
                 ...state,
-                status: "reconnect",
+                status: "reconnecting",
             };
         });
     },
@@ -242,7 +241,7 @@ export const selectShouldConnectRoom = createSelector(
             (localMediaStatus === "started" || isNodeSdk) &&
             signalConnectionDeviceIdentified &&
             !!hasOrganizationIdFetched &&
-            ["ready", "reconnect", "disconnected"].includes(roomConnectionStatus)
+            ["ready", "reconnecting", "disconnected"].includes(roomConnectionStatus)
         ) {
             return true;
         }

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -27,7 +27,7 @@ import { selectIsCameraEnabled, selectIsMicrophoneEnabled, selectLocalMediaStatu
 import { selectSelfId, selectLocalParticipantClientClaim } from "./localParticipant";
 
 export type ConnectionStatus =
-    | "initializing"
+    | "ready"
     | "connecting"
     | "connected"
     | "room_locked"
@@ -52,7 +52,7 @@ export interface RoomConnectionState {
 
 const initialState: RoomConnectionState = {
     session: null,
-    status: "initializing",
+    status: "ready",
     error: null,
 };
 
@@ -256,7 +256,7 @@ export const selectShouldConnectRoom = createSelector(
             (localMediaStatus === "started" || isNodeSdk) &&
             signalConnectionDeviceIdentified &&
             !!hasOrganizationIdFetched &&
-            ["initializing", "reconnect", "disconnected"].includes(roomConnectionStatus)
+            ["ready", "reconnect", "disconnected"].includes(roomConnectionStatus)
         ) {
             return true;
         }

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -4,13 +4,13 @@ import { createReactor, startAppListening } from "../listenerMiddleware";
 import { RootState } from "../store";
 import { createAppThunk } from "../thunk";
 import {
-    doWantsToJoin,
+    doAppStart,
     selectAppDisplayName,
     selectAppRoomName,
     selectAppUserAgent,
     selectAppExternalId,
     selectAppIsNodeSdk,
-    selectAppWantsToJoin,
+    selectAppIsActive,
 } from "./app";
 import { selectRoomKey, setRoomKey } from "./authorization";
 
@@ -208,7 +208,7 @@ export const doConnectRoom = createAppThunk(() => (dispatch, getState) => {
 });
 
 export const doJoinRoom = createAppThunk(() => (dispatch) => {
-    dispatch(doWantsToJoin());
+    dispatch(doAppStart());
 });
 
 export const doLeaveRoom = createAppThunk(() => (dispatch, getState) => {
@@ -236,7 +236,7 @@ export const selectRoomConnectionError = (state: RootState) => state.roomConnect
 
 export const selectShouldConnectRoom = createSelector(
     [
-        selectAppWantsToJoin,
+        selectAppIsActive,
         selectOrganizationId,
         selectRoomConnectionStatus,
         selectSignalConnectionDeviceIdentified,
@@ -244,7 +244,7 @@ export const selectShouldConnectRoom = createSelector(
         selectAppIsNodeSdk,
     ],
     (
-        appWantsToJoin,
+        appIsActive,
         hasOrganizationIdFetched,
         roomConnectionStatus,
         signalConnectionDeviceIdentified,
@@ -252,7 +252,7 @@ export const selectShouldConnectRoom = createSelector(
         isNodeSdk,
     ) => {
         if (
-            appWantsToJoin &&
+            appIsActive &&
             (localMediaStatus === "started" || isNodeSdk) &&
             signalConnectionDeviceIdentified &&
             !!hasOrganizationIdFetched &&

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -293,6 +293,6 @@ startAppListening({
 
 createReactor([selectRoomConnectionStatus, selectSignalStatus], ({ dispatch }, roomConnectionStatus, signalStatus) => {
     if (["kicked", "left"].includes(roomConnectionStatus) && signalStatus !== "disconnected") {
-        dispatch(doSignalDisconnect());
+        dispatch(doSignalDisconnect({ reset: true }));
     }
 });

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -63,7 +63,7 @@ export interface RtcConnectionState {
     rtcManager: RtcManager | null;
     rtcManagerDispatcher: RtcManagerDispatcher | null;
     rtcManagerInitialized: boolean;
-    status: "" | "ready" | "reconnect";
+    status: "inactive" | "ready" | "reconnecting";
     isAcceptingStreams: boolean;
 }
 
@@ -75,7 +75,7 @@ const initialState: RtcConnectionState = {
     rtcManager: null,
     rtcManagerDispatcher: null,
     rtcManagerInitialized: false,
-    status: "",
+    status: "inactive",
     isAcceptingStreams: false,
 };
 
@@ -136,13 +136,13 @@ export const rtcConnectionSlice = createSlice({
         builder.addCase(socketReconnecting, (state) => {
             return {
                 ...state,
-                status: "reconnect",
+                status: "reconnecting",
             };
         });
         builder.addCase(signalEvents.roomJoined, (state) => {
             return {
                 ...state,
-                status: state.status === "reconnect" ? "ready" : state.status,
+                status: state.status === "reconnecting" ? "ready" : state.status,
             };
         });
     },
@@ -406,7 +406,7 @@ createReactor([selectShouldInitializeRtc], ({ dispatch }, shouldInitializeRtc) =
 // Disonnect and clean up
 
 export const selectShouldDisconnectRtc = createSelector(selectRtcStatus, selectAppIsActive, (status, appIsActive) => {
-    if (!appIsActive && !["", "disconnected"].includes(status)) {
+    if (!appIsActive && !["inactive", "disconnected"].includes(status)) {
         return true;
     }
     return false;

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -12,7 +12,7 @@ import { selectSignalConnectionRaw, selectSignalConnectionSocket, socketReconnec
 import { createReactor, startAppListening } from "../../listenerMiddleware";
 import { selectRemoteParticipants, streamStatusUpdated } from "../remoteParticipants";
 import { StreamState } from "../../../RoomParticipant";
-import { selectAppIsNodeSdk, selectAppWantsToJoin } from "../app";
+import { selectAppIsNodeSdk, selectAppIsActive } from "../app";
 import { Chrome111 as MediasoupDeviceHandler } from "mediasoup-client/lib/handlers/Chrome111.js";
 import {
     selectIsCameraEnabled,
@@ -405,16 +405,12 @@ createReactor([selectShouldInitializeRtc], ({ dispatch }, shouldInitializeRtc) =
 
 // Disonnect and clean up
 
-export const selectShouldDisconnectRtc = createSelector(
-    selectRtcStatus,
-    selectAppWantsToJoin,
-    (status, wantsToJoin) => {
-        if (!wantsToJoin && !["", "disconnected"].includes(status)) {
-            return true;
-        }
-        return false;
-    },
-);
+export const selectShouldDisconnectRtc = createSelector(selectRtcStatus, selectAppIsActive, (status, appIsActive) => {
+    if (!appIsActive && !["", "disconnected"].includes(status)) {
+        return true;
+    }
+    return false;
+});
 
 createReactor([selectShouldDisconnectRtc], ({ dispatch }, shouldDisconnectRtc) => {
     if (shouldDisconnectRtc) {

--- a/packages/core/src/redux/slices/signalConnection/actions.ts
+++ b/packages/core/src/redux/slices/signalConnection/actions.ts
@@ -40,6 +40,7 @@ export const signalEvents = {
     newClient: createSignalEventAction<NewClientEvent>("newClient"),
     roomJoined: createSignalEventAction<RoomJoinedEvent>("roomJoined"),
     roomKnocked: createSignalEventAction<RoomKnockedEvent>("roomKnocked"),
+    roomLeft: createSignalEventAction<void>("roomLeft"),
     roomLocked: createSignalEventAction<RoomLockedEvent>("roomLocked"),
     roomSessionEnded: createSignalEventAction<RoomSessionEndedEvent>("roomSessionEnded"),
     screenshareStarted: createSignalEventAction<ScreenshareStartedEvent>("screenshareStarted"),

--- a/packages/core/src/redux/slices/signalConnection/index.ts
+++ b/packages/core/src/redux/slices/signalConnection/index.ts
@@ -209,6 +209,7 @@ export const doSignalDisconnect = createAppThunk(() => (dispatch, getState) => {
 
     socket?.disconnect();
     dispatch(socketDisconnected());
+    dispatch({ type: "app/reset" });
 });
 
 /**

--- a/packages/core/src/redux/slices/signalConnection/index.ts
+++ b/packages/core/src/redux/slices/signalConnection/index.ts
@@ -234,7 +234,7 @@ export const selectShouldConnectSignal = createSelector(
     selectAppWantsToJoin,
     selectSignalStatus,
     (wantsToJoin, signalStatus) => {
-        if (wantsToJoin && ["", "reconnect"].includes(signalStatus)) {
+        if (wantsToJoin && ["", "reconnect", "disconnected"].includes(signalStatus)) {
             return true;
         }
         return false;

--- a/packages/core/src/redux/slices/signalConnection/index.ts
+++ b/packages/core/src/redux/slices/signalConnection/index.ts
@@ -27,7 +27,7 @@ import {
     VideoEnabledEvent,
 } from "@whereby.com/media";
 import { Credentials } from "../../../api";
-import { doAppLeft, selectAppWantsToJoin } from "../app";
+import { doAppStop, selectAppIsActive } from "../app";
 import { signalEvents } from "./actions";
 
 function forwardSocketEvents(socket: ServerSocket, dispatch: ThunkDispatch<RootState, unknown, UnknownAction>) {
@@ -229,17 +229,17 @@ export const selectSignalConnectionSocket = (state: RootState) => state.signalCo
  * Reactors
  */
 startAppListening({
-    actionCreator: doAppLeft,
+    actionCreator: doAppStop,
     effect: (_, { dispatch }) => {
         dispatch(doSignalDisconnect({ reset: false }));
     },
 });
 
 export const selectShouldConnectSignal = createSelector(
-    selectAppWantsToJoin,
+    selectAppIsActive,
     selectSignalStatus,
-    (wantsToJoin, signalStatus) => {
-        if (wantsToJoin && ["", "reconnect", "disconnected"].includes(signalStatus)) {
+    (appIsActive, signalStatus) => {
+        if (appIsActive && ["", "reconnect", "disconnected"].includes(signalStatus)) {
             return true;
         }
         return false;

--- a/packages/core/src/redux/slices/signalConnection/index.ts
+++ b/packages/core/src/redux/slices/signalConnection/index.ts
@@ -45,6 +45,7 @@ function forwardSocketEvents(socket: ServerSocket, dispatch: ThunkDispatch<RootS
     socket.on("chat_message", (payload: ChatMessage) => dispatch(signalEvents.chatMessage(payload)));
     socket.on("disconnect", () => dispatch(signalEvents.disconnect()));
     socket.on("room_knocked", (payload: RoomKnockedEvent) => dispatch(signalEvents.roomKnocked(payload)));
+    socket.on("room_left", () => dispatch(signalEvents.roomLeft()));
     socket.on("room_locked", (payload: RoomLockedEvent) => dispatch(signalEvents.roomLocked(payload)));
     socket.on("room_session_ended", (payload: RoomSessionEndedEvent) =>
         dispatch(signalEvents.roomSessionEnded(payload)),
@@ -203,8 +204,9 @@ export const doSignalIdentifyDevice = createAppThunk(
 );
 
 export const doSignalDisconnect = createAppThunk(() => (dispatch, getState) => {
-    const socket = selectSignalConnectionRaw(getState()).socket;
-    socket?.emit("leave_room");
+    const state = getState();
+    const socket = selectSignalConnectionRaw(state).socket;
+
     socket?.disconnect();
     dispatch(socketDisconnected());
 });

--- a/packages/core/src/redux/slices/signalConnection/index.ts
+++ b/packages/core/src/redux/slices/signalConnection/index.ts
@@ -87,14 +87,14 @@ function createSocket() {
 export interface SignalConnectionState {
     deviceIdentified: boolean;
     isIdentifyingDevice: boolean;
-    status: "connected" | "connecting" | "disconnected" | "reconnect" | ""; // the state of the underlying socket.io connection
+    status: "ready" | "connecting" | "connected" | "disconnected" | "reconnecting"; // the state of the underlying socket.io connection
     socket: ServerSocket | null;
 }
 
 const initialState: SignalConnectionState = {
     deviceIdentified: false,
     isIdentifyingDevice: false,
-    status: "",
+    status: "ready",
     socket: null,
 };
 
@@ -125,7 +125,7 @@ export const signalConnectionSlice = createSlice({
         socketReconnecting: (state) => {
             return {
                 ...state,
-                status: "reconnect",
+                status: "reconnecting",
             };
         },
         deviceIdentifying: (state) => {
@@ -235,7 +235,7 @@ export const selectShouldConnectSignal = createSelector(
     selectAppIsActive,
     selectSignalStatus,
     (appIsActive, signalStatus) => {
-        if (appIsActive && ["", "reconnect"].includes(signalStatus)) {
+        if (appIsActive && ["ready", "reconnecting"].includes(signalStatus)) {
             return true;
         }
         return false;

--- a/packages/core/src/redux/store.ts
+++ b/packages/core/src/redux/store.ts
@@ -44,9 +44,22 @@ const appReducer = combineReducers({
 });
 
 export const rootReducer: AppReducer = (state, action) => {
-    // Reset store state on leave
-    if (action.type === signalEvents.roomLeft.type) {
-        return appReducer(undefined, action);
+    // Reset store state on signal disconnect
+    if (action.type === signalEvents.disconnect.type) {
+        const resetState: Partial<RootState> = {
+            app: {
+                ...(state?.app ?? appSlice.getInitialState()),
+                wantsToJoin: false,
+            },
+            localMedia: {
+                ...(state?.localMedia ?? localMediaSlice.getInitialState()),
+            },
+            organization: {
+                ...(state?.organization ?? organizationSlice.getInitialState()),
+            },
+        };
+
+        return appReducer(resetState, action);
     }
 
     return appReducer(state, action);

--- a/packages/core/src/redux/store.ts
+++ b/packages/core/src/redux/store.ts
@@ -15,7 +15,6 @@ import { remoteParticipantsSlice } from "./slices/remoteParticipants";
 import { roomSlice } from "./slices/room";
 import { roomConnectionSlice } from "./slices/roomConnection";
 import { signalConnectionSlice } from "./slices/signalConnection";
-import { signalEvents } from "./slices/signalConnection/actions";
 import { rtcAnalyticsSlice } from "./slices/rtcAnalytics";
 import { rtcConnectionSlice } from "./slices/rtcConnection";
 import { streamingSlice } from "./slices/streaming";
@@ -44,8 +43,8 @@ const appReducer = combineReducers({
 });
 
 export const rootReducer: AppReducer = (state, action) => {
-    // Reset store state on signal disconnect
-    if (action.type === signalEvents.disconnect.type) {
+    // Reset store state on reset signal
+    if (action.type === "app/reset") {
         const resetState: Partial<RootState> = {
             app: {
                 ...(state?.app ?? appSlice.getInitialState()),

--- a/packages/core/src/redux/store.ts
+++ b/packages/core/src/redux/store.ts
@@ -2,7 +2,7 @@ import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import { listenerMiddleware } from "./listenerMiddleware";
 import { createServices } from "../services";
 
-import { appSlice } from "./slices/app";
+import { appSlice, doAppReset } from "./slices/app";
 import { authorizationSlice } from "./slices/authorization";
 import { chatSlice } from "./slices/chat";
 import { cloudRecordingSlice } from "./slices/cloudRecording";
@@ -43,18 +43,16 @@ const appReducer = combineReducers({
 });
 
 export const rootReducer: AppReducer = (state, action) => {
-    // Reset store state on reset signal
-    if (action.type === "app/reset") {
+    // Reset store state on app reset action
+    if (doAppReset.match(action)) {
         const resetState: Partial<RootState> = {
             app: {
-                ...(state?.app ?? appSlice.getInitialState()),
-                wantsToJoin: false,
+                ...appSlice.getInitialState(),
+                initialConfig: state?.app?.initialConfig,
             },
             localMedia: {
-                ...(state?.localMedia ?? localMediaSlice.getInitialState()),
-            },
-            organization: {
-                ...(state?.organization ?? organizationSlice.getInitialState()),
+                ...localMediaSlice.getInitialState(),
+                ...state?.localMedia,
             },
         };
 

--- a/packages/core/src/redux/store.ts
+++ b/packages/core/src/redux/store.ts
@@ -15,6 +15,7 @@ import { remoteParticipantsSlice } from "./slices/remoteParticipants";
 import { roomSlice } from "./slices/room";
 import { roomConnectionSlice } from "./slices/roomConnection";
 import { signalConnectionSlice } from "./slices/signalConnection";
+import { signalEvents } from "./slices/signalConnection/actions";
 import { rtcAnalyticsSlice } from "./slices/rtcAnalytics";
 import { rtcConnectionSlice } from "./slices/rtcConnection";
 import { streamingSlice } from "./slices/streaming";
@@ -22,7 +23,7 @@ import { waitingParticipantsSlice } from "./slices/waitingParticipants";
 
 const IS_DEV = process.env.REACT_APP_IS_DEV === "true" ?? false;
 
-export const rootReducer = combineReducers({
+const appReducer = combineReducers({
     app: appSlice.reducer,
     authorization: authorizationSlice.reducer,
     chat: chatSlice.reducer,
@@ -41,6 +42,15 @@ export const rootReducer = combineReducers({
     streaming: streamingSlice.reducer,
     waitingParticipants: waitingParticipantsSlice.reducer,
 });
+
+export const rootReducer: AppReducer = (state, action) => {
+    // Reset store state on leave
+    if (action.type === signalEvents.roomLeft.type) {
+        return appReducer(undefined, action);
+    }
+
+    return appReducer(state, action);
+};
 
 export const createStore = ({
     preloadedState,
@@ -63,8 +73,8 @@ export const createStore = ({
     });
 };
 
-export type RootReducer = typeof rootReducer;
-export type RootState = ReturnType<typeof rootReducer>;
+export type AppReducer = typeof appReducer;
+export type RootState = ReturnType<typeof appReducer>;
 export type AppDispatch = ReturnType<typeof createStore>["dispatch"];
 
 export type Store = ReturnType<typeof createStore>;

--- a/packages/core/src/redux/tests/store/localScreenshare.spec.ts
+++ b/packages/core/src/redux/tests/store/localScreenshare.spec.ts
@@ -55,7 +55,7 @@ describe("actions", () => {
         const after = store.getState().localScreenshare;
 
         expect(diff(before, after)).toEqual({
-            status: "",
+            status: "inactive",
             stream: null,
         });
     });

--- a/packages/core/src/redux/tests/store/roomConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/roomConnection.spec.ts
@@ -1,5 +1,5 @@
 import { createStore, mockSignalEmit } from "../store.setup";
-import { doKnockRoom, doConnectRoom, doJoinRoom, doLeaveRoom } from "../../slices/roomConnection";
+import { doKnockRoom, doConnectRoom } from "../../slices/roomConnection";
 import { diff } from "deep-object-diff";
 
 describe("actions", () => {
@@ -30,35 +30,6 @@ describe("actions", () => {
         expect(mockSignalEmit).toHaveBeenCalledWith("join_room", expect.any(Object));
         expect(diff(before, after)).toEqual({
             status: "connecting",
-        });
-    });
-
-    it("doJoinRoom", async () => {
-        const store = createStore();
-
-        const before = store.getState().app;
-
-        store.dispatch(doJoinRoom());
-
-        const after = store.getState().app;
-
-        expect(diff(before, after)).toEqual({
-            appIsActive: true,
-        });
-    });
-
-    it("doLeaveRoom", async () => {
-        const store = createStore({ withSignalConnection: true });
-
-        const before = store.getState().roomConnection;
-
-        store.dispatch(doLeaveRoom());
-
-        const after = store.getState().roomConnection;
-
-        expect(mockSignalEmit).toHaveBeenCalledWith("leave_room");
-        expect(diff(before, after)).toEqual({
-            status: "leaving",
         });
     });
 });

--- a/packages/core/src/redux/tests/store/roomConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/roomConnection.spec.ts
@@ -1,5 +1,5 @@
 import { createStore, mockSignalEmit } from "../store.setup";
-import { doKnockRoom, doConnectRoom, doLeaveRoom } from "../../slices/roomConnection";
+import { doKnockRoom, doConnectRoom, doJoinRoom, doLeaveRoom } from "../../slices/roomConnection";
 import { diff } from "deep-object-diff";
 
 describe("actions", () => {
@@ -30,6 +30,20 @@ describe("actions", () => {
         expect(mockSignalEmit).toHaveBeenCalledWith("join_room", expect.any(Object));
         expect(diff(before, after)).toEqual({
             status: "connecting",
+        });
+    });
+
+    it("doJoinRoom", async () => {
+        const store = createStore();
+
+        const before = store.getState().app;
+
+        store.dispatch(doJoinRoom());
+
+        const after = store.getState().app;
+
+        expect(diff(before, after)).toEqual({
+            wantsToJoin: true,
         });
     });
 

--- a/packages/core/src/redux/tests/store/roomConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/roomConnection.spec.ts
@@ -43,7 +43,7 @@ describe("actions", () => {
         const after = store.getState().app;
 
         expect(diff(before, after)).toEqual({
-            wantsToJoin: true,
+            appIsActive: true,
         });
     });
 

--- a/packages/core/src/redux/tests/store/roomConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/roomConnection.spec.ts
@@ -1,5 +1,5 @@
 import { createStore, mockSignalEmit } from "../store.setup";
-import { doKnockRoom, doConnectRoom } from "../../slices/roomConnection";
+import { doKnockRoom, doConnectRoom, doLeaveRoom } from "../../slices/roomConnection";
 import { diff } from "deep-object-diff";
 
 describe("actions", () => {
@@ -30,6 +30,21 @@ describe("actions", () => {
         expect(mockSignalEmit).toHaveBeenCalledWith("join_room", expect.any(Object));
         expect(diff(before, after)).toEqual({
             status: "connecting",
+        });
+    });
+
+    it("doLeaveRoom", async () => {
+        const store = createStore({ withSignalConnection: true });
+
+        const before = store.getState().roomConnection;
+
+        store.dispatch(doLeaveRoom());
+
+        const after = store.getState().roomConnection;
+
+        expect(mockSignalEmit).toHaveBeenCalledWith("leave_room");
+        expect(diff(before, after)).toEqual({
+            status: "leaving",
         });
     });
 });

--- a/packages/core/src/redux/tests/store/rtcConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/rtcConnection.spec.ts
@@ -82,7 +82,7 @@ describe("actions", () => {
             rtcManager: null,
             rtcManagerDispatcher: null,
             rtcManagerInitialized: false,
-            status: "",
+            status: "inactive",
         });
     });
 

--- a/packages/core/src/redux/tests/store/signalConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/signalConnection.spec.ts
@@ -64,11 +64,10 @@ describe("signalConnectionSlice", () => {
 
             const before = store.getState().signalConnection;
 
-            store.dispatch(doSignalDisconnect());
+            store.dispatch(doSignalDisconnect({ reset: false }));
 
             const after = store.getState().signalConnection;
 
-            expect(mockSignalEmit).toHaveBeenCalledWith("leave_room");
             expect(mockServerSocket.disconnect).toHaveBeenCalled();
             expect(diff(before, after)).toEqual({
                 deviceIdentified: false,

--- a/packages/core/src/redux/tests/store/signalConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/signalConnection.spec.ts
@@ -1,5 +1,5 @@
 import { createStore, mockSignalEmit, mockServerSocket } from "../store.setup";
-import { doSignalSocketConnect, doSignalIdentifyDevice, doSignalDisconnect } from "../../slices/signalConnection";
+import { doSignalConnect, doSignalIdentifyDevice, doSignalDisconnect } from "../../slices/signalConnection";
 import { randomDeviceCredentials } from "../../../__mocks__/appMocks";
 import { diff } from "deep-object-diff";
 import { ServerSocket } from "@whereby.com/media";
@@ -15,10 +15,10 @@ jest.mock("@whereby.com/media", () => {
 
 describe("signalConnectionSlice", () => {
     describe("actions", () => {
-        it("doSignalSocketConnect", () => {
+        it("doSignalConnect", () => {
             const store = createStore();
 
-            store.dispatch(doSignalSocketConnect());
+            store.dispatch(doSignalConnect());
 
             expect(ServerSocket).toHaveBeenCalledTimes(1);
             expect(mockServerSocket.connect).toHaveBeenCalledTimes(1);
@@ -51,27 +51,21 @@ describe("signalConnectionSlice", () => {
         });
 
         it("doSignalDisconnect", () => {
-            const deviceCredentials = randomDeviceCredentials();
             const store = createStore({
                 withSignalConnection: true,
-                initialState: {
-                    deviceCredentials: {
-                        data: deviceCredentials,
-                        isFetching: false,
-                    },
-                },
             });
 
             const before = store.getState().signalConnection;
 
-            store.dispatch(doSignalDisconnect({ reset: false }));
+            store.dispatch(doSignalDisconnect());
 
             const after = store.getState().signalConnection;
 
             expect(mockServerSocket.disconnect).toHaveBeenCalled();
             expect(diff(before, after)).toEqual({
                 deviceIdentified: false,
-                status: "disconnected",
+                status: "",
+                socket: null,
             });
         });
     });

--- a/packages/core/src/redux/tests/store/signalConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/signalConnection.spec.ts
@@ -64,7 +64,7 @@ describe("signalConnectionSlice", () => {
             expect(mockServerSocket.disconnect).toHaveBeenCalled();
             expect(diff(before, after)).toEqual({
                 deviceIdentified: false,
-                status: "",
+                status: "ready",
                 socket: null,
             });
         });


### PR DESCRIPTION
### Description

Implement `joinRoom()` and `leaveRoom()` actions on the `useRoomConnection` hook.

As part of this process this PR also refactors the join and leave logic in the SDK to support leaving and re-joining without needing to reload the SDK. Previously all join/leave logic was tied to the lifecycle of the useRoomConnection hook.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

1. Check out this branch
2. Run `yarn build && yarn dev`
3. In a browser tab, open the dev console and go to "Network" to view the websocket connections.
4. In the Storybook UI (@ http://localhost:6006/) open the story: "Custom UI" > "Room Connection Only"
5. After successfully joining a room you should see the signal server websocket connection as "pending" in the developer tools.
6. Click on the "leave" button should remove the user from the room.
7. The websocket connection in the dev tools should now be closed.
8. Click on the "Join room" button
9. The user should successfully re-join the room and a new signal server websocket should now be "pending"
10. In the Dev Tools > Network tab, change the network throttling option from "No throttling" to "Offline"
11. The UI should now display "Disconnected" while the network tab will show signal websocket connection trying to be re-established (unsuccessfully while the network is disconnected)
12. In the Dev Tools > Network tab, change the network throttling option back from "Offline" to "No throttling"
13. The user should successfully re-join the room automatically on successfully signal reconnect.

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
