### PR TITLE
Handle cam track ended event

### DIFF
--- a/.changeset/small-walls-jog.md
+++ b/.changeset/small-walls-jog.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Handle cam track ended event

--- a/packages/media/src/webrtc/rtcManagerEvents.ts
+++ b/packages/media/src/webrtc/rtcManagerEvents.ts
@@ -8,6 +8,7 @@ export default {
     ICE_RESTART: "ice_restart",
     MICROPHONE_NOT_WORKING: "microphone_not_working",
     MICROPHONE_STOPPED_WORKING: "microphone_stopped_working",
+    CAMERA_STOPPED_WORKING: "camera_stopped_working",
     NEW_PC: "new_pc",
     SFU_CONNECTION_OPEN: "sfu_connection_open",
     SFU_CONNECTION_CLOSED: "sfu_connection_closed",

--- a/packages/media/src/webrtc/types.ts
+++ b/packages/media/src/webrtc/types.ts
@@ -21,7 +21,7 @@ export interface RtcManager {
     addNewStream(streamId: string, stream: MediaStream, isAudioEnabled: boolean, isVideoEnabled: boolean): void;
     disconnect(streamId: string, activeBreakout: boolean | null, eventClaim?: string): void;
     disconnectAll(): void;
-    replaceTrack(oldTrack: MediaStreamTrack, newTrack: MediaStreamTrack): void;
+    replaceTrack(oldTrack: CustomMediaStreamTrack, newTrack: CustomMediaStreamTrack): void;
     removeStream(streamId: string, _stream: MediaStream, requestedByClientId: string | null): void;
     shouldAcceptStreamsFromBothSides?: () => boolean;
     updateStreamResolution(streamId: string, ignored: null, resolution: { width: number; height: number }): void;
@@ -135,3 +135,7 @@ export type GetDeviceDataResult = {
         kind: string;
     };
 };
+
+export interface CustomMediaStreamTrack extends MediaStreamTrack {
+    replacement?: boolean,
+}


### PR DESCRIPTION
### Description

**Summary:**
* monitor cam track for ended event
* set delay for turning of cam to 0 ms when disabling cam and the track has ended
<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
