### PR TITLE
Change import to default in exports to ensure compatibility

### DIFF
--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -13,11 +13,11 @@
   "source": "src/index.js",
   "exports": {
     "./react": {
-      "import": "./dist/react/index.esm.js",
+      "default": "./dist/react/index.esm.js",
       "types": "./dist/react/index.d.ts"
     },
     "./embed": {
-      "import": "./dist/embed/index.esm.js",
+      "default": "./dist/embed/index.esm.js",
       "types": "./dist/embed/index.d.ts"
     }
   },


### PR DESCRIPTION
### Description

**Summary:**

See https://github.com/nextauthjs/next-auth/pull/8330 for more details. Some bundlers and resolvers have issues with the `import` key in exports. The `default` key works the same and is better supported by tooling.


**Related Issue:**

None

### Testing

Load this module using `vite` - after this, it works, before, it fails with a message like `No known conditions for "./react" specifier in "@whereby.com/browser-sdk" package`

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
