### PR TITLE
media: Add test coverage for VegaRtcManager

### DIFF
--- a/.changeset/neat-dryers-doubt.md
+++ b/.changeset/neat-dryers-doubt.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/media": patch
+---
+
+Adjust SFU rtc manager folder structure to allow breaking it apart and testing
+the units. Also adds test for setting spatial and temporal layers.

--- a/packages/media/src/webrtc/VegaRtcManager/__tests__/index.spec.ts
+++ b/packages/media/src/webrtc/VegaRtcManager/__tests__/index.spec.ts
@@ -1,15 +1,15 @@
-import * as helpers from "./webRtcHelpers";
 import * as mediasoupClient from "mediasoup-client";
+
+import VegaRtcManager from "../";
+
+import * as CONNECTION_STATUS from "../../../model/connectionStatusConstants";
+import * as helpers from "../../../../tests/webrtc/webRtcHelpers";
 
 jest.mock("webrtc-adapter", () => {
     return {
         browserDetails: { browser: "chrome" },
     };
 });
-
-import * as CONNECTION_STATUS from "../../src/model/connectionStatusConstants";
-import VegaRtcManager from "../../src/webrtc/VegaRtcManager";
-import { itShouldThrowIfMissing } from "../helpers";
 
 const originalNavigator = global.navigator;
 const originalMediasoupDevice = mediasoupClient.Device;

--- a/packages/media/src/webrtc/VegaRtcManager/__tests__/utils.spec.ts
+++ b/packages/media/src/webrtc/VegaRtcManager/__tests__/utils.spec.ts
@@ -1,0 +1,72 @@
+import { getLayers, getNumberOfActiveVideos, getNumberOfTemporalLayers } from "../utils";
+
+describe("utils", () => {
+    describe("getLayers", () => {
+        it.each`
+            width  | height | numberOfActiveVideos | numberOfTemporalLayers | uncappedSingleRemoteVideoOn | expected
+            ${400} | ${400} | ${6}                 | ${2}                   | ${false}                    | ${{ spatialLayer: 0, temporalLayer: 1 }}
+            ${480} | ${400} | ${6}                 | ${2}                   | ${false}                    | ${{ spatialLayer: 1, temporalLayer: 1 }}
+            ${400} | ${400} | ${2}                 | ${2}                   | ${false}                    | ${{ spatialLayer: 1, temporalLayer: 1 }}
+            ${200} | ${200} | ${2}                 | ${2}                   | ${false}                    | ${{ spatialLayer: 0, temporalLayer: 1 }}
+            ${960} | ${400} | ${2}                 | ${2}                   | ${false}                    | ${{ spatialLayer: 2, temporalLayer: 1 }}
+            ${960} | ${400} | ${2}                 | ${3}                   | ${false}                    | ${{ spatialLayer: 2, temporalLayer: 2 }}
+            ${99}  | ${99}  | ${2}                 | ${2}                   | ${false}                    | ${{ spatialLayer: 0, temporalLayer: 0 }}
+            ${480} | ${480} | ${0}                 | ${2}                   | ${false}                    | ${{ spatialLayer: 1, temporalLayer: 1 }}
+            ${960} | ${480} | ${1}                 | ${2}                   | ${false}                    | ${{ spatialLayer: 2, temporalLayer: 1 }}
+            ${480} | ${480} | ${1}                 | ${2}                   | ${true}                     | ${{ spatialLayer: 2, temporalLayer: 1 }}
+            ${480} | ${480} | ${2}                 | ${2}                   | ${true}                     | ${{ spatialLayer: 1, temporalLayer: 1 }}
+        `(
+            "expected $expected when width:$width, height:$height, numberOfActiveVideos:$numberOfActiveVideos, numberOfTemporalLayers:$numberOfTemporalLayers, uncappedSingleRemoteVideoOn:$uncappedSingleRemoteVideoOn",
+            ({
+                width,
+                height,
+                numberOfActiveVideos,
+                numberOfTemporalLayers,
+                expected,
+                uncappedSingleRemoteVideoOn,
+            }) => {
+                const result = getLayers(
+                    { width, height },
+                    { numberOfActiveVideos, numberOfTemporalLayers, uncappedSingleRemoteVideoOn },
+                );
+
+                expect(result).toEqual(expected);
+            },
+        );
+    });
+
+    describe("getNumberOfActiveVideos", () => {
+        it.each`
+            consumers                                                                                  | expected
+            ${[]}                                                                                      | ${0}
+            ${[{ _closed: true }]}                                                                     | ${0}
+            ${[{ _paused: true }]}                                                                     | ${0}
+            ${[{}]}                                                                                    | ${0}
+            ${[{ _appData: { source: "unknown" } }]}                                                   | ${0}
+            ${[{ _appData: { source: "webcam" } }]}                                                    | ${1}
+            ${[{ _appData: { source: "screenvideo" } }]}                                               | ${1}
+            ${[{ _appData: { source: "webcam" } }, { _appData: { source: "webcam" }, _paused: true }]} | ${1}
+            ${[{ _appData: { source: "screenvideo" } }, { _appData: { source: "webcam" } }]}           | ${2}
+        `("expected $expected when consumers:$consumers", ({ consumers, expected }) => {
+            expect(getNumberOfActiveVideos(consumers)).toEqual(expected);
+        });
+    });
+
+    describe("getNumberOfTemporalLayers", () => {
+        it("should return 2 by default", () => {
+            const consumer = { _rtpParameters: { encodings: [{ scalabilityMode: "T2" }] } };
+
+            const result = getNumberOfTemporalLayers(consumer);
+
+            expect(result).toBe(2);
+        });
+
+        it("should return 3 when scalabilityMode matches T3", () => {
+            const consumer = { _rtpParameters: { encodings: [{ scalabilityMode: "T3 is the thing" }] } };
+
+            const result = getNumberOfTemporalLayers(consumer);
+
+            expect(result).toBe(3);
+        });
+    });
+});

