### PR TITLE
common: add isDialIn participant property

### DIFF
--- a/.changeset/short-tools-worry.md
+++ b/.changeset/short-tools-worry.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/media": minor
+"@whereby.com/core": minor
+---
+
+Add isDialIn property to room participants

--- a/packages/core/src/RoomParticipant.ts
+++ b/packages/core/src/RoomParticipant.ts
@@ -12,6 +12,7 @@ interface RoomParticipantData {
     isAudioEnabled: boolean;
     isVideoEnabled: boolean;
     stickyReaction?: StickyReaction | null;
+    isDialIn: boolean;
 }
 
 export default class RoomParticipant {
@@ -22,14 +23,24 @@ export default class RoomParticipant {
     public readonly isLocalParticipant: boolean = false;
     public readonly isVideoEnabled: boolean;
     public readonly stickyReaction?: StickyReaction | null;
+    public readonly isDialIn: boolean;
 
-    constructor({ displayName, id, stream, isAudioEnabled, isVideoEnabled, stickyReaction }: RoomParticipantData) {
+    constructor({
+        displayName,
+        id,
+        stream,
+        isAudioEnabled,
+        isVideoEnabled,
+        stickyReaction,
+        isDialIn,
+    }: RoomParticipantData) {
         this.displayName = displayName;
         this.id = id;
         this.stream = stream;
         this.isAudioEnabled = isAudioEnabled;
         this.isVideoEnabled = isVideoEnabled;
         this.stickyReaction = stickyReaction;
+        this.isDialIn = isDialIn;
     }
 }
 
@@ -65,13 +76,22 @@ export interface RemoteParticipant {
     presentationStream: (MediaStream & { inboundId?: string }) | null;
     externalId: string | null;
     stickyReaction?: StickyReaction | null;
+    isDialIn: boolean;
 }
 
 export class LocalParticipant extends RoomParticipant {
     public readonly isLocalParticipant = true;
 
-    constructor({ displayName, id, stream, isAudioEnabled, isVideoEnabled, stickyReaction }: RoomParticipantData) {
-        super({ displayName, id, stream, isAudioEnabled, isVideoEnabled, stickyReaction });
+    constructor({
+        displayName,
+        id,
+        stream,
+        isAudioEnabled,
+        isVideoEnabled,
+        stickyReaction,
+        isDialIn,
+    }: RoomParticipantData) {
+        super({ displayName, id, stream, isAudioEnabled, isVideoEnabled, stickyReaction, isDialIn });
     }
 }
 

--- a/packages/core/src/__mocks__/appMocks.ts
+++ b/packages/core/src/__mocks__/appMocks.ts
@@ -84,6 +84,7 @@ export const randomSignalClient = ({
     role = { roleName: "visitor" },
     startedCloudRecordingAt = null,
     externalId = null,
+    isDialIn = false,
 }: Partial<SignalClient> = {}): SignalClient => {
     return {
         displayName,
@@ -94,6 +95,7 @@ export const randomSignalClient = ({
         role,
         startedCloudRecordingAt,
         externalId,
+        isDialIn,
     };
 };
 
@@ -106,6 +108,7 @@ export const randomLocalParticipant = ({
     clientClaim = randomString(),
     isScreenSharing = false,
     roleName = "visitor",
+    isDialIn = false,
 }: Partial<LocalParticipantState> = {}): LocalParticipantState => {
     return {
         id,
@@ -117,6 +120,7 @@ export const randomLocalParticipant = ({
         clientClaim,
         isScreenSharing,
         roleName,
+        isDialIn,
     };
 };
 
@@ -132,6 +136,7 @@ export const randomRemoteParticipant = ({
     newJoiner = false,
     presentationStream = null,
     externalId = null,
+    isDialIn = false,
 }: Partial<RemoteParticipant> = {}): RemoteParticipant => {
     return {
         id,
@@ -145,6 +150,7 @@ export const randomRemoteParticipant = ({
         newJoiner,
         presentationStream,
         externalId,
+        isDialIn,
     };
 };
 

--- a/packages/core/src/redux/slices/__tests__/authorization.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/authorization.unit.ts
@@ -49,6 +49,7 @@ describe("authorizationSlice", () => {
                                 },
                                 startedCloudRecordingAt: null,
                                 externalId: null,
+                                isDialIn: false,
                             },
                         ],
                         knockers: [],

--- a/packages/core/src/redux/slices/__tests__/cloudRecording.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/cloudRecording.unit.ts
@@ -41,6 +41,7 @@ describe("cloudRecordingSlice", () => {
                         },
                         startedCloudRecordingAt: "2021-01-01T00:00:00.000Z",
                         externalId: null,
+                        isDialIn: false,
                     },
                 }),
             );

--- a/packages/core/src/redux/slices/__tests__/remoteParticipants.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/remoteParticipants.unit.ts
@@ -31,6 +31,7 @@ describe("remoteParticipantsSlice", () => {
                                     },
                                     startedCloudRecordingAt: null,
                                     externalId: null,
+                                    isDialIn: false,
                                 },
                             ],
                             knockers: [],
@@ -54,6 +55,7 @@ describe("remoteParticipantsSlice", () => {
                         startedCloudRecordingAt: null,
                         presentationStream: null,
                         externalId: null,
+                        isDialIn: false,
                     },
                 ]);
             });
@@ -83,6 +85,7 @@ describe("remoteParticipantsSlice", () => {
                     startedCloudRecordingAt: client.startedCloudRecordingAt,
                     presentationStream: null,
                     externalId: null,
+                    isDialIn: false,
                 },
             ]);
         });

