### PR TITLE
common: Add `stayBehind` parameter to `endMeeting` host room action

### DIFF
--- a/.changeset/tame-frogs-sparkle.md
+++ b/.changeset/tame-frogs-sparkle.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/browser-sdk": minor
+"@whereby.com/core": minor
+---
+
+Add stayBehind parameter to endMeeting host room action

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -173,7 +173,10 @@ export function useRoomConnection(
         (clientId: string) => store.dispatch(doKickParticipant({ clientId })),
         [store],
     );
-    const endMeeting = React.useCallback(() => store.dispatch(doEndMeeting()), [store]);
+    const endMeeting = React.useCallback(
+        (stayBehind?: boolean) => store.dispatch(doEndMeeting({ stayBehind })),
+        [store],
+    );
 
     return {
         state: roomConnectionState,

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -76,7 +76,7 @@ export interface RoomConnectionActions {
     lockRoom(locked: boolean): void;
     muteParticipants(clientIds: string[]): void;
     kickParticipant(clientId: string): void;
-    endMeeting(): void;
+    endMeeting(stayBehind?: boolean): void;
     rejectWaitingParticipant(participantId: string): void;
     sendChatMessage(text: string): void;
     setDisplayName(displayName: string): void;

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -10,6 +10,7 @@ export default function VideoExperience({
     localMedia,
     externalId,
     showHostControls,
+    hostOptions,
 }: {
     displayName?: string;
     roomName: string;
@@ -17,6 +18,7 @@ export default function VideoExperience({
     localMedia?: UseLocalMediaResult;
     externalId?: string;
     showHostControls?: boolean;
+    hostOptions?: Array<string>;
 }) {
     const [chatMessage, setChatMessage] = useState("");
     const [isLocalScreenshareActive, setIsLocalScreenshareActive] = useState(false);
@@ -107,7 +109,7 @@ export default function VideoExperience({
                                 Unlock room
                             </button>
                             <button
-                                onClick={() => endMeeting(false)}
+                                onClick={() => endMeeting(Boolean(hostOptions?.includes("stayBehind")))}
                                 className={localParticipant?.roleName !== "host" ? "hostControlActionDisallowed" : ""}
                             >
                                 End meeting

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -107,7 +107,7 @@ export default function VideoExperience({
                                 Unlock room
                             </button>
                             <button
-                                onClick={() => endMeeting()}
+                                onClick={() => endMeeting(false)}
                                 className={localParticipant?.roleName !== "host" ? "hostControlActionDisallowed" : ""}
                             >
                                 End meeting

--- a/packages/browser-sdk/src/stories/custom-ui.stories.tsx
+++ b/packages/browser-sdk/src/stories/custom-ui.stories.tsx
@@ -155,20 +155,47 @@ export const RoomConnectionOnly = ({ roomUrl, displayName }: { roomUrl: string; 
 };
 
 export const RoomConnectionWithHostControls = {
-    render: ({ roomUrl, roomKey, displayName }: { roomUrl: string; roomKey: string; displayName?: string }) => {
+    render: ({
+        roomUrl,
+        roomKey,
+        displayName,
+        hostOptions,
+    }: {
+        roomUrl: string;
+        roomKey: string;
+        displayName?: string;
+        hostOptions: Array<string>;
+    }) => {
         if (!roomUrl || !roomUrl.match(roomRegEx)) {
             return <p>Set room url on the Controls panel</p>;
         }
 
-        return <VideoExperience displayName={displayName} roomName={roomUrl} roomKey={roomKey} showHostControls />;
+        return (
+            <VideoExperience
+                displayName={displayName}
+                roomName={roomUrl}
+                roomKey={roomKey}
+                showHostControls
+                hostOptions={hostOptions}
+            />
+        );
     },
     argTypes: {
         ...defaultArgs.argTypes,
         roomKey: { control: "text", type: { required: true } },
+        hostOptions: {
+            name: "Host options",
+            control: {
+                type: "check",
+                labels: { stayBehind: "Stay behind after triggering meeting end" },
+            },
+            options: ["stayBehind"],
+        },
     },
     args: {
         ...defaultArgs.args,
         roomKey: process.env.STORYBOOK_ROOM_HOST_ROOMKEY || "[Host roomKey required]",
+        hostOptions: ["stayBehind"],
     },
 };
 

--- a/packages/core/src/redux/slices/room.ts
+++ b/packages/core/src/redux/slices/room.ts
@@ -2,6 +2,7 @@ import { createSlice } from "@reduxjs/toolkit";
 import { RootState } from "../store";
 import { createAppAuthorizedThunk } from "../thunk";
 import { signalEvents } from "./signalConnection/actions";
+import { doAppStop } from "./app";
 import {
     selectIsAuthorizedToLockRoom,
     selectIsAuthorizedToKickClient,
@@ -77,7 +78,7 @@ export const doKickParticipant = createAppAuthorizedThunk(
 
 export const doEndMeeting = createAppAuthorizedThunk(
     (state) => selectIsAuthorizedToEndMeeting(state),
-    () => (_, getState) => {
+    (payload: { stayBehind?: boolean }) => (dispatch, getState) => {
         const state = getState();
 
         const clientsToKick = selectRemoteParticipants(state).map((c) => c.id);
@@ -86,6 +87,10 @@ export const doEndMeeting = createAppAuthorizedThunk(
             const { socket } = selectSignalConnectionRaw(state);
 
             socket?.emit("kick_client", { clientIds: clientsToKick, reasonId: "end-meeting" });
+        }
+
+        if (!payload.stayBehind) {
+            dispatch(doAppStop());
         }
     },
 );


### PR DESCRIPTION
Add a "stay behind" option for a host invoking the `endMeeting` action to opt-out of also leaving the room.

### Testing

1. Ensure that a "host" roomKey is configured in the `.env` file as `STORYBOOK_ROOM_HOST_ROOMKEY`
2. Run `yarn build && yarn dev`
3. Navigate to the "Room Connection With Host Controls" story (direct link once `yarn dev` is running [here](http://localhost:6006/?path=/story/examples-custom-ui--room-connection-with-host-controls))
4. Locate the storybook control called "Stay behind after triggering meeting end" and make sure it is **unchecked** (see screenshot)
5. Click on the "End meeting" button. 
6. All remote participants should be removed from the meeting and the current host participant should also leave the meeting.
8. Reload the storybook story
9. Again locate the storybook control called "Stay behind after triggering meeting end" and make sure it is **checked**
10. Click on the "End meeting" button.
11. All remote participants should be removed from the meeting but the current host participant should NOT leave the meeting. 

### Screenshots

##### stayBehind option in storybook

<img width="640" alt="Screenshot 2024-05-02 at 15 22 57" src="https://github.com/whereby/sdk/assets/119658286/75da1070-3200-41e0-a94e-8bf03d7aee28">


### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
