### PR TITLE
media: Fix issue with stream resolution on SFU

### DIFF
--- a/.changeset/two-cherries-begin.md
+++ b/.changeset/two-cherries-begin.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Fix issue where stream resolution is not set, as the consumer is not ready at the time resolution is reported.


### PR DESCRIPTION
### Description
In many cases, `updateStreamResolution` is called before the consumer is ready. In order to avoid the integrating application needing to be aware of consumer state, we now keep track of streamId and resolution and apply the correct simulcast layer when the consumer is ready.

### Testing

Will provide a PWA PR with manual test instructions.

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
