### PR TITLE
core: Add notification system

### DIFF
--- a/.changeset/three-sloths-bathe.md
+++ b/.changeset/three-sloths-bathe.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/browser-sdk": minor
+"@whereby.com/core": minor
+---
+
+Add a notifications system to core and expose notifications in the useRoomConnection hook

--- a/apps/embed-element-app/package.json
+++ b/apps/embed-element-app/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@coreui/icons": "^3.0.1",
         "@coreui/icons-react": "^2.2.1",
-        "@types/node": "^20.11.19",
+        "@types/node": "^20.12.8",
         "@types/react": "^18.2.57",
         "@types/react-dom": "^18.2.24",
         "@whereby.com/browser-sdk": "*",

--- a/apps/quiz-app/package.json
+++ b/apps/quiz-app/package.json
@@ -9,7 +9,7 @@
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.10.6",
         "@types/jest": "^27.5.2",
-        "@types/node": "^20.11.19",
+        "@types/node": "^20.12.8",
         "@types/react": "^18.2.57",
         "@types/react-dom": "^18.2.24",
         "@whereby.com/browser-sdk": "*",

--- a/apps/sample-app/package.json
+++ b/apps/sample-app/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "dependencies": {
         "@types/jest": "^27.5.2",
-        "@types/node": "^20.11.19",
+        "@types/node": "^20.12.8",
         "@types/react": "^18.2.57",
         "@types/react-dom": "^18.2.24",
         "@whereby.com/browser-sdk": "*",

--- a/apps/telehealth-tutorial-app/package.json
+++ b/apps/telehealth-tutorial-app/package.json
@@ -8,7 +8,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^27.5.2",
-    "@types/node": "^20.11.19",
+    "@types/node": "^20.12.8",
     "@types/react": "^18.2.57",
     "@types/react-dom": "^18.2.24",
     "@whereby.com/browser-sdk": "*",

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -56,7 +56,7 @@
     "@storybook/react-vite": "^8.0.10",
     "@testing-library/react": "^14.0.0",
     "@types/chrome": "^0.0.210",
-    "@types/node": "^20.11.19",
+    "@types/node": "^20.12.8",
     "@types/react": "^18.2.57",
     "@types/uuid": "^9.0.7",
     "@vitejs/plugin-react": "^4.2.1",

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import {
     AppConfig,
     Store,
+    NotificationCallbackFunction,
     createStore,
     observeStore,
     createServices,
@@ -24,6 +25,7 @@ import {
     doKickParticipant,
     doEndMeeting,
     doRtcReportStreamResolution,
+    doSetNotificationCallback,
 } from "@whereby.com/core";
 
 import VideoView from "../VideoView";
@@ -46,10 +48,15 @@ interface RoomConnectionComponents {
     VideoView: (props: VideoViewComponentProps) => ReturnType<typeof VideoView>;
 }
 
+interface RoomConnectionEvents {
+    onNotification: (callback: NotificationCallbackFunction) => void;
+}
+
 export type RoomConnectionRef = {
     state: RoomConnectionState;
     actions: RoomConnectionActions;
     components: RoomConnectionComponents;
+    events: RoomConnectionEvents;
     _ref: Store;
 };
 
@@ -182,6 +189,13 @@ export function useRoomConnection(
         [store],
     );
 
+    const onNotification = React.useCallback(
+        (callback: NotificationCallbackFunction = () => {}) => {
+            store.dispatch(doSetNotificationCallback(callback));
+        },
+        [store],
+    );
+
     return {
         state: roomConnectionState,
         actions: {
@@ -206,6 +220,9 @@ export function useRoomConnection(
         },
         components: {
             VideoView: boundVideoView || VideoView,
+        },
+        events: {
+            onNotification,
         },
         _ref: store,
     };

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -37,6 +37,7 @@ const initialState: RoomConnectionState = {
     connectionStatus: "ready",
     screenshares: [],
     waitingParticipants: [],
+    notifications: [],
 };
 
 type VideoViewComponentProps = Omit<React.ComponentProps<typeof VideoView>, "onResize">;

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -2,7 +2,6 @@ import * as React from "react";
 import {
     AppConfig,
     Store,
-    NotificationCallbackFunction,
     createStore,
     observeStore,
     createServices,
@@ -25,7 +24,6 @@ import {
     doKickParticipant,
     doEndMeeting,
     doRtcReportStreamResolution,
-    doSetNotificationCallback,
 } from "@whereby.com/core";
 
 import VideoView from "../VideoView";
@@ -39,7 +37,6 @@ const initialState: RoomConnectionState = {
     connectionStatus: "ready",
     screenshares: [],
     waitingParticipants: [],
-    notifications: [],
 };
 
 type VideoViewComponentProps = Omit<React.ComponentProps<typeof VideoView>, "onResize">;
@@ -48,15 +45,10 @@ interface RoomConnectionComponents {
     VideoView: (props: VideoViewComponentProps) => ReturnType<typeof VideoView>;
 }
 
-interface RoomConnectionEvents {
-    onNotification: (callback: NotificationCallbackFunction) => void;
-}
-
 export type RoomConnectionRef = {
     state: RoomConnectionState;
     actions: RoomConnectionActions;
     components: RoomConnectionComponents;
-    events: RoomConnectionEvents;
     _ref: Store;
 };
 
@@ -189,13 +181,6 @@ export function useRoomConnection(
         [store],
     );
 
-    const onNotification = React.useCallback(
-        (callback: NotificationCallbackFunction = () => {}) => {
-            store.dispatch(doSetNotificationCallback(callback));
-        },
-        [store],
-    );
-
     return {
         state: roomConnectionState,
         actions: {
@@ -220,9 +205,6 @@ export function useRoomConnection(
         },
         components: {
             VideoView: boundVideoView || VideoView,
-        },
-        events: {
-            onNotification,
         },
         _ref: store,
     };

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/selector.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/selector.ts
@@ -9,6 +9,7 @@ import {
     selectLocalParticipantRaw,
     selectLocalMediaStream,
     selectStreamingRaw,
+    selectNotificationsMessages,
 } from "@whereby.com/core";
 
 import { RoomConnectionState } from "./types";
@@ -23,6 +24,7 @@ export const selectRoomConnectionState = createSelector(
     selectRoomConnectionStatus,
     selectStreamingRaw,
     selectWaitingParticipants,
+    selectNotificationsMessages,
     (
         chatMessages,
         cloudRecording,
@@ -33,14 +35,11 @@ export const selectRoomConnectionState = createSelector(
         connectionStatus,
         streaming,
         waitingParticipants,
+        notificationsMessages,
     ) => {
         const state: RoomConnectionState = {
             chatMessages,
             cloudRecording: cloudRecording.isRecording ? { status: "recording" } : undefined,
-            localScreenshareStatus: localParticipant.isScreenSharing ? "active" : undefined,
-            localParticipant: { ...localParticipant, stream: localMediaStream },
-            remoteParticipants,
-            screenshares,
             connectionStatus,
             liveStream: streaming.isStreaming
                 ? {
@@ -48,6 +47,11 @@ export const selectRoomConnectionState = createSelector(
                       startedAt: streaming.startedAt,
                   }
                 : undefined,
+            localScreenshareStatus: localParticipant.isScreenSharing ? "active" : undefined,
+            localParticipant: { ...localParticipant, stream: localMediaStream },
+            notifications: notificationsMessages,
+            remoteParticipants,
+            screenshares,
             waitingParticipants,
         };
 

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/selector.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/selector.ts
@@ -9,7 +9,7 @@ import {
     selectLocalParticipantRaw,
     selectLocalMediaStream,
     selectStreamingRaw,
-    selectNotificationsMessages,
+    selectNotificationsEmitter,
 } from "@whereby.com/core";
 
 import { RoomConnectionState } from "./types";
@@ -24,7 +24,7 @@ export const selectRoomConnectionState = createSelector(
     selectRoomConnectionStatus,
     selectStreamingRaw,
     selectWaitingParticipants,
-    selectNotificationsMessages,
+    selectNotificationsEmitter,
     (
         chatMessages,
         cloudRecording,
@@ -35,12 +35,13 @@ export const selectRoomConnectionState = createSelector(
         connectionStatus,
         streaming,
         waitingParticipants,
-        notificationsMessages,
+        notificationsEmitter,
     ) => {
         const state: RoomConnectionState = {
             chatMessages,
             cloudRecording: cloudRecording.isRecording ? { status: "recording" } : undefined,
             connectionStatus,
+            events: notificationsEmitter,
             liveStream: streaming.isStreaming
                 ? {
                       status: "streaming",
@@ -49,7 +50,6 @@ export const selectRoomConnectionState = createSelector(
                 : undefined,
             localScreenshareStatus: localParticipant.isScreenSharing ? "active" : undefined,
             localParticipant: { ...localParticipant, stream: localMediaStream },
-            notifications: notificationsMessages,
             remoteParticipants,
             screenshares,
             waitingParticipants,

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -5,12 +5,12 @@ import {
     Screenshare,
     LocalMediaOptions,
     ConnectionStatus,
+    NotificationsEventEmitter,
 } from "@whereby.com/core";
 
 import { RoleName } from "@whereby.com/media";
 
 import { UseLocalMediaResult } from "../useLocalMedia/types";
-import { EventEmitter } from "stream";
 
 export type RemoteParticipantState = Omit<RemoteParticipant, "newJoiner" | "streams">;
 export interface LocalParticipantState extends LocalParticipant {
@@ -48,7 +48,7 @@ export interface RoomConnectionState {
     connectionStatus: ConnectionStatus;
     chatMessages: ChatMessage[];
     cloudRecording?: CloudRecordingState;
-    events?: EventEmitter;
+    events?: NotificationsEventEmitter;
     liveStream?: LiveStreamState;
     localScreenshareStatus?: LocalScreenshareStatus;
     localParticipant?: LocalParticipantState;

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -1,6 +1,5 @@
 import {
     ChatMessage as SignalChatMessage,
-    NotificationMessage,
     LocalParticipant,
     RemoteParticipant,
     Screenshare,
@@ -11,6 +10,7 @@ import {
 import { RoleName } from "@whereby.com/media";
 
 import { UseLocalMediaResult } from "../useLocalMedia/types";
+import { EventEmitter } from "stream";
 
 export type RemoteParticipantState = Omit<RemoteParticipant, "newJoiner" | "streams">;
 export interface LocalParticipantState extends LocalParticipant {
@@ -48,10 +48,10 @@ export interface RoomConnectionState {
     connectionStatus: ConnectionStatus;
     chatMessages: ChatMessage[];
     cloudRecording?: CloudRecordingState;
+    events?: EventEmitter;
     liveStream?: LiveStreamState;
     localScreenshareStatus?: LocalScreenshareStatus;
     localParticipant?: LocalParticipantState;
-    notifications: NotificationMessage[];
     remoteParticipants: RemoteParticipantState[];
     screenshares: Screenshare[];
     waitingParticipants: WaitingParticipantState[];

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -1,5 +1,6 @@
 import {
     ChatMessage as SignalChatMessage,
+    NotificationMessage,
     LocalParticipant,
     RemoteParticipant,
     Screenshare,
@@ -44,14 +45,15 @@ export type LiveStreamState = {
 };
 
 export interface RoomConnectionState {
+    connectionStatus: ConnectionStatus;
     chatMessages: ChatMessage[];
     cloudRecording?: CloudRecordingState;
+    liveStream?: LiveStreamState;
     localScreenshareStatus?: LocalScreenshareStatus;
     localParticipant?: LocalParticipantState;
+    notifications: NotificationMessage[];
     remoteParticipants: RemoteParticipantState[];
     screenshares: Screenshare[];
-    connectionStatus: ConnectionStatus;
-    liveStream?: LiveStreamState;
     waitingParticipants: WaitingParticipantState[];
 }
 

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import DisplayNameForm from "./DisplayNameForm";
 import { UseLocalMediaResult } from "../../lib/react/useLocalMedia/types";
 import { useRoomConnection } from "../../lib/react/useRoomConnection";
@@ -34,7 +34,8 @@ export default function VideoExperience({
         ...(Boolean(externalId) && { externalId }),
     });
 
-    const { localParticipant, remoteParticipants, connectionStatus, waitingParticipants, screenshares } = state;
+    const { localParticipant, remoteParticipants, connectionStatus, waitingParticipants, screenshares, notifications } =
+        state;
     const {
         knock,
         sendChatMessage,
@@ -54,6 +55,13 @@ export default function VideoExperience({
         stopScreenshare,
     } = actions;
     const { VideoView } = components;
+
+    const notificationsLog = useMemo(() => {
+        return notifications
+            .toReversed()
+            .map(({ timestamp, message, type }) => `${timestamp}: ${message} (${type})`)
+            .join("\n");
+    }, [notifications]);
 
     return (
         <div>
@@ -212,6 +220,14 @@ export default function VideoExperience({
                             Toggle screenshare
                         </button>
                         <DisplayNameForm initialDisplayName={displayName} onSetDisplayName={setDisplayName} />
+                    </div>
+                    <div className="notifications">
+                        Notifications log:
+                        <div>
+                            <textarea rows={10} cols={120}>
+                                {notificationsLog}
+                            </textarea>
+                        </div>
                     </div>
                 </>
             )}

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState } from "react";
 import DisplayNameForm from "./DisplayNameForm";
 import { UseLocalMediaResult } from "../../lib/react/useLocalMedia/types";
 import { useRoomConnection } from "../../lib/react/useRoomConnection";
@@ -21,9 +21,10 @@ export default function VideoExperience({
     hostOptions?: Array<string>;
 }) {
     const [chatMessage, setChatMessage] = useState("");
+    const [notifications, setNotifications] = useState<Array<string>>([]);
     const [isLocalScreenshareActive, setIsLocalScreenshareActive] = useState(false);
 
-    const { state, actions, components } = useRoomConnection(roomName, {
+    const { state, actions, components, events } = useRoomConnection(roomName, {
         localMediaOptions: {
             audio: true,
             video: true,
@@ -34,8 +35,7 @@ export default function VideoExperience({
         ...(Boolean(externalId) && { externalId }),
     });
 
-    const { localParticipant, remoteParticipants, connectionStatus, waitingParticipants, screenshares, notifications } =
-        state;
+    const { localParticipant, remoteParticipants, connectionStatus, waitingParticipants, screenshares } = state;
     const {
         knock,
         sendChatMessage,
@@ -55,13 +55,12 @@ export default function VideoExperience({
         stopScreenshare,
     } = actions;
     const { VideoView } = components;
+    const { onNotification } = events;
 
-    const notificationsLog = useMemo(() => {
-        return notifications
-            .toReversed()
-            .map(({ timestamp, message, type }) => `${timestamp}: ${message} (${type})`)
-            .join("\n");
-    }, [notifications]);
+    onNotification(({ timestamp, message, type }) => {
+        const localDate = new Date(timestamp).toLocaleString();
+        setNotifications([...notifications, `${localDate}: ${message} (${type})`]);
+    });
 
     return (
         <div>
@@ -224,9 +223,7 @@ export default function VideoExperience({
                     <div className="notifications">
                         Notifications log:
                         <div>
-                            <textarea rows={10} cols={120}>
-                                {notificationsLog}
-                            </textarea>
+                            <textarea rows={10} cols={120} value={notifications.join("\n")} readOnly />
                         </div>
                     </div>
                 </>

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -24,7 +24,7 @@ export default function VideoExperience({
     const [notifications, setNotifications] = useState<Array<string>>([]);
     const [isLocalScreenshareActive, setIsLocalScreenshareActive] = useState(false);
 
-    const { state, actions, components, events } = useRoomConnection(roomName, {
+    const { state, actions, components } = useRoomConnection(roomName, {
         localMediaOptions: {
             audio: true,
             video: true,
@@ -35,7 +35,7 @@ export default function VideoExperience({
         ...(Boolean(externalId) && { externalId }),
     });
 
-    const { localParticipant, remoteParticipants, connectionStatus, waitingParticipants, screenshares } = state;
+    const { localParticipant, remoteParticipants, connectionStatus, waitingParticipants, screenshares, events } = state;
     const {
         knock,
         sendChatMessage,
@@ -55,12 +55,13 @@ export default function VideoExperience({
         stopScreenshare,
     } = actions;
     const { VideoView } = components;
-    const { onNotification } = events;
 
-    onNotification(({ timestamp, message, type }) => {
-        const localDate = new Date(timestamp).toLocaleString();
-        setNotifications([...notifications, `${localDate}: ${message} (${type})`]);
-    });
+    ["debug", "log", "info", "warn", "error"].map((logLevel) =>
+        events?.on(logLevel, ({ timestamp, message, type }) => {
+            const localDate = new Date(timestamp).toLocaleString();
+            setNotifications([...notifications, `[${logLevel}] ${localDate}: ${message} (${type})`]);
+        }),
+    );
 
     return (
         <div>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     },
     "devDependencies": {
         "@types/btoa": "^1.2.3",
-        "@types/node": "^20.11.19",
+        "@types/node": "^20.12.8",
         "@types/uuid": "^9.0.7",
         "deep-object-diff": "^1.1.9",
         "dotenv": "^16.4.5",

--- a/packages/core/src/api/credentialsService/index.ts
+++ b/packages/core/src/api/credentialsService/index.ts
@@ -1,4 +1,4 @@
-import EventEmitter from "events";
+import { EventEmitter } from "events";
 
 import DeviceService from "../deviceService/index";
 import AbstractStore from "../modules/AbstractStore";

--- a/packages/core/src/redux/index.ts
+++ b/packages/core/src/redux/index.ts
@@ -11,6 +11,7 @@ export * from "./slices/deviceCredentials";
 export * from "./slices/localMedia";
 export * from "./slices/localParticipant";
 export * from "./slices/localScreenshare";
+export * from "./slices/notifications";
 export * from "./slices/organization";
 export * from "./slices/remoteParticipants";
 export * from "./slices/room";

--- a/packages/core/src/redux/slices/__tests__/notifications.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/notifications.unit.ts
@@ -1,7 +1,5 @@
 import {
     notificationsSlice,
-    doSetNotification,
-    NotificationEvent,
     NotificationMessage,
     NotificationsState,
     doClearNotifications,
@@ -10,25 +8,22 @@ import {
 
 describe("notificationsSlice", () => {
     describe("reducers", () => {
-        it("doSetNotification", () => {
-            const now = Date.now();
-            jest.spyOn(global.Date, "now").mockImplementationOnce(() => now);
-
-            const testNotification: NotificationEvent = {
+        it("addNotification", () => {
+            const testNotification: NotificationMessage = {
                 type: "micNotWorking",
                 message: "Problems with your microphone have been detected and it is not delivering input",
                 level: "error",
+                timestamp: Date.now(),
             };
 
             const result: NotificationsState = notificationsSlice.reducer(
                 initialNotificationsState,
-                doSetNotification({ ...testNotification }),
+                notificationsSlice.actions.addNotification({ ...testNotification }),
             );
 
             expect(result.messages).toEqual([
                 {
                     ...testNotification,
-                    timestamp: now,
                 },
             ]);
         });
@@ -43,6 +38,7 @@ describe("notificationsSlice", () => {
 
             const result: NotificationsState = notificationsSlice.reducer(
                 {
+                    ...initialNotificationsState,
                     messages: [testNotification, testNotification],
                 },
                 doClearNotifications(),

--- a/packages/core/src/redux/slices/__tests__/notifications.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/notifications.unit.ts
@@ -1,0 +1,54 @@
+import {
+    notificationsSlice,
+    doSetNotification,
+    NotificationEvent,
+    NotificationMessage,
+    NotificationsState,
+    doClearNotifications,
+    initialNotificationsState,
+} from "../notifications";
+
+describe("notificationsSlice", () => {
+    describe("reducers", () => {
+        it("doSetNotification", () => {
+            const now = Date.now();
+            jest.spyOn(global.Date, "now").mockImplementationOnce(() => now);
+
+            const testNotification: NotificationEvent = {
+                type: "micNotWorking",
+                message: "Problems with your microphone have been detected and it is not delivering input",
+                level: "error",
+            };
+
+            const result: NotificationsState = notificationsSlice.reducer(
+                initialNotificationsState,
+                doSetNotification({ ...testNotification }),
+            );
+
+            expect(result.messages).toEqual([
+                {
+                    ...testNotification,
+                    timestamp: now,
+                },
+            ]);
+        });
+
+        it("doClearNotifications", () => {
+            const testNotification: NotificationMessage = {
+                type: "micNotWorking",
+                message: "Problems with your microphone have been detected and it is not delivering input",
+                level: "error",
+                timestamp: Date.now(),
+            };
+
+            const result: NotificationsState = notificationsSlice.reducer(
+                {
+                    messages: [testNotification, testNotification],
+                },
+                doClearNotifications(),
+            );
+
+            expect(result.messages).toEqual(initialNotificationsState.messages);
+        });
+    });
+});

--- a/packages/core/src/redux/slices/__tests__/notifications.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/notifications.unit.ts
@@ -1,6 +1,6 @@
 import {
     notificationsSlice,
-    NotificationMessage,
+    NotificationEvent,
     NotificationsState,
     doClearNotifications,
     initialNotificationsState,
@@ -9,7 +9,7 @@ import {
 describe("notificationsSlice", () => {
     describe("reducers", () => {
         it("addNotification", () => {
-            const testNotification: NotificationMessage = {
+            const testNotification: NotificationEvent = {
                 type: "micNotWorking",
                 message: "Problems with your microphone have been detected and it is not delivering input",
                 level: "error",
@@ -21,7 +21,7 @@ describe("notificationsSlice", () => {
                 notificationsSlice.actions.addNotification({ ...testNotification }),
             );
 
-            expect(result.messages).toEqual([
+            expect(result.events).toEqual([
                 {
                     ...testNotification,
                 },
@@ -29,7 +29,7 @@ describe("notificationsSlice", () => {
         });
 
         it("doClearNotifications", () => {
-            const testNotification: NotificationMessage = {
+            const testNotification: NotificationEvent = {
                 type: "micNotWorking",
                 message: "Problems with your microphone have been detected and it is not delivering input",
                 level: "error",
@@ -39,12 +39,12 @@ describe("notificationsSlice", () => {
             const result: NotificationsState = notificationsSlice.reducer(
                 {
                     ...initialNotificationsState,
-                    messages: [testNotification, testNotification],
+                    events: [testNotification, testNotification],
                 },
                 doClearNotifications(),
             );
 
-            expect(result.messages).toEqual(initialNotificationsState.messages);
+            expect(result.events).toEqual(initialNotificationsState.events);
         });
     });
 });

--- a/packages/core/src/redux/slices/notifications.ts
+++ b/packages/core/src/redux/slices/notifications.ts
@@ -1,0 +1,66 @@
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+import { RootState } from "../store";
+
+export interface NotificationEvent {
+    type: string;
+    message: string;
+    level?: "debug" | "log" | "info" | "warn" | "error";
+    props?: {
+        [key: string]: unknown;
+    };
+}
+
+export interface NotificationMessage extends NotificationEvent {
+    level: "debug" | "log" | "info" | "warn" | "error";
+    timestamp: number;
+}
+
+/**
+ * Reducer
+ */
+
+export interface NotificationsState {
+    messages: NotificationMessage[];
+}
+
+export const initialNotificationsState: NotificationsState = {
+    messages: [],
+};
+
+export const notificationsSlice = createSlice({
+    name: "notifications",
+    initialState: initialNotificationsState,
+    reducers: {
+        doSetNotification: (state, action: PayloadAction<NotificationEvent>) => {
+            const notificationMessage: NotificationMessage = {
+                ...action.payload,
+                level: action.payload.level ?? "log",
+                timestamp: Date.now(),
+            };
+
+            return {
+                ...state,
+                messages: [...state.messages, notificationMessage],
+            };
+        },
+        doClearNotifications: (state) => {
+            return {
+                ...state,
+                messages: [],
+            };
+        },
+    },
+});
+
+/**
+ * Action creators
+ */
+
+export const { doSetNotification, doClearNotifications } = notificationsSlice.actions;
+
+/**
+ * Selectors
+ */
+
+export const selectNotificationsRaw = (state: RootState) => state.notifications;
+export const selectNotificationsMessages = (state: RootState) => state.notifications.messages;

--- a/packages/core/src/redux/slices/signalConnection/index.ts
+++ b/packages/core/src/redux/slices/signalConnection/index.ts
@@ -28,6 +28,8 @@ import {
 import { Credentials } from "../../../api";
 import { selectAppIsActive } from "../app";
 import { signalEvents } from "./actions";
+import { doSetNotification } from "../notifications";
+
 export { signalEvents } from "./actions";
 
 function forwardSocketEvents(socket: ServerSocket, dispatch: ThunkDispatch<RootState, unknown, UnknownAction>) {
@@ -279,5 +281,28 @@ startAppListening({
     actionCreator: signalEvents.clientKicked,
     effect: (_, { dispatch }) => {
         dispatch(doSignalDisconnect());
+    },
+});
+
+startAppListening({
+    predicate: (_action, currentState, previousState) => {
+        const oldSignalStatus = selectSignalStatus(previousState);
+        const signalStatus = selectSignalStatus(currentState);
+        return oldSignalStatus !== signalStatus;
+    },
+    effect: (_, { dispatch, getState }) => {
+        const state = getState();
+        const signalStatus = selectSignalStatus(state);
+
+        const notificationSignalEvents = ["connected", "disconnected", "reconnecting"];
+
+        if (notificationSignalEvents.includes(signalStatus)) {
+            dispatch(
+                doSetNotification({
+                    type: "networkConnection",
+                    message: `Network ${signalStatus}`,
+                }),
+            );
+        }
     },
 });

--- a/packages/core/src/redux/store.ts
+++ b/packages/core/src/redux/store.ts
@@ -45,7 +45,7 @@ const appReducer = combineReducers({
 });
 
 export const rootReducer: AppReducer = (state, action) => {
-    // Reset store state on app reset action
+    // Reset store state on app join action
     if (doAppStart.match(action)) {
         const resetState: Partial<RootState> = {
             app: {

--- a/packages/core/src/redux/store.ts
+++ b/packages/core/src/redux/store.ts
@@ -10,6 +10,7 @@ import { deviceCredentialsSlice } from "./slices/deviceCredentials";
 import { localMediaSlice } from "./slices/localMedia";
 import { localParticipantSlice } from "./slices/localParticipant";
 import { localScreenshareSlice } from "./slices/localScreenshare";
+import { notificationsSlice } from "./slices/notifications";
 import { organizationSlice } from "./slices/organization";
 import { remoteParticipantsSlice } from "./slices/remoteParticipants";
 import { roomSlice } from "./slices/room";
@@ -31,6 +32,7 @@ const appReducer = combineReducers({
     localMedia: localMediaSlice.reducer,
     localParticipant: localParticipantSlice.reducer,
     localScreenshare: localScreenshareSlice.reducer,
+    notifications: notificationsSlice.reducer,
     organization: organizationSlice.reducer,
     remoteParticipants: remoteParticipantsSlice.reducer,
     room: roomSlice.reducer,

--- a/packages/core/src/redux/tests/store/notifications.spec.ts
+++ b/packages/core/src/redux/tests/store/notifications.spec.ts
@@ -1,0 +1,44 @@
+import { createStore } from "../store.setup";
+import { NotificationEvent, doSetNotification } from "../../slices/notifications";
+import { diff } from "deep-object-diff";
+
+describe("actions", () => {
+    it("doSetNotification", async () => {
+        const now = Date.now();
+        jest.spyOn(global.Date, "now").mockImplementationOnce(() => now);
+
+        const testNotification: NotificationEvent = {
+            type: "micNotWorking",
+            message: "Problems with your microphone have been detected and it is not delivering input",
+        };
+
+        const notificationsCallback = jest.fn();
+
+        const store = createStore({
+            initialState: {
+                notifications: {
+                    messages: [],
+                    callback: notificationsCallback,
+                },
+            },
+        });
+
+        const before = store.getState().notifications;
+
+        store.dispatch(doSetNotification(testNotification));
+
+        const after = store.getState().notifications;
+
+        const expectedTestNotificationMessage = {
+            ...testNotification,
+            level: "log",
+            timestamp: now,
+        };
+
+        expect(notificationsCallback).toHaveBeenCalledWith(expectedTestNotificationMessage);
+
+        expect(diff(before, after)).toEqual({
+            messages: { 0: expectedTestNotificationMessage },
+        });
+    });
+});

--- a/packages/core/src/redux/tests/store/notifications.spec.ts
+++ b/packages/core/src/redux/tests/store/notifications.spec.ts
@@ -1,6 +1,7 @@
 import { createStore } from "../store.setup";
 import { NotificationEvent, doSetNotification } from "../../slices/notifications";
 import { diff } from "deep-object-diff";
+import { EventEmitter } from "events";
 
 describe("actions", () => {
     it("doSetNotification", async () => {
@@ -12,13 +13,14 @@ describe("actions", () => {
             message: "Problems with your microphone have been detected and it is not delivering input",
         };
 
-        const notificationsCallback = jest.fn();
+        const notificationsEmitter = new EventEmitter();
+        jest.spyOn(notificationsEmitter, "emit");
 
         const store = createStore({
             initialState: {
                 notifications: {
                     messages: [],
-                    callback: notificationsCallback,
+                    emitter: notificationsEmitter,
                 },
             },
         });
@@ -35,7 +37,10 @@ describe("actions", () => {
             timestamp: now,
         };
 
-        expect(notificationsCallback).toHaveBeenCalledWith(expectedTestNotificationMessage);
+        expect(notificationsEmitter.emit).toHaveBeenCalledWith(
+            expectedTestNotificationMessage.level,
+            expectedTestNotificationMessage,
+        );
 
         expect(diff(before, after)).toEqual({
             messages: { 0: expectedTestNotificationMessage },

--- a/packages/core/src/redux/tests/store/notifications.spec.ts
+++ b/packages/core/src/redux/tests/store/notifications.spec.ts
@@ -1,5 +1,5 @@
 import { createStore } from "../store.setup";
-import { NotificationEvent, doSetNotification } from "../../slices/notifications";
+import { Notification, NotificationsEventEmitter, doSetNotification } from "../../slices/notifications";
 import { diff } from "deep-object-diff";
 import { EventEmitter } from "events";
 
@@ -8,18 +8,18 @@ describe("actions", () => {
         const now = Date.now();
         jest.spyOn(global.Date, "now").mockImplementationOnce(() => now);
 
-        const testNotification: NotificationEvent = {
+        const testNotification: Notification = {
             type: "micNotWorking",
             message: "Problems with your microphone have been detected and it is not delivering input",
         };
 
-        const notificationsEmitter = new EventEmitter();
+        const notificationsEmitter: NotificationsEventEmitter = new EventEmitter();
         jest.spyOn(notificationsEmitter, "emit");
 
         const store = createStore({
             initialState: {
                 notifications: {
-                    messages: [],
+                    events: [],
                     emitter: notificationsEmitter,
                 },
             },
@@ -31,19 +31,19 @@ describe("actions", () => {
 
         const after = store.getState().notifications;
 
-        const expectedTestNotificationMessage = {
+        const expectedTestNotificationEvent = {
             ...testNotification,
             level: "log",
             timestamp: now,
         };
 
         expect(notificationsEmitter.emit).toHaveBeenCalledWith(
-            expectedTestNotificationMessage.level,
-            expectedTestNotificationMessage,
+            expectedTestNotificationEvent.level,
+            expectedTestNotificationEvent,
         );
 
         expect(diff(before, after)).toEqual({
-            messages: { 0: expectedTestNotificationMessage },
+            events: { 0: expectedTestNotificationEvent },
         });
     });
 });

--- a/packages/media/src/utils/ReconnectManager.ts
+++ b/packages/media/src/utils/ReconnectManager.ts
@@ -73,7 +73,7 @@ export class ReconnectManager extends EventEmitter {
         if (!this._signalDisconnectTime) {
             this._resetClientState(payload);
             payload.room.clients = payload.room.clients.filter(
-                (c: any) => !(c.deviceId === myDeviceId && c.isPendingToLeave)
+                (c: any) => !(c.deviceId === myDeviceId && c.isPendingToLeave),
             );
             this.emit(PROTOCOL_RESPONSES.ROOM_JOINED, payload);
             return;
@@ -93,7 +93,7 @@ export class ReconnectManager extends EventEmitter {
 
         // Filter out our own pending client after page reload
         payload.room.clients = payload.room.clients.filter(
-            (c: any) => !(c.deviceId === myDeviceId && c.isPendingToLeave)
+            (c: any) => !(c.deviceId === myDeviceId && c.isPendingToLeave),
         );
 
         const allStats = await getUpdatedStats();

--- a/packages/media/tests/webrtc/RtcManagerDispatcher.spec.ts
+++ b/packages/media/tests/webrtc/RtcManagerDispatcher.spec.ts
@@ -6,7 +6,7 @@ import * as mediasoupClient from "mediasoup-client";
 
 import { PROTOCOL_RESPONSES } from "../../src/model/protocol";
 import * as CONNECTION_STATUS from "../../src/model/connectionStatusConstants";
-import EventEmitter from "events";
+import { EventEmitter } from "events";
 import { v4 as uuidv4 } from "uuid";
 
 const originalMediasoupDevice = mediasoupClient.Device;
@@ -49,7 +49,7 @@ describe("RtcManagerDispatcher", () => {
         let emitted;
         emitter.on(
             CONNECTION_STATUS.EVENTS.RTC_MANAGER_CREATED,
-            ({ rtcManager }: { rtcManager: any }) => (emitted = rtcManager)
+            ({ rtcManager }: { rtcManager: any }) => (emitted = rtcManager),
         );
         serverSocketStub.emitFromServer(PROTOCOL_RESPONSES.ROOM_JOINED, {
             selfId,
@@ -90,7 +90,7 @@ describe("RtcManagerDispatcher", () => {
     it("replaces RTC manager when switching room mode", () => {
         const messages: any[] = [];
         emitter.on(CONNECTION_STATUS.EVENTS.RTC_MANAGER_CREATED, ({ rtcManager }: { rtcManager: any }) =>
-            messages.push({ create: rtcManager })
+            messages.push({ create: rtcManager }),
         );
         emitter.on(CONNECTION_STATUS.EVENTS.RTC_MANAGER_DESTROYED, () => messages.push({ destroy: true }));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4200,7 +4200,7 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.34.tgz#10964ba0dee6ac4cd462e2795b6bebd407303433"
   integrity sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==
 
-"@types/node@*", "@types/node@^20.11.19":
+"@types/node@*":
   version "20.11.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.19.tgz#b466de054e9cb5b3831bee38938de64ac7f81195"
   integrity sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==
@@ -4216,6 +4216,13 @@
   version "18.19.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.13.tgz#c3e989ca967b862a1f6c8c4148fe31865eedaf1a"
   integrity sha512-kgnbRDj8ioDyGxoiaXsiu1Ybm/K14ajCgMOkwiqpHrnF7d7QiYRoRqHIpglMMs3DwXinlK4qJ8TZGlj4hfleJg==
+  dependencies:
+    undici-types "~5.26.4"
+
+"@types/node@^20.12.8":
+  version "20.12.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.8.tgz#35897bf2bfe3469847ab04634636de09552e8256"
+  integrity sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==
   dependencies:
     undici-types "~5.26.4"
 


### PR DESCRIPTION
### Description

Add an events system to dispatch notification messages to the `state.events` object in the `useRoomConnection` hook that implements the standard [EventEmitter API](https://nodejs.org/dist/v11.13.0/docs/api/events.html#events_class_eventemitter).

### Testing

1. Run `yarn build && yarn dev`
2. Navigate to the "Room Connection Only" story (direct link when storybook is running is [here](http://localhost:6006/?path=/story/examples-custom-ui--room-connection-only)).
3. Observe the "Notifications Log" at the bottom of the UI
4. In the developer tools, toggle the Network connection from "No throttling" to "Offline"
5. After a couple of seconds, toggle the Network connection back from "Offline" to "No throttling"
6. The UI should re-connect to the call and a log of the `connected => disconnected => reconnecting => connected` flow should now be shown in the "Notifications Log" in the UI.

### Screenshots/GIFs (if applicable)

<img width="856" alt="Screenshot 2024-05-03 at 13 16 38" src="https://github.com/whereby/sdk/assets/119658286/c199f3aa-c9a5-401c-9179-6afb27deb241">

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
