### PR TITLE
core: remove node sdk startup logic

### DIFF
--- a/.changeset/cold-birds-sing.md
+++ b/.changeset/cold-birds-sing.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": minor
+---
+
+Remove local media bypass logic for nodejs clients

--- a/packages/core/src/redux/slices/__tests__/localMedia.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/localMedia.unit.ts
@@ -4,23 +4,21 @@ describe("localMediaSlice", () => {
     describe("reactors", () => {
         describe("reactLocalMediaStart", () => {
             it.each`
-                appIsActive | localMediaStatus | localMediaOptions               | isNodeSdk | expected
-                ${false}    | ${"inactive"}    | ${undefined}                    | ${false}  | ${undefined}
-                ${false}    | ${"started"}     | ${undefined}                    | ${false}  | ${undefined}
-                ${false}    | ${"started"}     | ${{ audio: true, video: true }} | ${false}  | ${undefined}
-                ${true}     | ${"started"}     | ${{ audio: true, video: true }} | ${false}  | ${undefined}
-                ${true}     | ${"inactive"}    | ${undefined}                    | ${false}  | ${undefined}
-                ${true}     | ${"inactive"}    | ${{ audio: true, video: true }} | ${true}   | ${undefined}
-                ${true}     | ${"inactive"}    | ${{ audio: true, video: true }} | ${false}  | ${{ audio: true, video: true }}
+                appIsActive | localMediaStatus | localMediaOptions               | expected
+                ${false}    | ${"inactive"}    | ${undefined}                    | ${undefined}
+                ${false}    | ${"started"}     | ${undefined}                    | ${undefined}
+                ${false}    | ${"started"}     | ${{ audio: true, video: true }} | ${undefined}
+                ${true}     | ${"started"}     | ${{ audio: true, video: true }} | ${undefined}
+                ${true}     | ${"inactive"}    | ${undefined}                    | ${undefined}
+                ${true}     | ${"inactive"}    | ${{ audio: true, video: true }} | ${{ audio: true, video: true }}
             `(
-                "expected $expected when appIsActive=$appIsActive, localMediaStatus=$localMediaStatus, localMediaOptions=$localMediaOptions, isNodeSdk=$isNodeSdk",
-                ({ appIsActive, localMediaStatus, localMediaOptions, isNodeSdk, expected }) => {
+                "expected $expected when appIsActive=$appIsActive, localMediaStatus=$localMediaStatus, localMediaOptions=$localMediaOptions",
+                ({ appIsActive, localMediaStatus, localMediaOptions, expected }) => {
                     expect(
                         selectLocalMediaShouldStartWithOptions.resultFunc(
                             appIsActive,
                             localMediaStatus,
                             localMediaOptions,
-                            isNodeSdk,
                         ),
                     ).toEqual(expected);
                 },

--- a/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
@@ -93,22 +93,20 @@ describe("roomConnectionSlice", () => {
             const x = () => oneOf(true, false);
 
             it.each`
-                appIsActive | organizationId | roomConnectionStatus | signalIdentified | localMediaStatus | isNodeSdk | expected
-                ${true}     | ${undefined}   | ${"ready"}           | ${x()}           | ${"started"}     | ${x()}    | ${false}
-                ${true}     | ${"orgId"}     | ${"ready"}           | ${true}          | ${"started"}     | ${false}  | ${true}
-                ${true}     | ${"orgId"}     | ${"connected"}       | ${x()}           | ${"started"}     | ${x()}    | ${false}
-                ${true}     | ${"orgId"}     | ${"ready"}           | ${false}         | ${"starting"}    | ${x()}    | ${false}
-                ${true}     | ${"orgId"}     | ${"ready"}           | ${x()}           | ${"error"}       | ${false}  | ${false}
-                ${true}     | ${"orgId"}     | ${"ready"}           | ${true}          | ${"error"}       | ${true}   | ${true}
+                appIsActive | organizationId | roomConnectionStatus | signalIdentified | localMediaStatus | expected
+                ${true}     | ${undefined}   | ${"ready"}           | ${x()}           | ${"started"}     | ${false}
+                ${true}     | ${"orgId"}     | ${"ready"}           | ${true}          | ${"started"}     | ${true}
+                ${true}     | ${"orgId"}     | ${"connected"}       | ${x()}           | ${"started"}     | ${false}
+                ${true}     | ${"orgId"}     | ${"ready"}           | ${false}         | ${"starting"}    | ${false}
+                ${true}     | ${"orgId"}     | ${"ready"}           | ${x()}           | ${"error"}       | ${false}
             `(
-                "Should return $expected when appIsActive=$appIsActive, organizationId=$organizationId, roomConnectionStatus=$roomConnectionStatus, signalIdentified=$signalIdentified, localMediaStatus=$localMediaStatus, isNodeSdk=$isNodeSdk",
+                "Should return $expected when appIsActive=$appIsActive, organizationId=$organizationId, roomConnectionStatus=$roomConnectionStatus, signalIdentified=$signalIdentified, localMediaStatus=$localMediaStatus",
                 ({
                     appIsActive,
                     organizationId,
                     roomConnectionStatus,
                     signalIdentified,
                     localMediaStatus,
-                    isNodeSdk,
                     expected,
                 }) => {
                     expect(
@@ -118,7 +116,6 @@ describe("roomConnectionSlice", () => {
                             roomConnectionStatus,
                             signalIdentified,
                             localMediaStatus,
-                            isNodeSdk,
                         ),
                     ).toEqual(expected);
                 },

--- a/packages/core/src/redux/slices/app.ts
+++ b/packages/core/src/redux/slices/app.ts
@@ -28,7 +28,7 @@ export interface AppState {
     initialConfig?: AppConfig;
 }
 
-const initialState: AppState = {
+export const initialState: AppState = {
     isNodeSdk: false,
     isActive: false,
     roomName: null,

--- a/packages/core/src/redux/slices/localMedia.ts
+++ b/packages/core/src/redux/slices/localMedia.ts
@@ -3,7 +3,7 @@ import { getStream, getUpdatedDevices, getDeviceData } from "@whereby.com/media"
 import { createAppAsyncThunk, createAppThunk } from "../thunk";
 import { RootState } from "../store";
 import { createReactor, startAppListening } from "../listenerMiddleware";
-import { doAppStart, selectAppIsNodeSdk, selectAppIsActive } from "./app";
+import { doAppStart, selectAppIsActive } from "./app";
 import { debounce } from "../../utils";
 import { signalEvents } from "./signalConnection/actions";
 
@@ -613,9 +613,8 @@ export const selectLocalMediaShouldStartWithOptions = createSelector(
     selectAppIsActive,
     selectLocalMediaStatus,
     selectLocalMediaOptions,
-    selectAppIsNodeSdk,
-    (appIsActive, localMediaStatus, localMediaOptions, isNodeSdk) => {
-        if (appIsActive && ["inactive", "stopped"].includes(localMediaStatus) && !isNodeSdk && localMediaOptions) {
+    (appIsActive, localMediaStatus, localMediaOptions) => {
+        if (appIsActive && ["inactive", "stopped"].includes(localMediaStatus) && localMediaOptions) {
             return localMediaOptions;
         }
     },

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -9,7 +9,6 @@ import {
     selectAppRoomName,
     selectAppUserAgent,
     selectAppExternalId,
-    selectAppIsNodeSdk,
     selectAppIsActive,
 } from "./app";
 import { selectRoomKey, setRoomKey } from "./authorization";
@@ -230,7 +229,6 @@ export const selectShouldConnectRoom = createSelector(
         selectRoomConnectionStatus,
         selectSignalConnectionDeviceIdentified,
         selectLocalMediaStatus,
-        selectAppIsNodeSdk,
     ],
     (
         appIsActive,
@@ -238,11 +236,10 @@ export const selectShouldConnectRoom = createSelector(
         roomConnectionStatus,
         signalConnectionDeviceIdentified,
         localMediaStatus,
-        isNodeSdk,
     ) => {
         if (
             appIsActive &&
-            (localMediaStatus === "started" || isNodeSdk) &&
+            localMediaStatus === "started" &&
             signalConnectionDeviceIdentified &&
             !!hasOrganizationIdFetched &&
             ["ready", "reconnecting", "disconnected"].includes(roomConnectionStatus)


### PR DESCRIPTION
This is causing issues with the dial in worker, so let's instead add
polyfills on that side to make it work more like the browser, rather
than altering the sdk behaviour

-------

### Description
When I tried newer /core versions with the Dial In agent (it was on 0.9.1) it didn't like all the rejoin functionality we've added here.

Instead I figured it's nicer to make the node clients work as similarly to browser clients as possible, so I've polyfilled the required functionality on the node agent side and we can remove it from here

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
I've got a PR here updating the node agents: https://github.com/whereby/recording-service/pull/419
It shouldn't effect browser clients at all
<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->