--- a/packages/media/src/webrtc/VegaRtcManager/index.ts
+++ b/packages/media/src/webrtc/VegaRtcManager/index.ts
@@ -1,19 +1,22 @@
 import { Device } from "mediasoup-client";
-import { PROTOCOL_EVENTS, PROTOCOL_REQUESTS, PROTOCOL_RESPONSES } from "../model/protocol";
-import * as CONNECTION_STATUS from "../model/connectionStatusConstants";
-import rtcManagerEvents from "./rtcManagerEvents";
-import rtcStats from "./rtcStatsService";
 import adapterRaw from "webrtc-adapter";
-import VegaConnection from "./VegaConnection";
-import { getMediaSettings, modifyMediaCapabilities } from "../utils/mediaSettings";
-import { MEDIA_JITTER_BUFFER_TARGET } from "./constants";
-import { getHandler } from "../utils/getHandler";
 import { v4 as uuidv4 } from "uuid";
-import createMicAnalyser from "./VegaMicAnalyser";
-import { maybeTurnOnly } from "../utils/transportSettings";
-import VegaMediaQualityMonitor from "./VegaMediaQualityMonitor";
-import Logger from "../utils/Logger";
-import { RtcManager } from "./types";
+
+import rtcManagerEvents from "../rtcManagerEvents";
+import rtcStats from "../rtcStatsService";
+import VegaConnection from "../VegaConnection";
+import createMicAnalyser from "../VegaMicAnalyser";
+import { RtcManager } from "../types";
+import VegaMediaQualityMonitor from "../VegaMediaQualityMonitor";
+import { MEDIA_JITTER_BUFFER_TARGET } from "../constants";
+
+import { PROTOCOL_EVENTS, PROTOCOL_REQUESTS, PROTOCOL_RESPONSES } from "../../model/protocol";
+import * as CONNECTION_STATUS from "../../model/connectionStatusConstants";
+import { getMediaSettings, modifyMediaCapabilities } from "../../utils/mediaSettings";
+import { getHandler } from "../../utils/getHandler";
+import { maybeTurnOnly } from "../../utils/transportSettings";
+import Logger from "../../utils/Logger";
+import { getLayers, getNumberOfActiveVideos, getNumberOfTemporalLayers } from "./utils";
 
 // @ts-ignore
 const adapter = adapterRaw.default ?? adapterRaw;
