### PR TITLE
browser-sdk: Fix small grid UI bugs

### DIFF
--- a/.changeset/heavy-maps-pretend.md
+++ b/.changeset/heavy-maps-pretend.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": patch
+---
+
+Fix small grid UI bugs

--- a/packages/browser-sdk/src/lib/react/Grid/index.tsx
+++ b/packages/browser-sdk/src/lib/react/Grid/index.tsx
@@ -37,14 +37,14 @@ interface GridVideoCellViewProps {
     onSetClientAspectRatio: ({ aspectRatio, clientId }: { aspectRatio: number; clientId: string }) => void;
 }
 
-function GridVideoCellView({ aspectRatio, participant, render, onSetClientAspectRatio }: GridVideoCellViewProps) {
+function GridVideoCellView({ aspectRatio, participant, render }: GridVideoCellViewProps) {
     const videoEl = React.useRef<WherebyVideoElement>(null);
 
     const handleResize = React.useCallback(() => {
         const ar = videoEl.current && videoEl.current.captureAspectRatio();
 
         if (ar && ar !== aspectRatio && participant?.id) {
-            onSetClientAspectRatio({ aspectRatio: ar, clientId: participant.id });
+            // onSetClientAspectRatio({ aspectRatio: ar, clientId: participant.id });
         }
     }, []);
 
@@ -85,7 +85,7 @@ interface GridProps {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function Grid({ renderParticipant, stageParticipantLimit }: GridProps) {
+function Grid({ renderParticipant, stageParticipantLimit, videoGridGap }: GridProps) {
     const gridRef = React.useRef<HTMLDivElement>(null);
 
     const {
@@ -95,7 +95,7 @@ function Grid({ renderParticipant, stageParticipantLimit }: GridProps) {
         videoStage,
         setContainerBounds,
         setClientAspectRatios,
-    } = useGrid({ activeVideosSubgridTrigger: 12, stageParticipantLimit });
+    } = useGrid({ activeVideosSubgridTrigger: 12, stageParticipantLimit, videoGridGap });
 
     const presentationGridContent = React.useMemo(
         () =>

--- a/packages/browser-sdk/src/lib/react/Grid/useGrid.ts
+++ b/packages/browser-sdk/src/lib/react/Grid/useGrid.ts
@@ -10,12 +10,14 @@ interface Props {
     activeVideosSubgridTrigger?: number;
     forceSubgrid?: boolean;
     stageParticipantLimit?: number;
+    videoGridGap?: number;
 }
 
 function useGrid({
     activeVideosSubgridTrigger,
     forceSubgrid,
     stageParticipantLimit = STAGE_PARTICIPANT_LIMIT,
+    videoGridGap = 8,
 }: Props = {}) {
     const [containerBounds, setContainerBounds] = React.useState({ width: 0, height: 0 });
     const [clientAspectRatios, setClientAspectRatios] = React.useState<{ [key: string]: number }>({});
@@ -70,7 +72,7 @@ function useGrid({
             isConstrained: false,
             roomBounds: containerFrame.bounds,
             videos: cellViewsVideoGrid,
-            videoGridGap: 0,
+            videoGridGap,
             presentationVideos: cellViewsInPresentationGrid,
             subgridVideos: cellViewsInSubgrid,
         });

--- a/packages/browser-sdk/src/lib/react/Grid/useGridParticipants.ts
+++ b/packages/browser-sdk/src/lib/react/Grid/useGridParticipants.ts
@@ -90,8 +90,8 @@ function useGridParticipants({
     }, [allClientViews, clientViewsInSubgrid]);
 
     const clientViewsInPresentationGrid = React.useMemo(() => {
-        return allClientViews.filter((client) => client.isPresentation).concat(spotlightedParticipants);
-    }, [allClientViews, spotlightedParticipants]);
+        return spotlightedParticipants;
+    }, [spotlightedParticipants]);
 
     const clientViewsInGrid = React.useMemo(() => {
         return clientViewsOnStage.filter((client) => !clientViewsInPresentationGrid.includes(client));

--- a/packages/browser-sdk/src/stories/custom-ui.stories.tsx
+++ b/packages/browser-sdk/src/stories/custom-ui.stories.tsx
@@ -305,7 +305,7 @@ export const GridStory = ({ roomUrl }: { roomUrl: string; displayName?: string }
                 </button>
             </div>
             <div style={{ height: "500px", width: "100%" }}>
-                <VideoGrid videoGridGap={10} stageParticipantLimit={3} />
+                <VideoGrid videoGridGap={8} stageParticipantLimit={3} />
             </div>
         </>
     );


### PR DESCRIPTION
### Description
A couple of small things I think was lost during the rebase from development into main:

* Screenshares are showing twice
* Aspect ratio reporting is looping (so just disable it for now)
* VideoGridGap prop is not passed to the grid engine

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
