### PR TITLE
browser-sdk: Prevent in-room actions from being invoked out-of-order

### DIFF
--- a/.changeset/kind-years-cheer.md
+++ b/.changeset/kind-years-cheer.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": patch
+---
+
+Ensure that in-room actions can not be invoked when not in a room connected state

--- a/apps/sample-app/src/App.tsx
+++ b/apps/sample-app/src/App.tsx
@@ -211,7 +211,7 @@ const Room = ({ roomUrl, localMedia, displayName, isHost }: RoomProps) => {
         return () => {
             roomConnection.events?.off("*", sdkEventHandler);
         };
-    }, [roomConnection.events]);
+    }, [roomConnection.events, roomConnection.state, roomConnection.actions]);
 
     if (connectionStatus === "ready") {
         return (


### PR DESCRIPTION
### Description

In browser-sdk version 3 we made a change that requires users to explicitly call `actions.joinRoom()` to connect to a room (https://github.com/whereby/sdk/pull/254).

With this change it is possible that users may try to invoke other actions when they have not yet joined and been connected to a room.

This PR adds an additional wrapper around `actions` APIs that check the user is connected to room so that actions can be successfully performed.

If the browser-sdk is not currently connected to a room then a warning will be displayed in the developer console and the action will not be triggered.

### Testing

1. Check out this PR branch and run `yarn build && yarn dev`
2. Check that all custom stories continue to work as expected once Storybook has loaded.
3. Deliberably try to invoke an in-room action out-of-order. e.g. download the following snippet as `tmp-out-of-order-check.diff` and, in the SDK folder, apply that to the project with `git apply tmp-out-of-order-check.diff`.

```diff
diff --git a/packages/browser-sdk/src/stories/components/VideoExperience.tsx b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
index 59bdaa1c..8dabbad4 100644
--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -202,7 +202,9 @@ export default function VideoExperience({
 
     return (
         <div>
-            {!joinRoomOnLoad && connectionStatus === "ready" && <button onClick={() => joinRoom()}>Join room</button>}
+            {!joinRoomOnLoad && connectionStatus === "ready" && (
+                <button onClick={() => toggleCamera()}>Toggle camera (out-of-order event should fail)</button>
+            )}
             {connectionStatus === "connecting" && <span>Connecting...</span>}
             {connectionStatus === "room_locked" && (
                 <div style={{ color: "red" }}>
```

4. A warning should be displayed in the user's browser (`"Action cannot be performed outside of a connected room"`) and no additional errors should be displayed in the console.

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
