### PR TITLE
core: Exclude non person roles in remote participants selector

### DIFF
--- a/.changeset/chilly-kings-chew.md
+++ b/.changeset/chilly-kings-chew.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": minor
+---
+
+Exclude non person roles in participant selection

--- a/packages/core/src/redux/constants.ts
+++ b/packages/core/src/redux/constants.ts
@@ -1,0 +1,1 @@
+export const NON_PERSON_ROLES = ["recorder", "streamer"];

--- a/packages/core/src/redux/slices/localParticipant.ts
+++ b/packages/core/src/redux/slices/localParticipant.ts
@@ -9,6 +9,7 @@ import { selectLocalMediaStream, toggleCameraEnabled, toggleMicrophoneEnabled } 
 import { createReactor, startAppListening } from "../listenerMiddleware";
 import { signalEvents } from "./signalConnection/actions";
 import { ClientView } from "../types";
+import { NON_PERSON_ROLES } from "../constants";
 
 export interface LocalParticipantState extends LocalParticipant {
     isScreenSharing: boolean;
@@ -177,6 +178,10 @@ export const selectLocalParticipantView = createSelector(
             isAudioEnabled: participant.isAudioEnabled,
             isVideoEnabled: participant.isVideoEnabled,
         };
+
+        if (NON_PERSON_ROLES.includes(participant.roleName)) {
+            return null;
+        }
 
         return clientView;
     },

--- a/packages/core/src/redux/slices/remoteParticipants.ts
+++ b/packages/core/src/redux/slices/remoteParticipants.ts
@@ -8,8 +8,8 @@ import { signalEvents } from "./signalConnection/actions";
 import { createAppAuthorizedThunk } from "../thunk";
 import { selectIsAuthorizedToAskToSpeak, selectIsAuthorizedToRequestAudioEnable } from "./authorization";
 import { selectSignalConnectionRaw } from "./signalConnection";
-
-const NON_PERSON_ROLES = ["recorder", "streamer"];
+import { NON_PERSON_ROLES } from "../constants";
+import { selectLocalParticipantRaw } from "./localParticipant";
 
 /**
  * State mapping utils
@@ -305,9 +305,19 @@ export const doRequestAudioEnable = createAppAuthorizedThunk(
  */
 
 export const selectRemoteParticipantsRaw = (state: RootState) => state.remoteParticipants;
-export const selectRemoteParticipants = (state: RootState) => state.remoteParticipants.remoteParticipants;
+export const selectRemoteClients = (state: RootState) => state.remoteParticipants.remoteParticipants;
 
+export const selectRemoteParticipants = createSelector(selectRemoteClients, (clients) =>
+    clients.filter((c) => !NON_PERSON_ROLES.includes(c.roleName)),
+);
+export const selectNumClients = createSelector(selectRemoteClients, (clients) => clients.length + 1);
 export const selectNumParticipants = createSelector(
     selectRemoteParticipants,
-    (clients) => clients.filter((c) => !NON_PERSON_ROLES.includes(c.roleName)).length + 1,
+    selectLocalParticipantRaw,
+    (clients, localParticipant) => {
+        if (NON_PERSON_ROLES.includes(localParticipant.roleName)) {
+            return clients.length;
+        }
+        return clients.length + 1;
+    },
 );

--- a/packages/core/src/redux/slices/room.ts
+++ b/packages/core/src/redux/slices/room.ts
@@ -9,7 +9,7 @@ import {
     selectIsAuthorizedToEndMeeting,
 } from "./authorization";
 import { selectSignalConnectionRaw } from "./signalConnection";
-import { selectRemoteParticipants } from "./remoteParticipants";
+import { selectRemoteClients, selectRemoteParticipants } from "./remoteParticipants";
 import { selectLocalScreenshareStream } from "./localScreenshare";
 import { Screenshare, RemoteParticipant } from "../../RoomParticipant";
 import { selectLocalParticipantView, selectLocalParticipantRaw } from "./localParticipant";
@@ -93,7 +93,7 @@ export const doEndMeeting = createAppAuthorizedThunk(
     (payload: { stayBehind?: boolean }) => (dispatch, getState) => {
         const state = getState();
 
-        const clientsToKick = selectRemoteParticipants(state).map((c) => c.id);
+        const clientsToKick = selectRemoteClients(state).map((c) => c.id);
 
         if (clientsToKick.length) {
             const { socket } = selectSignalConnectionRaw(state);
@@ -206,6 +206,6 @@ export const selectAllClientViews = createSelector(
     selectLocalParticipantView,
     selectRemoteClientViews,
     (localParticipant, remoteParticipants) => {
-        return [localParticipant, ...remoteParticipants];
+        return [...(localParticipant ? [localParticipant] : []), ...remoteParticipants];
     },
 );

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -10,7 +10,7 @@ import {
 } from "@whereby.com/media";
 import { selectSignalConnectionRaw, selectSignalConnectionSocket, socketReconnecting } from "../signalConnection";
 import { createReactor, startAppListening } from "../../listenerMiddleware";
-import { selectRemoteParticipants, streamStatusUpdated } from "../remoteParticipants";
+import { selectRemoteClients, streamStatusUpdated } from "../remoteParticipants";
 import { StreamState } from "../../../RoomParticipant";
 import { selectAppIsNodeSdk, selectAppIsActive } from "../app";
 import { Chrome111 as MediasoupDeviceHandler } from "mediasoup-client/lib/handlers/Chrome111.js";
@@ -215,7 +215,7 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
     dispatch(isAcceptingStreams(true));
     const state = getState();
     const rtcManager = selectRtcConnectionRaw(state).rtcManager;
-    const remoteParticipants = selectRemoteParticipants(state);
+    const remoteClients = selectRemoteClients(state);
 
     if (!rtcManager) {
         throw new Error("No rtc manager");
@@ -227,7 +227,7 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
     const updates: StreamStatusUpdate[] = [];
 
     for (const { clientId, streamId, state } of payload) {
-        const participant = remoteParticipants.find((p) => p.id === clientId);
+        const participant = remoteClients.find((p) => p.id === clientId);
         if (!participant) continue;
         if (
             state === "to_accept" ||
@@ -421,7 +421,7 @@ createReactor([selectShouldDisconnectRtc], ({ dispatch }, shouldDisconnectRtc) =
 // react accept streams
 export const selectStreamsToAccept = createSelector(
     selectRtcStatus,
-    selectRemoteParticipants,
+    selectRemoteClients,
     (rtcStatus, remoteParticipants) => {
         if (rtcStatus !== "ready") {
             return [];


### PR DESCRIPTION
### Description
Exclude non person roles (recorder and streamer) clients from participants selector. Also adds a new selector `selectRemoteClients`, which **includes** non person roles. This is used for stream handling f.ex.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
