### PR TITLE
core: Handle case when invalid characters are provided in display name

### DIFF
--- a/.changeset/witty-fans-knock.md
+++ b/.changeset/witty-fans-knock.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/media": patch
+"@whereby.com/core": patch
+---
+
+Handle case when invalid characters are provided in display name

--- a/packages/core/src/redux/slices/__tests__/remoteParticipants.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/remoteParticipants.unit.ts
@@ -153,6 +153,28 @@ describe("remoteParticipantsSlice", () => {
                     },
                 ]);
             });
+
+            it("should console.warn if a metadata error is returned", () => {
+                jest.spyOn(global.console, "warn");
+
+                const clientMetaDataError = "invalid_display_name";
+
+                const participant = randomRemoteParticipant();
+                const state = {
+                    remoteParticipants: [participant],
+                };
+
+                const result = remoteParticipantsSlice.reducer(
+                    state,
+                    signalEvents.clientMetadataReceived({
+                        error: clientMetaDataError,
+                    }),
+                );
+
+                expect(global.console.warn).toHaveBeenCalledWith(clientMetaDataError);
+
+                expect(result.remoteParticipants).toEqual([participant]);
+            });
         });
 
         describe("signalEvents.videoEnabled", () => {

--- a/packages/core/src/redux/slices/remoteParticipants.ts
+++ b/packages/core/src/redux/slices/remoteParticipants.ts
@@ -246,7 +246,14 @@ export const remoteParticipantsSlice = createSlice({
             });
         });
         builder.addCase(signalEvents.clientMetadataReceived, (state, action) => {
-            const { clientId, displayName } = action.payload.payload;
+            const { error, payload } = action.payload;
+
+            if (error || !payload) {
+                console.warn(error || "Client metadata error received");
+                return state;
+            }
+
+            const { clientId, displayName } = payload;
 
             return updateParticipant(state, clientId, {
                 displayName,

--- a/packages/media/src/utils/types.ts
+++ b/packages/media/src/utils/types.ts
@@ -162,8 +162,9 @@ export interface VideoEnabledEvent {
 }
 
 export interface ClientMetadataReceivedEvent {
-    type: string;
-    payload: { clientId: string; displayName: string };
+    error?: string;
+    type?: string;
+    payload?: { clientId: string; displayName: string };
 }
 
 export interface AudioEnableRequestedEvent {


### PR DESCRIPTION
### Description

When invalid characters are provided in the display name the change is rejected by the signal server. This PR gracefully handles errors returned when updating client metadata instead of throwing: `Cannot destructure property 'clientId' of 'action.payload.payload' as it is undefined.`.

### Testing

1. Check out `main` branch (to verify the problem first)
2. `yarn build && yarn dev`
3. Open the "Room Connection Only" story (direct link when storybook is running is [here](http://localhost:6006/?path=/story/examples-custom-ui--room-connection-only))
4. In the 'Display name' form field enter a value that includes one or more of the invalid characters for this field e.g. `$!<>:;`. Click "Save" button next to this form field.
5. An error will be displayed in the developer console: `Cannot destructure property 'clientId' of 'action.payload.payload' as it is undefined.` 
6. Check out this branch and re-run steps 2-4.
7. Error is handled gracefully and no error is shown on the console.


### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
