### PR TITLE
core: Delay resetting the core redux store state until the next joinRoom() API request

### DIFF
--- a/.changeset/early-pugs-tan.md
+++ b/.changeset/early-pugs-tan.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/browser-sdk": patch
+"@whereby.com/core": patch
+---
+
+Delay resetting the store state until the next joinRoom() API request is called

--- a/apps/sample-app/src/App.tsx
+++ b/apps/sample-app/src/App.tsx
@@ -83,7 +83,15 @@ const Room = ({ roomUrl, localMedia, displayName, isHost }: RoomProps) => {
     if (connectionStatus === "ready") {
         return (
             <button data-testid="joinRoomBtn" onClick={() => joinRoom()}>
-                Re-join room
+                Join room
+            </button>
+        );
+    }
+
+    if (connectionStatus === "left" || connectionStatus === "kicked") {
+        return (
+            <button data-testid="rejoinRoomBtn" onClick={() => joinRoom()}>
+                Re-join {connectionStatus} room
             </button>
         );
     }

--- a/apps/sample-app/test/testsuites/connect.spec.ts
+++ b/apps/sample-app/test/testsuites/connect.spec.ts
@@ -21,13 +21,13 @@ test.describe("unlocked room", () => {
 
         await page.click('[data-testid="leaveRoomBtn"]');
         await expect(page.locator("dd[data-testid='connectionStatus']")).toContainText("leaving");
-        await expect(page.locator('[data-testid="joinRoomBtn"]')).toHaveCount(1);
+        await expect(page.locator('[data-testid="rejoinRoomBtn"]')).toHaveCount(1);
 
-        await page.click('[data-testid="joinRoomBtn"]');
+        await page.click('[data-testid="rejoinRoomBtn"]');
         await expect(page.locator("dd[data-testid='connectionStatus']")).toContainText("connected");
 
         await page.click('[data-testid="leaveRoomBtn"]');
         await expect(page.locator("dd[data-testid='connectionStatus']")).toContainText("leaving");
-        await expect(page.locator('[data-testid="joinRoomBtn"]')).toHaveCount(1);
+        await expect(page.locator('[data-testid="rejoinRoomBtn"]')).toHaveCount(1);
     });
 });

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -57,7 +57,6 @@ export default function VideoExperience({
 
     return (
         <div>
-            {connectionStatus === "ready" && <button onClick={() => joinRoom()}>Join room</button>}
             {connectionStatus === "connecting" && <span>Connecting...</span>}
             {connectionStatus === "room_locked" && (
                 <div style={{ color: "red" }}>
@@ -218,6 +217,9 @@ export default function VideoExperience({
             )}
             {connectionStatus === "leaving" && <span>Leaving...</span>}
             {connectionStatus === "disconnected" && <span>Disconnected</span>}
+            {["kicked", "left"].includes(connectionStatus) && (
+                <button onClick={() => joinRoom()}>Re-join {connectionStatus} room</button>
+            )}
         </div>
     );
 }

--- a/packages/core/src/redux/slices/__tests__/app.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/app.unit.ts
@@ -2,7 +2,7 @@ import { appSlice } from "../app";
 
 describe("appSlice", () => {
     describe("reducers", () => {
-        describe("doAppConfigure", () => {
+        describe("doAppStart", () => {
             it("should change the state", () => {
                 const initialConfig = {
                     isNodeSdk: true,
@@ -13,11 +13,10 @@ describe("appSlice", () => {
                     externalId: "externalId",
                 };
 
-                const result = appSlice.reducer(undefined, appSlice.actions.doAppConfigure(initialConfig));
+                const result = appSlice.reducer(undefined, appSlice.actions.doAppStart(initialConfig));
 
                 expect(result).toEqual({
-                    isLoaded: true,
-                    isActive: false,
+                    isActive: true,
                     roomName: "/roomName",
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",
@@ -38,11 +37,10 @@ describe("appSlice", () => {
                     externalId: "externalId",
                 };
 
-                const result = appSlice.reducer(undefined, appSlice.actions.doAppConfigure(initialConfig));
+                const result = appSlice.reducer(undefined, appSlice.actions.doAppStart(initialConfig));
 
                 expect(result).toEqual({
-                    isLoaded: true,
-                    isActive: false,
+                    isActive: true,
                     roomName: "/roomName",
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",

--- a/packages/core/src/redux/slices/__tests__/authorization.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/authorization.unit.ts
@@ -6,7 +6,7 @@ import {
     selectIsAuthorizedToRequestAudioEnable,
 } from "../authorization";
 import { signalEvents } from "../signalConnection/actions";
-import { doAppConfigure } from "../app";
+import { doAppStart } from "../app";
 
 describe("authorizationSlice", () => {
     describe("reducers", () => {
@@ -16,10 +16,10 @@ describe("authorizationSlice", () => {
             expect(result.roomKey).toEqual("roomKey");
         });
 
-        it("doAppConfigure", () => {
+        it("doAppStart", () => {
             const result = authorizationSlice.reducer(
                 undefined,
-                doAppConfigure({
+                doAppStart({
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",
                     displayName: "displayName",

--- a/packages/core/src/redux/slices/authorization.ts
+++ b/packages/core/src/redux/slices/authorization.ts
@@ -2,7 +2,7 @@ import { PayloadAction, createSelector, createSlice } from "@reduxjs/toolkit";
 import { RoleName } from "@whereby.com/media";
 import { RootState } from "../store";
 import { signalEvents } from "./signalConnection/actions";
-import { doAppConfigure } from "./app";
+import { doAppStart } from "./app";
 
 const ROOM_ACTION_PERMISSIONS_BY_ROLE: { [permissionKey: string]: Array<RoleName> } = {
     canLockRoom: ["host"],
@@ -37,7 +37,7 @@ export const authorizationSlice = createSlice({
         },
     },
     extraReducers: (builder) => {
-        builder.addCase(doAppConfigure, (state, action) => {
+        builder.addCase(doAppStart, (state, action) => {
             return {
                 ...state,
                 roomKey: action.payload.roomKey,

--- a/packages/core/src/redux/slices/localMedia.ts
+++ b/packages/core/src/redux/slices/localMedia.ts
@@ -3,7 +3,7 @@ import { getStream, getUpdatedDevices, getDeviceData } from "@whereby.com/media"
 import { createAppAsyncThunk, createAppThunk } from "../thunk";
 import { RootState } from "../store";
 import { createReactor, startAppListening } from "../listenerMiddleware";
-import { doAppConfigure, selectAppIsNodeSdk, selectAppIsActive } from "./app";
+import { doAppStart, selectAppIsNodeSdk, selectAppIsActive } from "./app";
 import { debounce } from "../../utils";
 import { signalEvents } from "./signalConnection/actions";
 
@@ -130,7 +130,7 @@ export const localMediaSlice = createSlice({
         },
     },
     extraReducers: (builder) => {
-        builder.addCase(doAppConfigure, (state, action) => {
+        builder.addCase(doAppStart, (state, action) => {
             return {
                 ...state,
                 options: action.payload.localMediaOptions,

--- a/packages/core/src/redux/slices/localParticipant.ts
+++ b/packages/core/src/redux/slices/localParticipant.ts
@@ -4,7 +4,7 @@ import { RootState } from "../store";
 import { createAppAsyncThunk } from "../thunk";
 import { LocalParticipant } from "../../RoomParticipant";
 import { selectSignalConnectionRaw } from "./signalConnection";
-import { doAppConfigure } from "./app";
+import { doAppStart } from "./app";
 import { toggleCameraEnabled, toggleMicrophoneEnabled } from "./localMedia";
 import { startAppListening } from "../listenerMiddleware";
 import { signalEvents } from "./signalConnection/actions";
@@ -78,7 +78,7 @@ export const localParticipantSlice = createSlice({
         },
     },
     extraReducers: (builder) => {
-        builder.addCase(doAppConfigure, (state, action) => {
+        builder.addCase(doAppStart, (state, action) => {
             return {
                 ...state,
                 displayName: action.payload.displayName,

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -91,6 +91,10 @@ export const roomConnectionSlice = createSlice({
             };
         });
         builder.addCase(signalEvents.disconnect, (state) => {
+            if (["kicked", "left"].includes(state.status)) {
+                return { ...state };
+            }
+
             return {
                 ...state,
                 status: "disconnected",

--- a/packages/core/src/redux/slices/signalConnection/index.ts
+++ b/packages/core/src/redux/slices/signalConnection/index.ts
@@ -3,7 +3,6 @@ import { RootState } from "../../store";
 import { createAppThunk } from "../../thunk";
 import { createReactor, startAppListening } from "../../listenerMiddleware";
 import { selectDeviceCredentialsRaw } from "../deviceCredentials";
-import { doAppReset } from "../app";
 
 import {
     AudioEnableRequestedEvent,
@@ -213,8 +212,6 @@ export const doSignalDisconnect = createAppThunk(() => (dispatch, getState) => {
 
         socket?.disconnect();
         dispatch(socketDisconnected());
-    } else {
-        doAppReset();
     }
 });
 
@@ -281,12 +278,5 @@ startAppListening({
     actionCreator: signalEvents.clientKicked,
     effect: (_, { dispatch }) => {
         dispatch(doSignalDisconnect());
-    },
-});
-
-startAppListening({
-    actionCreator: socketDisconnected,
-    effect: (_, { dispatch }) => {
-        dispatch(doAppReset());
     },
 });

--- a/packages/core/src/redux/store.ts
+++ b/packages/core/src/redux/store.ts
@@ -2,7 +2,7 @@ import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import { listenerMiddleware } from "./listenerMiddleware";
 import { createServices } from "../services";
 
-import { appSlice, doAppReset } from "./slices/app";
+import { appSlice, doAppStart } from "./slices/app";
 import { authorizationSlice } from "./slices/authorization";
 import { chatSlice } from "./slices/chat";
 import { cloudRecordingSlice } from "./slices/cloudRecording";
@@ -44,7 +44,7 @@ const appReducer = combineReducers({
 
 export const rootReducer: AppReducer = (state, action) => {
     // Reset store state on app reset action
-    if (doAppReset.match(action)) {
+    if (doAppStart.match(action)) {
         const resetState: Partial<RootState> = {
             app: {
                 ...appSlice.getInitialState(),

--- a/packages/core/src/redux/tests/store/signalConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/signalConnection.spec.ts
@@ -64,8 +64,7 @@ describe("signalConnectionSlice", () => {
             expect(mockServerSocket.disconnect).toHaveBeenCalled();
             expect(diff(before, after)).toEqual({
                 deviceIdentified: false,
-                status: "ready",
-                socket: null,
+                status: "disconnected",
             });
         });
     });


### PR DESCRIPTION
### Description

In https://github.com/whereby/sdk/pull/232, as part of adding the ability to re-join rooms, we added a mechanism to reset the core redux store state on signal disconnect. It would be better if we only cleared the core state if/when a subsequent `joinRoom()` API request is made.

This ensures that the exit state of the redux store can remain intact until it needs to be reset again to rejoin a room.
### Testing

1. Run `yarn build && yarn dev`
2. Open the "Room Connection only" storybook URL (direct link when storybook is running is [here](http://localhost:6006/?path=/story/examples-custom-ui--room-connection-only)).
3. Click "Leave Room" button
4. The UI should display a single button called "Re-join left room". Clicking on this button should rejoin the room successfully.
5. Reload the "Room Connection only" storybook URL (or simply re-join)
6. From another URL kick the SDK client out of the room
7. In the storybook tab a single button called "Re-join kicked room" should now be displayed. Clicking on this button should rejoin the room successfully.
8. In the Network tab of the developer console, switch from "No throttling" to "Offline".
9. The storybook UI should show the string "Disconnected"
10. Again in the Network tab of the developer console, switch back from "Offline" to "No throttling"
11. The room should be re-joined automatically.

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