--- a/packages/core/src/redux/slices/localParticipant.ts
+++ b/packages/core/src/redux/slices/localParticipant.ts
@@ -28,6 +28,7 @@ const initialState: LocalParticipantState = {
     roleName: "none",
     clientClaim: undefined,
     stickyReaction: undefined,
+    isDialIn: false,
 };
 
 /**

--- a/packages/media/src/utils/types.ts
+++ b/packages/media/src/utils/types.ts
@@ -55,6 +55,7 @@ export interface SignalClient {
     role: ClientRole;
     startedCloudRecordingAt: string | null;
     externalId: string | null;
+    isDialIn: boolean;
 }
 
 export interface Spotlight {


### PR DESCRIPTION
-------

### Description


**Summary:**
We added this property to the signal client, so we should add it here to
make it visible to SDK clients


<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**
https://linear.app/whereby/issue/COB-927/add-dial-in-client-property-to-browser-sdk
<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. if you haven't already, create a twilio account, buy a phone number in a convenient country, and add the account SID and auth token to your local stack config like so:
``` json
    "twilio-account-sid": "<account sid>",
    "twilio-auth-token": "<auth token>",
```
1. you'll also need an ngrok account with the auth token configured in local stack:
``` json
    "ngrok-auth-token": "<auth token>",
```
1. start local stack!
1. build the dial-in image in the recording-service repo with `yarn dial-in:build-for-local-stack`
1. enable the `dialInOn` flag for your local embedded build org
1. create a room in your local stack embedded build org with dial-in enabled like so (make sure you include the dialIn field so you get the dial in info in the response!):
```json
{
    "endDate": "2024-12-06T11:54:05.323Z",
    "isLocked": true,
    "roomMode": "normal",
    "roomNamePrefix": "dial-in-",
    "roomNamePattern": "human-short",
    "isDialInEnabled": true,
    "fields": ["dialIn"]
}
```
make note of the returned dial-in code, we'll use this to join the room from a phone:
``` json
{
      "startDate": "2024-07-31T15:30:02.766Z",
      "endDate": "2024-12-06T11:54:05.323Z",
      "roomName": "/dial-in-t7b4tf",
      "roomUrl": "https://kevin-embedded.whereby.com/dial-in-t7b4tf",
      "meetingId": "89071433",
      "dialIn": {
        "code": "5747754832",          <- Here
        "phoneNumbers": [
          {
            "countryCode": "US",
            "phoneNumber": "+1 (415) 488-8450"
          },
          {
            "countryCode": "GB",
            "phoneNumber": "+44 1433 449947"
          }
        ]
      }
    }
```
1. build this SDK branch with local-stack API and Signal addresses
1. Add your room URL to the telehealth embeded test app and `yarn dev:telehealth-app` to start it up
1. add a silly console.log message in the teleheath app's App.tsx line ~24 so we can see the list of remote participants:
``` typescript
    const { localParticipant, remoteParticipants, screenshares, chatMessages } = state;
    console.log("Remote participants", remoteParticipants);
```
1. join the room from the telehealth app in the browser
1. dial your twilio phone number, and when prompted enter the code above
1. after a few seconds you should join the room as a dial-in participant
1. check the logs of the telehealth app, you should see the remote participant has `isDialIn: true`
``` typescript
{
    "avatarUrl": "",
    "breakoutGroup": "",
    "coLocationGroup": "",
    "deviceCapabilities": {
        "canScreenshare": true
    },
    "deviceId": "9fbc5ec3-81bb-4c2f-b75a-bf2b6af84e0a",
    "displayName": "+447494875798",
    "fromDevice": null,
    "fromMethod": null,
    "id": "9b72ed9c-d665-4df5-b5a7-371038319803",
    "isAudioEnabled": true,
    "isAudioOnlyModeEnabled": false,
    "isCoLocated": false,
    "isDevicePermissionDenied": false,
    "isDialIn": true,                                <- Hurray
    "isOwner": false,
    "isRecording": false,
    "isScreenshareAudioEnabled": false,
    "isVideoEnabled": false,
    "name": "Anonymous 9b72ed9c-d665-4df5-b5a7-371038319803",
    "stickyReaction": null,
    "socketId": "ADdooaqGFJYmb9YIAhEp",
    "isPendingToLeave": false,
    "startedCloudRecordingAt": null,
    "userId": null,
    "externalMetadata": null,
    "externalId": null,
    "stream": null,
    "streams": [
        {
            "id": "0",
            "state": "new_accept"
        }
    ],
    "isLocalParticipant": false,
    "roleName": "host",
    "presentationStream": null,
    "newJoiner": true
}
```

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->