### PR TITLE
media: set cpu sample rate correctly

### DIFF
--- a/.changeset/mighty-tools-destroy.md
+++ b/.changeset/mighty-tools-destroy.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Refactor StatsMonitor to allow for unit testing

--- a/.changeset/spotty-cougars-divide.md
+++ b/.changeset/spotty-cougars-divide.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Add sampleInterval to cpu observer

--- a/packages/media/src/utils/__tests__/originTrial.spec.ts
+++ b/packages/media/src/utils/__tests__/originTrial.spec.ts
@@ -1,0 +1,101 @@
+import { registerOriginTrials } from "../originTrial";
+
+describe("registerOriginTrials", () => {
+    let document: any;
+    let token: string;
+
+    beforeEach(() => {
+        document = {
+            createElement: jest.fn(() => ({
+                httpEquiv: "",
+                content: "",
+            })),
+            head: {
+                append: jest.fn(),
+            },
+            location: {
+                hostname: "hostname.com",
+            },
+        };
+
+        token = "token";
+    });
+
+    it("should append meta tags for origin trials when location matches", () => {
+        registerOriginTrials(
+            [
+                {
+                    hostnamePattern: /hostname\.com/,
+                    token,
+                },
+            ],
+            {},
+            document as any,
+        );
+
+        expect(document.createElement).toHaveBeenCalledWith("meta");
+        expect(document.head.append).toHaveBeenCalledWith({ httpEquiv: "origin-trial", content: token });
+    });
+
+    it("should not append meta tags for origin trials when location does not match", () => {
+        registerOriginTrials(
+            [
+                {
+                    hostnamePattern: /host-name\.com/,
+                    token,
+                },
+            ],
+            {},
+            document as any,
+        );
+
+        expect(document.createElement).not.toHaveBeenCalledWith("meta");
+        expect(document.head.append).not.toHaveBeenCalledWith({ httpEquiv: "origin-trial", content: token });
+    });
+
+    it("should not append meta tags for origin trials if already registered", () => {
+        registerOriginTrials(
+            [
+                {
+                    hostnamePattern: /hostname\.com/,
+                    token,
+                },
+            ],
+            { [`${/hostname\.com/}-${token}`]: true },
+            document as any,
+        );
+
+        expect(document.createElement).not.toHaveBeenCalledWith("meta");
+        expect(document.head.append).not.toHaveBeenCalledWith({ httpEquiv: "origin-trial", content: token });
+    });
+
+    describe("when multiple origin trials are provided", () => {
+        it("should append meta tags for all origin trials when location matches unless already registered", () => {
+            registerOriginTrials(
+                [
+                    {
+                        hostnamePattern: /hostname\.com/,
+                        token: "token1",
+                    },
+                    {
+                        hostnamePattern: /hostname\.com/,
+                        token: "token2",
+                    },
+                    {
+                        hostnamePattern: /hostname\.com/,
+                        token: "token3",
+                    },
+                    {
+                        hostnamePattern: /host-name\.com/,
+                        token: "token4",
+                    },
+                ],
+                { [`${/hostname\.com/}-token1`]: true },
+                document as any,
+            );
+
+            expect(document.createElement).toHaveBeenCalledTimes(2);
+            expect(document.head.append).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/packages/media/src/utils/originTrial.ts
+++ b/packages/media/src/utils/originTrial.ts
@@ -1,0 +1,32 @@
+export interface OriginTrial {
+    hostnamePattern: RegExp;
+    token: string;
+}
+
+interface RegisteredTrials {
+    [hostnameAndToken: string]: true;
+}
+
+const REGISTERED_TRIALS: RegisteredTrials = {};
+
+export function registerOriginTrials(
+    trials: OriginTrial[],
+    registeredTrials: RegisteredTrials = REGISTERED_TRIALS,
+    document: Document = window.document,
+) {
+    trials.forEach(({ hostnamePattern, token }) => {
+        const key = `${hostnamePattern}-${token}`;
+        if (registeredTrials[key]) {
+            return;
+        }
+
+        if (hostnamePattern.test(document.location.hostname)) {
+            const otMeta = document.createElement("meta");
+            otMeta.httpEquiv = "origin-trial";
+            otMeta.content = token;
+            document.head.append(otMeta);
+
+            registeredTrials[key] = true;
+        }
+    });
+}

--- a/packages/media/src/webrtc/stats/StatsMonitor/__tests__/cpuObserver.spec.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/__tests__/cpuObserver.spec.ts
@@ -1,0 +1,62 @@
+import { startCpuObserver } from "../cpuObserver";
+import { OriginTrial, registerOriginTrials } from "../../../../utils/originTrial";
+
+jest.mock("../../../../utils/originTrial");
+
+describe("startCpuObserver", () => {
+    let cb: jest.Mock;
+    let originTrials: OriginTrial[];
+    let sampleRate: number;
+    let window: any;
+
+    beforeEach(() => {
+        cb = jest.fn();
+        originTrials = [{ hostnamePattern: /hostname\.com/, token: "token" }];
+        sampleRate = 1;
+        window = {};
+    });
+
+    it("should register origin trials", () => {
+        startCpuObserver(cb, { originTrials, sampleRate }, window);
+
+        expect(registerOriginTrials).toHaveBeenCalledWith(originTrials);
+    });
+
+    describe("when PressureObserver is not available", () => {
+        it("should return undefined", () => {
+            const result = startCpuObserver(cb, { originTrials, sampleRate }, window);
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe("when PressureObserver is available", () => {
+        let observe: jest.Mock;
+        let unobserve: jest.Mock;
+
+        beforeEach(() => {
+            observe = jest.fn();
+            unobserve = jest.fn();
+
+            window.PressureObserver = jest.fn(() => ({
+                observe,
+                unobserve,
+            }));
+        });
+
+        it("should observe cpu pressure", () => {
+            startCpuObserver(cb, { originTrials, sampleRate }, window);
+
+            expect(window.PressureObserver).toHaveBeenCalled();
+            expect(observe).toHaveBeenCalledWith("cpu");
+        });
+
+        it("should return stop function", () => {
+            const cpuObserver = startCpuObserver(cb, { originTrials, sampleRate }, window);
+
+            cpuObserver?.stop();
+
+            expect(unobserve).toHaveBeenCalledWith("cpu");
+        });
+    });
+});

--- a/packages/media/src/webrtc/stats/StatsMonitor/__tests__/cpuObserver.spec.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/__tests__/cpuObserver.spec.ts
@@ -48,7 +48,7 @@ describe("startCpuObserver", () => {
             startCpuObserver(cb, { originTrials, sampleRate }, window);
 
             expect(window.PressureObserver).toHaveBeenCalled();
-            expect(observe).toHaveBeenCalledWith("cpu");
+            expect(observe).toHaveBeenCalledWith("cpu", { sampleInterval: sampleRate * 1000 });
         });
 
         it("should return stop function", () => {

--- a/packages/media/src/webrtc/stats/StatsMonitor/__tests__/index.spec.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/__tests__/index.spec.ts
@@ -1,0 +1,96 @@
+import { StatsMonitorOptions, StatsMonitorState, subscribeStats } from "..";
+import { collectStats } from "../collectStats";
+import { startCpuObserver } from "../cpuObserver";
+
+jest.mock("../collectStats");
+jest.mock("../cpuObserver");
+
+jest.useFakeTimers();
+
+describe("subscribeStats", () => {
+    let options: StatsMonitorOptions;
+    let baseState: StatsMonitorState;
+
+    beforeEach(() => {
+        baseState = {
+            currentMonitor: null,
+            getClients: jest.fn(),
+            lastUpdateTime: 0,
+            statsByView: {},
+            subscriptions: [],
+        };
+        options = { interval: 2000, logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() } };
+    });
+
+    describe("with current monitor", () => {
+        let currentMonitor: StatsMonitorState["currentMonitor"];
+
+        beforeEach(() => {
+            currentMonitor = { getUpdatedStats: jest.fn(), stop: jest.fn() };
+        });
+
+        it("should store new subscription", () => {
+            const state = { ...baseState, currentMonitor };
+            const subscription = { onUpdatedStats: jest.fn() };
+
+            subscribeStats(subscription, options, state);
+
+            expect(state.subscriptions).toEqual([subscription]);
+        });
+
+        it("should return stop function which removes subscription", () => {
+            const state = { ...baseState, currentMonitor };
+            const subscription = { onUpdatedStats: jest.fn() };
+
+            subscribeStats(subscription, options, state).stop();
+
+            expect(state.subscriptions).toEqual([]);
+            expect(currentMonitor?.stop).toHaveBeenCalled();
+            expect(state.currentMonitor).toBeNull();
+        });
+    });
+
+    describe("when no current monitor exists", () => {
+        it("should start cpu observer", () => {
+            const state = { ...baseState };
+            const subscription = { onUpdatedStats: jest.fn() };
+
+            subscribeStats(subscription, options, state);
+
+            expect(startCpuObserver).toHaveBeenCalled();
+        });
+
+        it("should schedule stats collection", () => {
+            const state = { ...baseState };
+            const subscription = { onUpdatedStats: jest.fn() };
+
+            subscribeStats(subscription, options, state);
+            jest.advanceTimersByTime(options.interval);
+
+            expect(collectStats).toHaveBeenCalled();
+        });
+
+        it("should set monitor with getUpdatedStats and stop functions", () => {
+            const state = { ...baseState, currentMonitor: null };
+            const subscription = { onUpdatedStats: jest.fn() };
+
+            subscribeStats(subscription, options, state);
+
+            expect(state.currentMonitor).toMatchObject({
+                getUpdatedStats: expect.any(Function),
+                stop: expect.any(Function),
+            });
+        });
+
+        it("should stop cpu monitor on stop", () => {
+            const state = { ...baseState, currentMonitor: null };
+            const stop = jest.fn();
+            (startCpuObserver as jest.Mock).mockReturnValueOnce({ stop });
+            const subscription = { onUpdatedStats: jest.fn() };
+
+            subscribeStats(subscription, options, state).stop();
+
+            expect(stop).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/media/src/webrtc/stats/StatsMonitor/collectStats.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/collectStats.ts
@@ -1,0 +1,247 @@
+import { StatsMonitorOptions, StatsMonitorState } from ".";
+import {
+    captureSsrcInfo,
+    captureCommonSsrcMetrics,
+    captureVideoSsrcMetrics,
+    captureAudioSsrcMetrics,
+    captureCandidatePairInfoMetrics,
+} from "./metrics";
+import { getPeerConnectionsWithStatsReports } from "./peerConnection";
+import { getPeerConnectionIndex, removePeerConnection } from "./peerConnectionTracker";
+
+const getOrCreateSsrcMetricsContainer = (
+    statsByView: any,
+    time: number,
+    pcIndex: any,
+    clientId: string,
+    trackId: any,
+    ssrc: any,
+) => {
+    let viewStats = statsByView[clientId];
+    if (!viewStats) {
+        viewStats = { tracks: {}, startTime: time, updated: time };
+        statsByView[clientId] = viewStats;
+    }
+    viewStats.updated = time;
+    let trackStats = viewStats.tracks[trackId];
+    if (!trackStats) {
+        trackStats = { ssrcs: {}, startTime: time, updated: time };
+        viewStats.tracks[trackId] = trackStats;
+    }
+    trackStats.updated = time;
+    let ssrcStats = trackStats.ssrcs[ssrc];
+    if (!ssrcStats) {
+        ssrcStats = {
+            startTime: time,
+            updated: time,
+            pcIndex,
+        };
+        trackStats.ssrcs[ssrc] = ssrcStats;
+    }
+    ssrcStats.updated = time;
+    return ssrcStats;
+};
+
+const removeNonUpdatedStats = (statsByView: any, time: number) => {
+    Object.entries(statsByView).forEach(([viewId, viewStats]: any) => {
+        if (viewStats.updated < time) {
+            delete statsByView[viewId];
+        } else {
+            Object.entries(viewStats.tracks).forEach(([trackId, trackStats]: any) => {
+                if (trackStats.updated < time) {
+                    delete viewStats.tracks[trackId];
+                } else {
+                    Object.entries(trackStats.ssrcs).forEach(([ssrc, ssrcStats]: any) => {
+                        if (ssrcStats.updated < time) {
+                            delete trackStats.ssrcs[ssrc];
+                        }
+                    });
+                }
+            });
+        }
+    });
+};
+
+export async function collectStats(
+    state: StatsMonitorState,
+    { logger, interval }: StatsMonitorOptions,
+    immediate: any,
+) {
+    const collectStatsBound = collectStats.bind(null, state, { interval, logger });
+
+    try {
+        // refresh provided clients before each run
+        const clients = state.getClients();
+        // general stats, and stats that cannot be matched to any client will be added to "selfview" / unknown
+        const defaultClient = clients.find((c: any) => c.isLocalClient && !c.isPresentation) || { id: "unknown" };
+
+        // default stats need to be initialized
+        let defaultViewStats = state.statsByView[defaultClient.id];
+        if (!defaultViewStats) {
+            defaultViewStats = { tracks: {}, candidatePairs: {}, pressure: null };
+            state.statsByView[defaultClient.id] = defaultViewStats;
+        }
+
+        // set pressure to last record received
+        defaultViewStats.pressure = state.lastPressureObserverRecord;
+
+        // throttle calls to ensure we get a diff from previous stats
+        const timeSinceLastUpdate = Date.now() - state.lastUpdateTime;
+        if (timeSinceLastUpdate < 400) {
+            if (immediate) return state.statsByView;
+            state.subscriptions.forEach((subscription: any) =>
+                subscription.onUpdatedStats?.(state.statsByView, clients),
+            );
+            state.nextTimeout = setTimeout(collectStatsBound, interval);
+            return;
+        }
+
+        // keep track of what has been updated this run
+        state.lastUpdateTime = Date.now();
+
+        // loop through current peer connections
+        (await getPeerConnectionsWithStatsReports()).forEach(([pc, report, pcData]) => {
+            // each new peer connection will get +1, to be able to see/count/correlate data
+            const pcIndex = getPeerConnectionIndex(pc);
+
+            // for some reason, the close event isn't called always, so we clean up manually
+            if (pc.connectionState === "closed") {
+                report = new Map();
+                removePeerConnection(pc);
+            }
+
+            // keep track of visited ssrcs for cleanup later
+            pcData.previousSSRCs = pcData.currentSSRCs || {};
+            pcData.currentSSRCs = {};
+
+            // loop though each stats dictionary in report
+            report.forEach((currentRtcStats: any) => {
+                if (currentRtcStats.type === "candidate-pair" && /inprogress|succeeded/.test(currentRtcStats.state)) {
+                    const prevRtcStats = pcData._oldReport?.get(currentRtcStats.id);
+                    const timeDiff = prevRtcStats ? currentRtcStats.timestamp - prevRtcStats.timestamp : interval;
+
+                    const cpId = pcIndex + ":" + currentRtcStats.id;
+                    let cpMetrics = defaultViewStats.candidatePairs[cpId];
+                    if (!cpMetrics) {
+                        cpMetrics = { startTime: state.lastUpdateTime, id: cpId };
+                        defaultViewStats.candidatePairs[cpId] = cpMetrics;
+                    }
+                    captureCandidatePairInfoMetrics(cpMetrics, currentRtcStats, prevRtcStats, timeDiff, report);
+                    cpMetrics.lastRtcStatsTime = state.lastUpdateTime;
+                }
+
+                if (currentRtcStats.type === "inbound-rtp" || currentRtcStats.type === "outbound-rtp") {
+                    const kind = currentRtcStats.mediaType || currentRtcStats.kind;
+                    const ssrc = currentRtcStats.ssrc;
+
+                    let trackId = currentRtcStats.trackIdentifier || pcData.ssrcToTrackId[ssrc];
+
+                    let prevRtcStats = pcData._oldReport?.get(currentRtcStats.id);
+
+                    // update trackId if mediasource changes
+                    if (prevRtcStats && prevRtcStats.mediaSourceId !== currentRtcStats.mediaSourceId) {
+                        const mediaSourceStats = report.get(currentRtcStats.mediaSourceId);
+                        if (mediaSourceStats && mediaSourceStats.trackIdentifier) {
+                            trackId = mediaSourceStats.trackIdentifier;
+                            pcData.ssrcToTrackId[ssrc] = trackId;
+                        }
+                    }
+
+                    // find the current client using this trackId, or default
+                    const client = clients.find((c: any) => c[kind].track?.id === trackId) || defaultClient;
+
+                    pcData.currentSSRCs[ssrc] = client.id;
+                    // we need to stats reset when selected candidate pair changes
+                    // todo: metrics should += diff, not use count directly
+                    if (prevRtcStats) {
+                        const newTransport = report.get(currentRtcStats.transportId);
+                        const oldTransport = pcData._oldReport.get(prevRtcStats.transportId);
+                        if (
+                            oldTransport &&
+                            newTransport?.selectedCandidatePairId !== oldTransport.selectedCandidatePairId
+                        ) {
+                            // new candidate-pair, rtp stats will reset
+                            prevRtcStats = null;
+                        } else if (
+                            currentRtcStats.bytesReceived < prevRtcStats.bytesReceived ||
+                            currentRtcStats.bytesSent < prevRtcStats.bytesSent
+                        ) {
+                            // appears rts stats has reset
+                            prevRtcStats = null;
+                        }
+                    }
+
+                    const timeDiff = prevRtcStats ? currentRtcStats.timestamp - prevRtcStats.timestamp : interval;
+                    const ssrcMetrics = getOrCreateSsrcMetricsContainer(
+                        state.statsByView,
+                        state.lastUpdateTime,
+                        pcIndex,
+                        client.id,
+                        trackId,
+                        ssrc,
+                    );
+
+                    // capture tracks/ssrc info/metrics
+                    captureSsrcInfo(ssrcMetrics, currentRtcStats, prevRtcStats, timeDiff, report);
+                    captureCommonSsrcMetrics(ssrcMetrics, currentRtcStats, prevRtcStats, timeDiff, report);
+                    if (kind === "video") {
+                        captureVideoSsrcMetrics(ssrcMetrics, currentRtcStats, prevRtcStats, timeDiff, report);
+                    }
+                    if (kind === "audio") {
+                        captureAudioSsrcMetrics(ssrcMetrics, currentRtcStats, prevRtcStats, timeDiff, report);
+                    }
+                }
+            });
+
+            pcData._oldReport = report;
+
+            // clean up old stats/metrics
+            Object.keys(pcData.previousSSRCs)
+                .filter((ssrc) => !pcData.currentSSRCs[ssrc])
+                .forEach((ssrc) => {
+                    const clientId = pcData.previousSSRCs[ssrc];
+                    if (clientId) {
+                        // remove
+                        const clientView = state.statsByView[clientId];
+                        if (clientView) {
+                            Object.values(clientView.tracks).forEach((trackStats: any) => {
+                                if (trackStats.ssrcs[ssrc]) {
+                                    delete trackStats.ssrcs[ssrc];
+                                }
+                            });
+                        }
+                    }
+                });
+        });
+
+        removeNonUpdatedStats(state.statsByView, state.lastUpdateTime);
+
+        // mark candidatepairs as active/inactive
+        Object.entries(defaultViewStats.candidatePairs).forEach(([cpKey, cp]: any) => {
+            const active = cp.lastRtcStatsTime === state.lastUpdateTime;
+            cp.active = active;
+            if (!active) {
+                cp.state = "old/inactive";
+                if (!cp.inactiveFromTime) cp.inactiveFromTime = state.lastUpdateTime;
+                else {
+                    // delete candidate pair after a few secs
+                    if (state.lastUpdateTime - cp.inactiveFromTime > 4000) {
+                        delete defaultViewStats.candidatePairs[cpKey];
+                    }
+                }
+            }
+        });
+
+        if (immediate) {
+            return state.statsByView;
+        } else {
+            state.subscriptions.forEach((subscription: any) =>
+                subscription.onUpdatedStats?.(state.statsByView, clients),
+            );
+        }
+    } catch (ex) {
+        logger.warn(ex);
+    }
+
+    state.nextTimeout = setTimeout(collectStatsBound, interval);
+}

--- a/packages/media/src/webrtc/stats/StatsMonitor/cpuObserver.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/cpuObserver.ts
@@ -1,6 +1,7 @@
 import { OriginTrial, registerOriginTrials } from "../../../utils/originTrial";
 
 interface CpuObserverOptions {
+    /** Sample rate, in seconds */
     sampleRate: number;
     originTrials: OriginTrial[];
 }
@@ -31,7 +32,7 @@ export function startCpuObserver(
 
     if ("PressureObserver" in window) {
         pressureObserver = new (window.PressureObserver as any)(cb, { sampleRate });
-        pressureObserver.observe("cpu");
+        pressureObserver.observe("cpu", { sampleInterval: sampleRate * 1000 });
 
         return {
             stop: () => {

--- a/packages/media/src/webrtc/stats/StatsMonitor/cpuObserver.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/cpuObserver.ts
@@ -1,0 +1,42 @@
+import { OriginTrial, registerOriginTrials } from "../../../utils/originTrial";
+
+interface CpuObserverOptions {
+    sampleRate: number;
+    originTrials: OriginTrial[];
+}
+
+const CPU_OBSERVER_OPTIONS: CpuObserverOptions = {
+    sampleRate: 1,
+    // these tokens expire May 29th 2024
+    originTrials: [
+        {
+            hostnamePattern: /hereby\.dev/,
+            token: "AkSNPHJw6EK08X0QU7kORnK9NABzRLAC7dqfXOwk5JwFAQG4Ey7WxLXxsnhieCgC1QHUdevE2EFICy7uBGDANwUAAABqeyJvcmlnaW4iOiJodHRwczovL2hlcmVieS5kZXY6NDQ0MyIsImZlYXR1cmUiOiJDb21wdXRlUHJlc3N1cmVfdjIiLCJleHBpcnkiOjE3MTY5NDA3OTksImlzU3ViZG9tYWluIjp0cnVlfQ==",
+        },
+        {
+            hostnamePattern: /whereby\.com/,
+            token: "Asc2wu8KpSx648i932NICteQDFcB05yl2QUUSHD7AQo8JGP2Fp6FF91TvYVJBsKGzLMH349rysPw5q9tqPC/PAUAAABqeyJvcmlnaW4iOiJodHRwczovL3doZXJlYnkuY29tOjQ0MyIsImZlYXR1cmUiOiJDb21wdXRlUHJlc3N1cmVfdjIiLCJleHBpcnkiOjE3MTY5NDA3OTksImlzU3ViZG9tYWluIjp0cnVlfQ==",
+        },
+    ],
+};
+
+export function startCpuObserver(
+    cb: (records: any) => void,
+    { sampleRate, originTrials }: CpuObserverOptions = CPU_OBSERVER_OPTIONS,
+    window: Window = globalThis.window,
+) {
+    registerOriginTrials(originTrials);
+
+    let pressureObserver: any;
+
+    if ("PressureObserver" in window) {
+        pressureObserver = new (window.PressureObserver as any)(cb, { sampleRate });
+        pressureObserver.observe("cpu");
+
+        return {
+            stop: () => {
+                pressureObserver.unobserve("cpu");
+            },
+        };
+    }
+}

--- a/packages/media/src/webrtc/stats/StatsMonitor/index.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/index.ts
@@ -1,402 +1,94 @@
-import { getCurrentPeerConnections, getPeerConnectionIndex, removePeerConnection } from "./peerConnectionTracker";
-import {
-    captureSsrcInfo,
-    captureCommonSsrcMetrics,
-    captureVideoSsrcMetrics,
-    captureAudioSsrcMetrics,
-    captureCandidatePairInfoMetrics,
-} from "./metrics";
 import Logger from "../../../utils/Logger";
+import { collectStats } from "./collectStats";
+import { startCpuObserver } from "./cpuObserver";
 
-const logger = new Logger();
-
-const STATS_INTERVAL = 2000;
-
-let getClients = () => [];
-export const setClientProvider = (provider: any) => (getClients = provider);
-
-const statsByView: any = {};
-export const getStats = () => {
-    return { ...statsByView };
-};
-
-let subscriptions: any = [];
-let currentMonitor: any = null;
-
-export const getUpdatedStats = () => currentMonitor?.getUpdatedStats();
-
-const getOrCreateSsrcMetricsContainer = (time: number, pcIndex: any, clientId: string, trackId: any, ssrc: any) => {
-    let viewStats = statsByView[clientId];
-    if (!viewStats) {
-        viewStats = { tracks: {}, startTime: time, updated: time };
-        statsByView[clientId] = viewStats;
-    }
-    viewStats.updated = time;
-    let trackStats = viewStats.tracks[trackId];
-    if (!trackStats) {
-        trackStats = { ssrcs: {}, startTime: time, updated: time };
-        viewStats.tracks[trackId] = trackStats;
-    }
-    trackStats.updated = time;
-    let ssrcStats = trackStats.ssrcs[ssrc];
-    if (!ssrcStats) {
-        ssrcStats = {
-            startTime: time,
-            updated: time,
-            pcIndex,
-        };
-        trackStats.ssrcs[ssrc] = ssrcStats;
-    }
-    ssrcStats.updated = time;
-    return ssrcStats;
-};
-
-const removeNonUpdatedStats = (time: number) => {
-    Object.entries(statsByView).forEach(([viewId, viewStats]: any) => {
-        if (viewStats.updated < time) {
-            delete statsByView[viewId];
-        } else {
-            Object.entries(viewStats.tracks).forEach(([trackId, trackStats]: any) => {
-                if (trackStats.updated < time) {
-                    delete viewStats.tracks[trackId];
-                } else {
-                    Object.entries(trackStats.ssrcs).forEach(([ssrc, ssrcStats]: any) => {
-                        if (ssrcStats.updated < time) {
-                            delete trackStats.ssrcs[ssrc];
-                        }
-                    });
-                }
-            });
-        }
-    });
-};
-
-// peer connection related data
-const pcDataByPc = new WeakMap();
-
-const getPeerConnectionsWithStatsReports = () =>
-    Promise.all(
-        getCurrentPeerConnections().map(async (pc: any) => {
-            let pcData = pcDataByPc.get(pc);
-            if (!pcData) {
-                pcData = { ssrcToTrackId: {} };
-                pcDataByPc.set(pc, pcData);
-            }
-
-            try {
-                const report = await pc.getStats();
-
-                let missingSsrcs: any = null;
-
-                report.forEach((stats: any) => {
-                    if (stats.type === "inbound-rtp" || stats.type === "outbound-rtp") {
-                        if (!stats.trackIdentifier && !pcData.ssrcToTrackId[stats.ssrc]) {
-                            // try to lookup by media-source
-                            if (stats.mediaSourceId) {
-                                const mediaSourceStats = report.get(stats.mediaSourceId);
-                                if (mediaSourceStats) {
-                                    if (mediaSourceStats.trackIdentifier) {
-                                        pcData.ssrcToTrackId[stats.ssrc] = mediaSourceStats.trackIdentifier;
-                                    }
-                                }
-                            }
-
-                            // try to lookup by deprecated stats
-                            if (!pcData.ssrcToTrackId[stats.ssrc] && stats.trackId) {
-                                const deprecatedTrackStats = report.get(stats.trackId);
-                                if (deprecatedTrackStats) {
-                                    if (deprecatedTrackStats.trackIdentifier) {
-                                        pcData.ssrcToTrackId[stats.ssrc] = deprecatedTrackStats.trackIdentifier;
-                                    }
-                                }
-                            }
-                            if (!pcData.ssrcToTrackId[stats.ssrc]) {
-                                // we need to lookup this ssrc by separate getStats calls
-                                if (!missingSsrcs) missingSsrcs = [];
-                                missingSsrcs.push(stats.ssrc);
-                            }
-                        }
-                    }
-                });
-
-                if (missingSsrcs) {
-                    // call getStats() on all senders and receivers to map missing ssrcs
-                    const sendersAndReceivers = [...pc.getSenders(), ...pc.getReceivers()];
-                    const reports = await Promise.all(sendersAndReceivers.map((o) => o.getStats()));
-                    reports.forEach((tReport, index) => {
-                        tReport.forEach((stats: any) => {
-                            if (stats.type === "inbound-rtp" || stats.type === "outbound-rtp") {
-                                pcData.ssrcToTrackId[stats.ssrc] = sendersAndReceivers[index].track.id;
-                            }
-                        });
-                    });
-
-                    // create fake track ids for anything not found
-                    missingSsrcs.forEach((ssrc: any) => {
-                        if (!pcData.ssrcToTrackId[ssrc]) {
-                            pcData.ssrcToTrackId[ssrc] = "?" + ssrc;
-                        }
-                    });
-                }
-                return [pc, report, pcData];
-            } catch (ex) {
-                return [pc, [], pcData];
-            }
-        })
-    );
-
-let originTrialActivated = false;
-function activateComputePressureOriginTrial() {
-    if (originTrialActivated) return;
-
-    const otMeta = document.createElement("meta");
-    otMeta.httpEquiv = "origin-trial";
-
-    // these tokens expire May 29th 2024
-    if (/hereby\.dev/.test(document.location.hostname)) {
-        // *.hereby.dev
-        otMeta.content =
-            "AkSNPHJw6EK08X0QU7kORnK9NABzRLAC7dqfXOwk5JwFAQG4Ey7WxLXxsnhieCgC1QHUdevE2EFICy7uBGDANwUAAABqeyJvcmlnaW4iOiJodHRwczovL2hlcmVieS5kZXY6NDQ0MyIsImZlYXR1cmUiOiJDb21wdXRlUHJlc3N1cmVfdjIiLCJleHBpcnkiOjE3MTY5NDA3OTksImlzU3ViZG9tYWluIjp0cnVlfQ==";
-    } else {
-        // *.whereby.com
-        otMeta.content =
-            "Asc2wu8KpSx648i932NICteQDFcB05yl2QUUSHD7AQo8JGP2Fp6FF91TvYVJBsKGzLMH349rysPw5q9tqPC/PAUAAABqeyJvcmlnaW4iOiJodHRwczovL3doZXJlYnkuY29tOjQ0MyIsImZlYXR1cmUiOiJDb21wdXRlUHJlc3N1cmVfdjIiLCJleHBpcnkiOjE3MTY5NDA3OTksImlzU3ViZG9tYWluIjp0cnVlfQ==";
-    }
-    document.head.append(otMeta);
-    originTrialActivated = true;
+interface StatsMonitor {
+    getUpdatedStats: () => any;
+    stop: () => void;
 }
 
-function startStatsMonitor({ interval }: { interval?: any }) {
-    let nextTimeout: any = 0;
+interface StatsSubscription {
+    onUpdatedStats: (statsByView: any, clients: any) => void;
+}
+export interface StatsMonitorState {
+    currentMonitor: StatsMonitor | null;
+    getClients: () => any[];
+    lastPressureObserverRecord?: any;
+    lastUpdateTime: number;
+    nextTimeout?: NodeJS.Timeout;
+    pressureObserver?: any;
+    statsByView: any;
+    subscriptions: StatsSubscription[];
+}
 
-    activateComputePressureOriginTrial();
+export interface StatsMonitorOptions {
+    interval: number;
+    logger: Pick<Logger, "debug" | "error" | "info" | "warn">;
+}
 
-    let pressureObserver: any;
-    let lastPressureObserverRecord: any;
+const STATE: StatsMonitorState = {
+    currentMonitor: null,
+    getClients: () => [],
+    lastUpdateTime: 0,
+    statsByView: {},
+    subscriptions: [],
+};
+
+const OPTIONS: StatsMonitorOptions = {
+    interval: 2000,
+    logger: new Logger(),
+};
+
+export const getStats = () => {
+    return { ...STATE.statsByView };
+};
+
+export const getUpdatedStats = () => STATE.currentMonitor?.getUpdatedStats();
+
+export const setClientProvider = (provider: any) => (STATE.getClients = provider);
+
+function startStatsMonitor(state: StatsMonitorState, { interval, logger }: StatsMonitorOptions) {
+    const collectStatsBound = collectStats.bind(null, state, { interval, logger });
+
+    let cpuObserver: any;
 
     try {
-        if ("PressureObserver" in window) {
-            pressureObserver = new (window.PressureObserver as any)(
-                (records: any) => (lastPressureObserverRecord = records.pop()),
-                {
-                    sampleRate: 1,
-                }
-            );
-            pressureObserver.observe("cpu");
-        }
+        cpuObserver = startCpuObserver((records: any) => (state.lastPressureObserverRecord = records.pop()));
     } catch (ex) {
         logger.warn("Failed to observe CPU pressure", ex);
     }
 
-    let lastUpdateTime = 0;
-
-    const collectStats = async (immediate: any) => {
-        try {
-            // refresh provided clients before each run
-            const clients = getClients();
-            // general stats, and stats that cannot be matched to any client will be added to "selfview" / unknown
-            const defaultClient = clients.find((c: any) => c.isLocalClient && !c.isPresentation) || { id: "unknown" };
-
-            // default stats need to be initialized
-            let defaultViewStats = statsByView[defaultClient.id];
-            if (!defaultViewStats) {
-                defaultViewStats = { tracks: {}, candidatePairs: {}, pressure: null };
-                statsByView[defaultClient.id] = defaultViewStats;
-            }
-
-            // set pressure to last record received
-            defaultViewStats.pressure = lastPressureObserverRecord;
-
-            // throttle calls to ensure we get a diff from previous stats
-            const timeSinceLastUpdate = Date.now() - lastUpdateTime;
-            if (timeSinceLastUpdate < 400) {
-                if (immediate) return statsByView;
-                subscriptions.forEach((subscription: any) => subscription.onUpdatedStats?.(statsByView, clients));
-                nextTimeout = setTimeout(collectStats, interval || STATS_INTERVAL);
-                return;
-            }
-
-            // keep track of what has been updated this run
-            lastUpdateTime = Date.now();
-
-            // loop through current peer connections
-            (await getPeerConnectionsWithStatsReports()).forEach(([pc, report, pcData]) => {
-                // each new peer connection will get +1, to be able to see/count/correlate data
-                const pcIndex = getPeerConnectionIndex(pc);
-
-                // for some reason, the close event isn't called always, so we clean up manually
-                if (pc.connectionState === "closed") {
-                    report = new Map();
-                    removePeerConnection(pc);
-                }
-
-                // keep track of visited ssrcs for cleanup later
-                pcData.previousSSRCs = pcData.currentSSRCs || {};
-                pcData.currentSSRCs = {};
-
-                // loop though each stats dictionary in report
-                report.forEach((currentRtcStats: any) => {
-                    if (
-                        currentRtcStats.type === "candidate-pair" &&
-                        /inprogress|succeeded/.test(currentRtcStats.state)
-                    ) {
-                        const prevRtcStats = pcData._oldReport?.get(currentRtcStats.id);
-                        const timeDiff = prevRtcStats
-                            ? currentRtcStats.timestamp - prevRtcStats.timestamp
-                            : STATS_INTERVAL;
-
-                        const cpId = pcIndex + ":" + currentRtcStats.id;
-                        let cpMetrics = defaultViewStats.candidatePairs[cpId];
-                        if (!cpMetrics) {
-                            cpMetrics = { startTime: lastUpdateTime, id: cpId };
-                            defaultViewStats.candidatePairs[cpId] = cpMetrics;
-                        }
-                        captureCandidatePairInfoMetrics(cpMetrics, currentRtcStats, prevRtcStats, timeDiff, report);
-                        cpMetrics.lastRtcStatsTime = lastUpdateTime;
-                    }
-
-                    if (currentRtcStats.type === "inbound-rtp" || currentRtcStats.type === "outbound-rtp") {
-                        const kind = currentRtcStats.mediaType || currentRtcStats.kind;
-                        const ssrc = currentRtcStats.ssrc;
-
-                        let trackId = currentRtcStats.trackIdentifier || pcData.ssrcToTrackId[ssrc];
-
-                        let prevRtcStats = pcData._oldReport?.get(currentRtcStats.id);
-
-                        // update trackId if mediasource changes
-                        if (prevRtcStats && prevRtcStats.mediaSourceId !== currentRtcStats.mediaSourceId) {
-                            const mediaSourceStats = report.get(currentRtcStats.mediaSourceId);
-                            if (mediaSourceStats && mediaSourceStats.trackIdentifier) {
-                                trackId = mediaSourceStats.trackIdentifier;
-                                pcData.ssrcToTrackId[ssrc] = trackId;
-                            }
-                        }
-
-                        // find the current client using this trackId, or default
-                        const client = clients.find((c: any) => c[kind].track?.id === trackId) || defaultClient;
-
-                        pcData.currentSSRCs[ssrc] = client.id;
-                        // we need to stats reset when selected candidate pair changes
-                        // todo: metrics should += diff, not use count directly
-                        if (prevRtcStats) {
-                            const newTransport = report.get(currentRtcStats.transportId);
-                            const oldTransport = pcData._oldReport.get(prevRtcStats.transportId);
-                            if (
-                                oldTransport &&
-                                newTransport?.selectedCandidatePairId !== oldTransport.selectedCandidatePairId
-                            ) {
-                                // new candidate-pair, rtp stats will reset
-                                prevRtcStats = null;
-                            } else if (
-                                currentRtcStats.bytesReceived < prevRtcStats.bytesReceived ||
-                                currentRtcStats.bytesSent < prevRtcStats.bytesSent
-                            ) {
-                                // appears rts stats has reset
-                                prevRtcStats = null;
-                            }
-                        }
-
-                        const timeDiff = prevRtcStats
-                            ? currentRtcStats.timestamp - prevRtcStats.timestamp
-                            : STATS_INTERVAL;
-                        const ssrcMetrics = getOrCreateSsrcMetricsContainer(
-                            lastUpdateTime,
-                            pcIndex,
-                            client.id,
-                            trackId,
-                            ssrc
-                        );
-
-                        // capture tracks/ssrc info/metrics
-                        captureSsrcInfo(ssrcMetrics, currentRtcStats, prevRtcStats, timeDiff, report);
-                        captureCommonSsrcMetrics(ssrcMetrics, currentRtcStats, prevRtcStats, timeDiff, report);
-                        if (kind === "video") {
-                            captureVideoSsrcMetrics(ssrcMetrics, currentRtcStats, prevRtcStats, timeDiff, report);
-                        }
-                        if (kind === "audio") {
-                            captureAudioSsrcMetrics(ssrcMetrics, currentRtcStats, prevRtcStats, timeDiff, report);
-                        }
-                    }
-                });
-
-                pcData._oldReport = report;
-
-                // clean up old stats/metrics
-                Object.keys(pcData.previousSSRCs)
-                    .filter((ssrc) => !pcData.currentSSRCs[ssrc])
-                    .forEach((ssrc) => {
-                        const clientId = pcData.previousSSRCs[ssrc];
-                        if (clientId) {
-                            // remove
-                            const clientView = statsByView[clientId];
-                            if (clientView) {
-                                Object.values(clientView.tracks).forEach((trackStats: any) => {
-                                    if (trackStats.ssrcs[ssrc]) {
-                                        delete trackStats.ssrcs[ssrc];
-                                    }
-                                });
-                            }
-                        }
-                    });
-            });
-
-            removeNonUpdatedStats(lastUpdateTime);
-
-            // mark candidatepairs as active/inactive
-            Object.entries(defaultViewStats.candidatePairs).forEach(([cpKey, cp]: any) => {
-                const active = cp.lastRtcStatsTime === lastUpdateTime;
-                cp.active = active;
-                if (!active) {
-                    cp.state = "old/inactive";
-                    if (!cp.inactiveFromTime) cp.inactiveFromTime = lastUpdateTime;
-                    else {
-                        // delete candidate pair after a few secs
-                        if (lastUpdateTime - cp.inactiveFromTime > 4000) {
-                            delete defaultViewStats.candidatePairs[cpKey];
-                        }
-                    }
-                }
-            });
-
-            if (immediate) {
-                return statsByView;
-            } else {
-                subscriptions.forEach((subscription: any) => subscription.onUpdatedStats?.(statsByView, clients));
-            }
-        } catch (ex) {
-            logger.warn(ex);
-        }
-
-        nextTimeout = setTimeout(collectStats, interval || STATS_INTERVAL);
-    };
-
     // initial run
-    setTimeout(collectStats, interval || STATS_INTERVAL);
+    setTimeout(collectStatsBound, interval);
 
     return {
-        stop: () => {
-            clearTimeout(nextTimeout);
-            if (pressureObserver) pressureObserver.unobserve("cpu");
-        },
         getUpdatedStats: () => {
-            return collectStats(true);
+            return collectStatsBound(true);
+        },
+        stop: () => {
+            clearTimeout(state.nextTimeout);
+            if (cpuObserver) cpuObserver.stop();
         },
     };
 }
 
-export function subscribeStats(subscription: any) {
-    subscriptions.push(subscription);
+export function subscribeStats(
+    subscription: StatsSubscription,
+    options: StatsMonitorOptions = OPTIONS,
+    state: StatsMonitorState = STATE,
+) {
+    state.subscriptions.push(subscription);
 
     // start the monitor on first subscription
-    if (!currentMonitor) currentMonitor = startStatsMonitor({});
+    if (!state.currentMonitor) state.currentMonitor = startStatsMonitor(state, options);
 
     return {
         stop() {
-            subscriptions = subscriptions.filter((s: any) => s !== subscription);
-            if (!subscriptions.length) {
+            state.subscriptions = state.subscriptions.filter((s) => s !== subscription);
+            if (!state.subscriptions.length) {
                 // stop monitor when last subscription is stopped/removed
-                currentMonitor?.stop();
-                currentMonitor = null;
+                state.currentMonitor?.stop();
+                state.currentMonitor = null;
             }
         },
     };

--- a/packages/media/src/webrtc/stats/StatsMonitor/peerConnection.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/peerConnection.ts
@@ -1,0 +1,75 @@
+import { getCurrentPeerConnections, getPeerConnectionIndex, removePeerConnection } from "./peerConnectionTracker";
+
+// peer connection related data
+const pcDataByPc = new WeakMap();
+
+export const getPeerConnectionsWithStatsReports = () =>
+    Promise.all(
+        getCurrentPeerConnections().map(async (pc: any) => {
+            let pcData = pcDataByPc.get(pc);
+            if (!pcData) {
+                pcData = { ssrcToTrackId: {} };
+                pcDataByPc.set(pc, pcData);
+            }
+
+            try {
+                const report = await pc.getStats();
+
+                let missingSsrcs: any = null;
+
+                report.forEach((stats: any) => {
+                    if (stats.type === "inbound-rtp" || stats.type === "outbound-rtp") {
+                        if (!stats.trackIdentifier && !pcData.ssrcToTrackId[stats.ssrc]) {
+                            // try to lookup by media-source
+                            if (stats.mediaSourceId) {
+                                const mediaSourceStats = report.get(stats.mediaSourceId);
+                                if (mediaSourceStats) {
+                                    if (mediaSourceStats.trackIdentifier) {
+                                        pcData.ssrcToTrackId[stats.ssrc] = mediaSourceStats.trackIdentifier;
+                                    }
+                                }
+                            }
+
+                            // try to lookup by deprecated stats
+                            if (!pcData.ssrcToTrackId[stats.ssrc] && stats.trackId) {
+                                const deprecatedTrackStats = report.get(stats.trackId);
+                                if (deprecatedTrackStats) {
+                                    if (deprecatedTrackStats.trackIdentifier) {
+                                        pcData.ssrcToTrackId[stats.ssrc] = deprecatedTrackStats.trackIdentifier;
+                                    }
+                                }
+                            }
+                            if (!pcData.ssrcToTrackId[stats.ssrc]) {
+                                // we need to lookup this ssrc by separate getStats calls
+                                if (!missingSsrcs) missingSsrcs = [];
+                                missingSsrcs.push(stats.ssrc);
+                            }
+                        }
+                    }
+                });
+
+                if (missingSsrcs) {
+                    // call getStats() on all senders and receivers to map missing ssrcs
+                    const sendersAndReceivers = [...pc.getSenders(), ...pc.getReceivers()];
+                    const reports = await Promise.all(sendersAndReceivers.map((o) => o.getStats()));
+                    reports.forEach((tReport, index) => {
+                        tReport.forEach((stats: any) => {
+                            if (stats.type === "inbound-rtp" || stats.type === "outbound-rtp") {
+                                pcData.ssrcToTrackId[stats.ssrc] = sendersAndReceivers[index].track.id;
+                            }
+                        });
+                    });
+
+                    // create fake track ids for anything not found
+                    missingSsrcs.forEach((ssrc: any) => {
+                        if (!pcData.ssrcToTrackId[ssrc]) {
+                            pcData.ssrcToTrackId[ssrc] = "?" + ssrc;
+                        }
+                    });
+                }
+                return [pc, report, pcData];
+            } catch (ex) {
+                return [pc, [], pcData];
+            }
+        }),
+    );


### PR DESCRIPTION
### Description

Adjust how we initialize the cpu pressure observer to pass sampleInterval as an option to conform with the new api.

### Testing

Nothing to test here. Tests should pass

### Additional Information

This is a small change by itself, but I have also refactored a bit the StatsMonitor to allow for easier unit testing and also breaking apart a module which had become very large.