### PR TITLE
browser-sdk: Add toggleBreakout(), and togglePeople() to embed element

### DIFF
--- a/.changeset/wise-flies-whisper.md
+++ b/.changeset/wise-flies-whisper.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": minor
+---
+
+Add support for new commands: openBreakout, closeBreakout, and togglePeople. Syntax fix in toggleChat command definition

--- a/apps/embed-element-app/src/App.tsx
+++ b/apps/embed-element-app/src/App.tsx
@@ -35,7 +35,7 @@ const events = [
 ];
 
 function App() {
-    const roomUrl = "enter your room url here";
+    const roomUrl ="enter your room url here";
     const elmRef = useRef<HTMLIFrameElement>(null);
     const [eventLogEntries, setEventLogEntries] = useState<any[]>([]);
     const [initTime, setInitTime] = useState<number>(0);
@@ -43,24 +43,23 @@ function App() {
     function handleWherebyEvent(event: any) {
         setEventLogEntries((prev) => [...prev, event]);
     }
-
-    useEffect(() => {
-        const element = elmRef.current;
-        if (element) {
-            events.forEach((event) => {
-                element.addEventListener(event, handleWherebyEvent);
-            });
-            setInitTime(Date.now());
-        }
-        return () => {
-            if (element) {
-                events.forEach((event) => {
-                    element.removeEventListener(event, handleWherebyEvent);
-                });
-            }
-        };
-    }, []);
-
+    
+          useEffect(() => {
+              const element = elmRef.current;
+              if (element) {
+                  events.forEach((event) => {
+                      element.addEventListener(event, handleWherebyEvent);
+                  });
+                  setInitTime(Date.now());
+              }
+              return () => {
+                  if (element) {
+                      events.forEach((event) => {
+                          element.removeEventListener(event, handleWherebyEvent);
+                      });
+                  }
+              };
+          }, []);
     return (
         <div className="App">
             <div className="LeftSidebar">
@@ -72,9 +71,10 @@ function App() {
             </div>
             <div className="WherebyEmbed">
                 <whereby-embed
-                    chat="off"
-                    people="off"
+                    chat="on"
                     background="off"
+                    people="on"
+                    breakout="on"
                     // TODO: remove this line when sdk is updated
                     // @ts-ignore
                     minimal="on"

--- a/packages/browser-sdk/src/lib/embed/index.ts
+++ b/packages/browser-sdk/src/lib/embed/index.ts
@@ -113,10 +113,12 @@ interface WherebyEmbedElementCommands {
     stopRecording: () => void;
     startStreaming: () => void;
     stopStreaming: () => void;
+    toggleBreakout: (enabled?: boolean) => void;
     toggleCamera: (enabled?: boolean) => void;
     toggleMicrophone: (enabled?: boolean) => void;
+    togglePeople: (enabled?: boolean) => void;
     toggleScreenshare: (enabled?: boolean) => void;
-    toogleChat: (enabled?: boolean) => void;
+    toggleChat: (enabled?: boolean) => void;
 }
 
 export interface WherebyEmbedElement extends HTMLIFrameElement, WherebyEmbedElementCommands {
@@ -174,7 +176,7 @@ const boolAttrs = [
     "timer",
     "toolbarDarkText",
     "topToolbar",
-    "video"
+    "video",
 ];
 
 define("WherebyEmbed", {
@@ -243,11 +245,17 @@ define("WherebyEmbed", {
     stopStreaming() {
         this._postCommand("stop_streaming");
     },
+    toggleBreakout(open?: boolean) {
+        this._postCommand("toggle_breakout", [open]);
+    },
     toggleCamera(enabled?: boolean) {
         this._postCommand("toggle_camera", [enabled]);
     },
     toggleMicrophone(enabled?: boolean) {
         this._postCommand("toggle_microphone", [enabled]);
+    },
+    togglePeople(enabled?: boolean) {
+        this._postCommand("toggle_people", [enabled]);
     },
     toggleScreenshare(enabled?: boolean) {
         this._postCommand("toggle_screenshare", [enabled]);


### PR DESCRIPTION
### Description

**Summary:**
Add support for new commands: openBreakout, closeBreakout, and togglePeople. Syntax fix in toggleChat command definition 


**Related Issue:**
Reliant on this PR
https://github.com/whereby/pwa/pull/4100

### Testing

In sdk repo, apps/embed-element-app example

- Imported WherebyEmbedElement
- Point roomUrl to local stack/room
- adjust const elmRef = useRef<WherebyEmbedElement>(null);
- Adjust attributes in to disable minimal, and include people tab and breakout
- Add buttons testing new functions. Example:
<button onClick={ () => elmRef.current?.openBreakout()}>breakout</button>

Then in terminal: 
`yarn dev:embed-element-app `

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

Gotcha:
The openBreakout() command will still work for non-host participants. However, the user can't actually edit or initiate any breakout settings.

The above note will be clarified in our documentation and expected that customers development teams manage this from their side. i.e., if (host = true){show/enable button} else {don't show}
