### PR TITLE
core: add isDialIn property to the app config

### DIFF
--- a/.changeset/seven-jobs-repeat.md
+++ b/.changeset/seven-jobs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": minor
+---
+
+Add isDialIn property to the app config

--- a/packages/core/src/redux/slices/__tests__/app.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/app.unit.ts
@@ -6,6 +6,7 @@ describe("appSlice", () => {
             it("should change the state", () => {
                 const initialConfig = {
                     isNodeSdk: true,
+                    isDialIn: true,
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",
                     displayName: "displayName",
@@ -17,6 +18,7 @@ describe("appSlice", () => {
 
                 expect(result).toEqual({
                     isActive: true,
+                    isDialIn: true,
                     roomName: "/roomName",
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",
@@ -41,6 +43,7 @@ describe("appSlice", () => {
 
                 expect(result).toEqual({
                     isActive: true,
+                    isDialIn: false,
                     roomName: "/roomName",
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",

--- a/packages/core/src/redux/slices/app.ts
+++ b/packages/core/src/redux/slices/app.ts
@@ -9,6 +9,7 @@ import { coreVersion } from "../../version";
 
 export interface AppConfig {
     isNodeSdk?: boolean;
+    isDialIn?: boolean;
     displayName: string;
     localMediaOptions?: LocalMediaOptions;
     roomKey: string | null;
@@ -20,6 +21,7 @@ export interface AppConfig {
 export interface AppState {
     isNodeSdk: boolean;
     isActive: boolean;
+    isDialIn: boolean;
     roomUrl: string | null;
     roomName: string | null;
     displayName: string | null;
@@ -31,6 +33,7 @@ export interface AppState {
 export const initialState: AppState = {
     isNodeSdk: false,
     isActive: false,
+    isDialIn: false,
     roomName: null,
     roomUrl: null,
     displayName: null,
@@ -71,6 +74,7 @@ export const { doAppStop, doAppStart } = appSlice.actions;
 
 export const selectAppRaw = (state: RootState) => state.app;
 export const selectAppIsActive = (state: RootState) => state.app.isActive;
+export const selectAppIsDialIn = (state: RootState) => state.app.isDialIn;
 export const selectAppRoomName = (state: RootState) => state.app.roomName;
 export const selectAppRoomUrl = (state: RootState) => state.app.roomUrl;
 export const selectAppDisplayName = (state: RootState) => state.app.displayName;

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -10,6 +10,7 @@ import {
     selectAppUserAgent,
     selectAppExternalId,
     selectAppIsActive,
+    selectAppIsDialIn,
 } from "./app";
 import { selectRoomKey, setRoomKey } from "./authorization";
 
@@ -148,6 +149,7 @@ export const doKnockRoom = createAppThunk(() => (dispatch, getState) => {
     const roomName = selectAppRoomName(state);
     const roomKey = selectRoomKey(state);
     const displayName = selectAppDisplayName(state);
+    const isDialIn = selectAppIsDialIn(state);
     const userAgent = selectAppUserAgent(state);
     const externalId = selectAppExternalId(state);
     const organizationId = selectOrganizationId(state);
@@ -161,6 +163,7 @@ export const doKnockRoom = createAppThunk(() => (dispatch, getState) => {
         deviceCapabilities: { canScreenshare: true },
         displayName,
         isCoLocated: false,
+        isDialIn,
         isDevicePermissionDenied: false,
         kickFromOtherRooms: false,
         organizationId,
@@ -181,6 +184,7 @@ export const doConnectRoom = createAppThunk(() => (dispatch, getState) => {
     const displayName = selectAppDisplayName(state);
     const userAgent = selectAppUserAgent(state);
     const externalId = selectAppExternalId(state);
+    const isDialIn = selectAppIsDialIn(state);
     const organizationId = selectOrganizationId(state);
     const isCameraEnabled = selectIsCameraEnabled(getState());
     const isMicrophoneEnabled = selectIsMicrophoneEnabled(getState());
@@ -195,6 +199,7 @@ export const doConnectRoom = createAppThunk(() => (dispatch, getState) => {
         deviceCapabilities: { canScreenshare: true },
         displayName,
         isCoLocated: false,
+        isDialIn,
         isDevicePermissionDenied: false,
         kickFromOtherRooms: false,
         organizationId,

--- a/packages/core/src/redux/tests/store/rtcConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/rtcConnection.spec.ts
@@ -77,6 +77,7 @@ describe("actions", () => {
                         app: {
                             isNodeSdk: true,
                             isActive: false,
+                            isDialIn: false,
                             roomName: null,
                             roomUrl: null,
                             displayName: null,


### PR DESCRIPTION
### Description

**Summary:**

Extend the `AppConfig` with a `isDialIn` property. This can be used later to identify dial-in participants in the meeting.

### Testing

1. Join your room with PWA with devtools open and inspect the redux state
2. Join the room using the `core` pkg (see example app below)
3. Inspect the `new_client` message:
    * the new client's `isDialIn` should be `true` the app config's `isDialIn` was `true`
    * the new client's `isDialIn` should be `false` the app config's `isDialIn` was `false` or unspecified

### Screenshots/GIFs (if applicable)

`new_client` with dial-in enabled:

<img width="319" alt="Screenshot 2024-07-23 at 15 42 11" src="https://github.com/user-attachments/assets/07e88153-da03-4bbe-b17a-408fa3b23a04">


### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

#### Test app

Install this PR's version of the `@whereby.com/core` and use it in a React app like:

```jsx
import { useEffect, useMemo } from "react";
import { createServices, createStore, doAppStart } from "@whereby.com/core";

function App() {
    const services = createServices();
    const store = createStore({
        injectServices: services,
    });

    const appConfig = useMemo(() => {
        return {
            displayName: "Caller",
            localMediaOptions: { audio: false, video: false },
            roomKey: "<your-room-key>",
            isNodeSdk: true,
            isDialIn: true,
            externalId: null,
            roomUrl:  "https://<local-stack-address>/<roomName>",
        };
    }, []);

    useEffect(() => {
        store.dispatch(doAppStart(appConfig));
    }, [store, appConfig]);

    return (
        <div>hello</div>
    );
}

export default App;
```
