### PR TITLE
browser-sdk: Remove auto-join to room sessions when invoking useRoomConnection hook

### DIFF
--- a/.changeset/seven-crabs-know.md
+++ b/.changeset/seven-crabs-know.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": major
+---
+
+Breaking change: require call to joinRoom() before joining a room session

--- a/apps/sample-app/src/App.tsx
+++ b/apps/sample-app/src/App.tsx
@@ -73,6 +73,11 @@ const Room = ({ roomUrl, localMedia, displayName, isHost }: RoomProps) => {
     } = roomConnection.actions;
 
     useEffect(() => {
+        joinRoom();
+        return () => leaveRoom();
+    }, []);
+
+    useEffect(() => {
         setIsCameraEnabled(localParticipant?.isVideoEnabled || false);
     }, [localParticipant?.isVideoEnabled]);
 

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -45,14 +45,12 @@ export function useRoomConnection(
     const dispatch = useAppDispatch();
     const roomConnectionState = useAppSelector(selectRoomConnectionState);
 
-    const [roomConfig, setRoomConfig] = React.useState<AppConfig>();
-
-    React.useEffect(() => {
+    const roomConfig = React.useMemo((): AppConfig => {
         const url = new URL(roomUrl); // Throw if invalid Whereby room url
         const searchParams = new URLSearchParams(url.search);
         const roomKey = roomConnectionOptions.roomKey || searchParams.get("roomKey");
 
-        const roomConfig = {
+        return {
             displayName: roomConnectionOptions.displayName || "Guest",
             localMediaOptions: roomConnectionOptions.localMedia ? undefined : roomConnectionOptions.localMediaOptions,
             roomKey,
@@ -60,12 +58,9 @@ export function useRoomConnection(
             userAgent: `browser-sdk:${browserSdkVersion}`,
             externalId: roomConnectionOptions.externalId || null,
         };
+    }, [roomUrl, roomConnectionOptions]);
 
-        setRoomConfig(roomConfig);
-
-        // TODO: remove this in SDK v3. Require developers to call joinRoom() API explicitly instead.
-        dispatch(doAppStart(roomConfig));
-
+    React.useEffect(() => {
         return () => {
             dispatch(doAppStop());
         };
@@ -101,10 +96,7 @@ export function useRoomConnection(
     const startScreenshare = React.useCallback(() => dispatch(doStartScreenshare()), [dispatch]);
     const stopCloudRecording = React.useCallback(() => dispatch(doStopCloudRecording()), [dispatch]);
     const stopScreenshare = React.useCallback(() => dispatch(doStopScreenshare()), [dispatch]);
-    const joinRoom = React.useCallback(
-        () => (roomConfig ? dispatch(doAppStart(roomConfig)) : () => {}),
-        [dispatch, roomConfig],
-    );
+    const joinRoom = React.useCallback(() => dispatch(doAppStart(roomConfig)), [dispatch]);
     const leaveRoom = React.useCallback(() => dispatch(doAppStop()), [dispatch]);
     const lockRoom = React.useCallback((locked: boolean) => dispatch(doLockRoom({ locked })), [dispatch]);
     const muteParticipants = React.useCallback(

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import DisplayNameForm from "./DisplayNameForm";
 import { UseLocalMediaResult } from "../../lib/react/useLocalMedia/types";
 import { useRoomConnection } from "../../lib/react/useRoomConnection";
@@ -12,6 +12,7 @@ export default function VideoExperience({
     externalId,
     showHostControls,
     hostOptions,
+    joinRoomOnLoad,
 }: {
     displayName?: string;
     roomName: string;
@@ -20,6 +21,7 @@ export default function VideoExperience({
     externalId?: string;
     showHostControls?: boolean;
     hostOptions?: Array<string>;
+    joinRoomOnLoad?: boolean;
 }) {
     const [chatMessage, setChatMessage] = useState("");
     const [isLocalScreenshareActive, setIsLocalScreenshareActive] = useState(false);
@@ -55,8 +57,16 @@ export default function VideoExperience({
         stopScreenshare,
     } = actions;
 
+    useEffect(() => {
+        if (!joinRoomOnLoad) return;
+
+        joinRoom();
+        return () => leaveRoom();
+    }, []);
+
     return (
         <div>
+            {!joinRoomOnLoad && connectionStatus === "ready" && <button onClick={() => joinRoom()}>Join room</button>}
             {connectionStatus === "connecting" && <span>Connecting...</span>}
             {connectionStatus === "room_locked" && (
                 <div style={{ color: "red" }}>


### PR DESCRIPTION
### Description

**BREAKING CHANGE: v2 -> v3**

In browser-sdk version 3 we will stop auto-joining room sessions on invocation of the `useRoomConnection` hook itself. 

The primary motivation for this change, which will affect all users of version <= 2, is for developers to have control on when _billiable events_ (such as joining and leaving rooms and, therein, the consumption of billable participant minutes) occur in the lifecycle of their products.

In version 2, the room session would be joined automatically when creating the hook.

```javascript
/* browser-sdk version 2 */

// Joins room automatically on load
useRoomConnection(roomUrl, roomOptions);
```

In version 3, the room session will not be joined automatically when creating the hook. Instead we need to subsequently invoke the `actions.joinRoom` method to join a room session at the provided room URL.

```javascript
/* browser-sdk version 3 */

// Will not join the room automatically on load
const { actions } = useRoomConnection(roomUrl, roomOptions);

// Option 1: Re-create the auto-join/auto-leave behaviour from v2 when the component mounts
useEffect(() => {
  actions.joinRoom();
  return () => actions.leaveRoom();
}, []);

// Option 2: Call actions.joinRoom() at any time within the app, e.g. from a button click:
<button onClick={() => actions.joinRoom()}>Join room</button>
```

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
