### PR TITLE
common: Add joinRoom/leaveRoom actions to all test apps

### DIFF
--- a/apps/quiz-app/src/views/Game/index.tsx
+++ b/apps/quiz-app/src/views/Game/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { Flex, Box } from "@chakra-ui/react";
 import { useRoomConnection } from "@whereby.com/browser-sdk/react";
 
@@ -24,8 +24,9 @@ const Game = ({ localMedia, displayName, roomUrl }: GameProps) => {
         displayName,
     });
 
-    const { state: roomState } = roomConnection;
+    const { state: roomState, actions: roomActions } = roomConnection;
     const { remoteParticipants, localParticipant } = roomState;
+    const { joinRoom, leaveRoom } = roomActions;
 
     const { state: quizState, actions: quizActions } = useQuizGame(roomConnection, { isQuizMaster });
 
@@ -69,6 +70,11 @@ const Game = ({ localMedia, displayName, roomUrl }: GameProps) => {
             break;
         default:
     }
+
+    useEffect(() => {
+        joinRoom();
+        return () => leaveRoom();
+    }, []);
 
     return (
         <Flex flexDirection="column" height="100%" gap={["4", null]}>

--- a/apps/telehealth-tutorial-app/src/App.tsx
+++ b/apps/telehealth-tutorial-app/src/App.tsx
@@ -22,7 +22,8 @@ function App() {
 
     const { state, actions } = roomConnection;
     const { localParticipant, remoteParticipants, screenshares, chatMessages } = state;
-    const { toggleCamera, toggleMicrophone, startScreenshare, stopScreenshare, sendChatMessage } = actions;
+    const { joinRoom, leaveRoom, toggleCamera, toggleMicrophone, startScreenshare, stopScreenshare, sendChatMessage } =
+        actions;
 
     function getDisplayName(id: string) {
         return remoteParticipants.find((p) => p.id === id)?.displayName || "Guest";
@@ -31,6 +32,11 @@ function App() {
     function scrollToBottom() {
         chatMessageBottomRef.current?.scrollIntoView({ behavior: "smooth" });
     }
+
+    React.useEffect(() => {
+        joinRoom();
+        return () => leaveRoom();
+    }, []);
 
     React.useEffect(() => {
         scrollToBottom();


### PR DESCRIPTION
### Description

In SDK v3 we now require apps to invoke `actions.joinRoom` after invoking the `useRoomConnection` hook.

We had a couple of test apps that were missing an update that called this action on mount. This PR ensures all the test apps continue to work in the same way as in version 2.

### Testing

1. Running the `telehealth-tutorial-app` test application (`cd apps/telehealth-tutorial-app && yarn dev`) should automatically connect to the configured room.
2. Running the `quiz-app` test application (`cd apps/quiz-app && yarn dev`) should automatically connect to the configured room.

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
