### PR TITLE
browser-sdk: add 'grant_device_permission' embed event

### DIFF
--- a/.changeset/funny-lies-end.md
+++ b/.changeset/funny-lies-end.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": patch
+---
+
+Add a grant_device_permission event to embed element

--- a/packages/browser-sdk/src/lib/embed/index.ts
+++ b/packages/browser-sdk/src/lib/embed/index.ts
@@ -90,6 +90,7 @@ interface WherebyEmbedElementEventMap {
     chat_toggle: CustomEvent<{ open: boolean }>;
     people_toggle: CustomEvent<{ open: boolean }>;
     pip_toggle: CustomEvent<{ open: boolean }>;
+    grant_device_permission: CustomEvent<{ granted: boolean}>;
     deny_device_permission: CustomEvent<{ denied: boolean }>;
     screenshare_toggle: CustomEvent<{ enabled: boolean }>;
     streaming_status_change: CustomEvent<{ status: string }>;

--- a/packages/browser-sdk/src/stories/prebuilt-ui.stories.tsx
+++ b/packages/browser-sdk/src/stories/prebuilt-ui.stories.tsx
@@ -79,17 +79,25 @@ const WherebyEmbed = ({
     const elmRef = useRef<WherebyEmbedElement>(null);
     const [cameraEnabled, setCameraEnabled] = useState(video);
     const [meetingEnded, setMeetingEnded] = useState(false);
+    const [grantedDevicePermissions, setGrantedDevicePermissions] = useState(false);
 
     useEffect(() => {
         const element = elmRef.current;
 
         element?.addEventListener("camera_toggle", (e) => {
             const cameraEnabled = e.detail.enabled;
+            console.log(cameraEnabled);
             setCameraEnabled(cameraEnabled);
         });
 
         element?.addEventListener("meeting_end", () => {
             setMeetingEnded(true);
+        });
+
+        element?.addEventListener("grant_device_permission", (e) => {
+            const grantedDevicePermissions = e.detail.granted;
+            console.log(grantedDevicePermissions);
+            setGrantedDevicePermissions(true);
         });
     }, []);
 
@@ -97,6 +105,7 @@ const WherebyEmbed = ({
         <p>
             <p>Camera: {cameraEnabled ? "ENABLED" : "DISABLED"}</p>
             <p>Meeting ended: {meetingEnded ? "TRUE" : "FALSE"}</p>
+            <p>Camera is allowed: {grantedDevicePermissions ? "Allowed" : "Denied"}</p>
             <whereby-embed
                 audio={offOn(audio)}
                 avatarUrl={avatarUrl}

--- a/packages/browser-sdk/src/stories/prebuilt-ui.stories.tsx
+++ b/packages/browser-sdk/src/stories/prebuilt-ui.stories.tsx
@@ -86,7 +86,6 @@ const WherebyEmbed = ({
 
         element?.addEventListener("camera_toggle", (e) => {
             const cameraEnabled = e.detail.enabled;
-            console.log(cameraEnabled);
             setCameraEnabled(cameraEnabled);
         });
 

--- a/packages/browser-sdk/src/stories/prebuilt-ui.stories.tsx
+++ b/packages/browser-sdk/src/stories/prebuilt-ui.stories.tsx
@@ -95,7 +95,6 @@ const WherebyEmbed = ({
 
         element?.addEventListener("grant_device_permission", (e) => {
             const grantedDevicePermissions = e.detail.granted;
-            console.log(grantedDevicePermissions);
             setGrantedDevicePermissions(true);
         });
     }, []);

--- a/packages/browser-sdk/src/stories/prebuilt-ui.stories.tsx
+++ b/packages/browser-sdk/src/stories/prebuilt-ui.stories.tsx
@@ -79,7 +79,6 @@ const WherebyEmbed = ({
     const elmRef = useRef<WherebyEmbedElement>(null);
     const [cameraEnabled, setCameraEnabled] = useState(video);
     const [meetingEnded, setMeetingEnded] = useState(false);
-    const [grantedDevicePermissions, setGrantedDevicePermissions] = useState(false);
 
     useEffect(() => {
         const element = elmRef.current;
@@ -93,17 +92,12 @@ const WherebyEmbed = ({
             setMeetingEnded(true);
         });
 
-        element?.addEventListener("grant_device_permission", (e) => {
-            const grantedDevicePermissions = e.detail.granted;
-            setGrantedDevicePermissions(true);
-        });
     }, []);
 
     return (
         <p>
             <p>Camera: {cameraEnabled ? "ENABLED" : "DISABLED"}</p>
             <p>Meeting ended: {meetingEnded ? "TRUE" : "FALSE"}</p>
-            <p>Camera is allowed: {grantedDevicePermissions ? "Allowed" : "Denied"}</p>
             <whereby-embed
                 audio={offOn(audio)}
                 avatarUrl={avatarUrl}


### PR DESCRIPTION
### Description

Creates an event for "grant_device_permissions" when a user successfully allows device permissions

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

Creates an event for "grant_device_permissions" when a user successfully allows device permissions

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

This is a type change, unit tests are included in [PWA4125](https://github.com/whereby/pwa/pull/4125).

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ x] My code follows the project's coding standards.
-   [x ] Prefixed the PR title and commit messages with the service or package name
-   [ x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
