### PR TITLE
media: Allows uncapped 1:1 meetings

### DIFF
--- a/.changeset/swift-tomatoes-sort.md
+++ b/.changeset/swift-tomatoes-sort.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": minor
+---
+
+media: Allows uncapped 1:1 meetings on SFU

--- a/packages/media/src/webrtc/VegaRtcManager.ts
+++ b/packages/media/src/webrtc/VegaRtcManager.ts
@@ -1411,6 +1411,10 @@ export default class VegaRtcManager implements RtcManager {
             spatialLayer = 1;
         }
 
+        if (this._features?.uncappedSingleRemoteVideoOn && numberOfActiveVideos === 1) {
+            spatialLayer = 2;
+            temporalLayer = numberOfTemporalLayers - 1;
+        }
         if (consumer.appData.spatialLayer !== spatialLayer || consumer.appData.temporalLayer !== temporalLayer) {
             consumer.appData.spatialLayer = spatialLayer;
             consumer.appData.temporalLayer = temporalLayer;


### PR DESCRIPTION
This will allow uncapped "1:1" meetings on SFU, enabled by feature flag. Testing instructions in PWA PR