### PR TITLE
Handle senders without track when replacing tracks in P2P

### DIFF
--- a/.changeset/new-humans-smile.md
+++ b/.changeset/new-humans-smile.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Handle senders without tracks when replacing tracks


### PR DESCRIPTION
### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->
We iterate over all RTCRtpSenders. We expect all to have a track but the track attribute is null if the sender is not transmitting. https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/track

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