@@ -1380,41 +1383,18 @@ export default class VegaRtcManager implements RtcManager {
 
         if (!consumer) return;
 
-        let numberOfActiveVideos = 0;
-        this._consumers.forEach((c: any) => {
-            if (c._closed || c._paused) return;
-            if (c._appData?.source === "webcam" || c._appData?.source === "screenvideo") numberOfActiveVideos++;
-        });
+        const numberOfActiveVideos = getNumberOfActiveVideos(this._consumers);
+        const numberOfTemporalLayers = getNumberOfTemporalLayers(consumer);
 
-        // assume it is using T2 mode unless we detect otherwise
-        let numberOfTemporalLayers = 2;
-        if (/T3/.test(consumer._rtpParameters?.encodings?.[0]?.scalabilityMode || "")) numberOfTemporalLayers = 3;
+        const { spatialLayer, temporalLayer } = getLayers(
+            { width, height },
+            {
+                numberOfActiveVideos,
+                numberOfTemporalLayers,
+                uncappedSingleRemoteVideoOn: this._features?.uncappedSingleRemoteVideoOn,
+            },
+        );
 
-        const maxSide = Math.max(width, height);
-        let spatialLayer = maxSide >= 480 ? (maxSide >= 960 ? 2 : 1) : 0;
-        let temporalLayer = numberOfTemporalLayers - 1; // default to full framerate
-
-        // if we are rendering tile-like sizes we reduce framerate by 50%
-        if (maxSide < 100) {
-            temporalLayer = Math.max(numberOfTemporalLayers - 2, 0);
-        }
-
-        // if we are rendering many videos, we reduce framerate by 50% for all videos with lowest spatial layer
-        if (numberOfActiveVideos > 8 && spatialLayer === 0) {
-            temporalLayer = Math.max(numberOfTemporalLayers - 2, 0);
-        }
-
-        // increase resolution if few videos (like 1:1 on phones)
-        // todo: consider spatialLayer 1 for maxSide > 200. 4 in a room is considerable higher quality on phones this way
-        // ... but might conflict with our intent of mobile-mode
-        if (numberOfActiveVideos < 4 && maxSide > 300 && spatialLayer === 0) {
-            spatialLayer = 1;
-        }
-
-        if (this._features?.uncappedSingleRemoteVideoOn && numberOfActiveVideos === 1) {
-            spatialLayer = 2;
-            temporalLayer = numberOfTemporalLayers - 1;
-        }
         if (consumer.appData.spatialLayer !== spatialLayer || consumer.appData.temporalLayer !== temporalLayer) {
             consumer.appData.spatialLayer = spatialLayer;
             consumer.appData.temporalLayer = temporalLayer;

--- a/packages/media/src/webrtc/VegaRtcManager/utils.ts
+++ b/packages/media/src/webrtc/VegaRtcManager/utils.ts
@@ -1,0 +1,61 @@
+export function getLayers(
+    {
+        width,
+        height,
+    }: {
+        width: number;
+        height: number;
+    },
+    {
+        numberOfActiveVideos,
+        numberOfTemporalLayers,
+        uncappedSingleRemoteVideoOn,
+    }: {
+        numberOfActiveVideos: number;
+        numberOfTemporalLayers: number;
+        uncappedSingleRemoteVideoOn: boolean;
+    },
+) {
+    const maxSide = Math.max(width, height);
+    let spatialLayer = maxSide >= 480 ? (maxSide >= 960 ? 2 : 1) : 0;
+    let temporalLayer = numberOfTemporalLayers - 1; // default to full framerate
+
+    // if we are rendering tile-like sizes we reduce framerate by 50%
+    if (maxSide < 100) {
+        temporalLayer = Math.max(numberOfTemporalLayers - 2, 0);
+    }
+
+    // if we are rendering many videos, we reduce framerate by 50% for all videos with lowest spatial layer
+    if (numberOfActiveVideos > 8 && spatialLayer === 0) {
+        temporalLayer = Math.max(numberOfTemporalLayers - 2, 0);
+    }
+
+    // increase resolution if few videos (like 1:1 on phones)
+    // todo: consider spatialLayer 1 for maxSide > 200. 4 in a room is considerable higher quality on phones this way
+    // ... but might conflict with our intent of mobile-mode
+    if (numberOfActiveVideos < 4 && maxSide > 300 && spatialLayer === 0) {
+        spatialLayer = 1;
+    }
+
+    if (uncappedSingleRemoteVideoOn && numberOfActiveVideos === 1) {
+        spatialLayer = 2;
+        temporalLayer = numberOfTemporalLayers - 1;
+    }
+
+    return { spatialLayer, temporalLayer };
+}
+
+export function getNumberOfActiveVideos(consumers: any) {
+    let numberOfActiveVideos = 0;
+    consumers.forEach((c: any) => {
+        if (c._closed || c._paused) return;
+        if (c._appData?.source === "webcam" || c._appData?.source === "screenvideo") numberOfActiveVideos++;
+    });
+
+    return numberOfActiveVideos;
+}
+
+export function getNumberOfTemporalLayers(consumer: any) {
+    // assume it is using T2 mode unless we detect otherwise
+    return /T3/.test(consumer._rtpParameters?.encodings?.[0]?.scalabilityMode || "") ? 3 : 2;
+}


### PR DESCRIPTION
### Description

We need to start somewhere. This change breaks out the calculation of spatial and temporal layers so they can be unit tested.

### Testing

Automated tests should cover this, no functional change.

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

