### PR TITLE
browser-sdk: open_settings command

### DIFF
--- a/.changeset/young-windows-cheat.md
+++ b/.changeset/young-windows-cheat.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": patch
+---
+
+Added command to open the settings pane

--- a/packages/browser-sdk/src/lib/embed/index.ts
+++ b/packages/browser-sdk/src/lib/embed/index.ts
@@ -3,6 +3,8 @@ import { ReactHTMLElement } from "react";
 
 import { parseRoomUrlAndSubdomain } from "@whereby.com/core";
 
+type SettingsPane = "theme" | "integrations" | "streaming" | "effects" | "notifications" | "advanced" | "media" | null;
+
 interface WherebyEmbedElementAttributes extends ReactHTMLElement<HTMLElement> {
     aec: string;
     agc: string;
@@ -85,15 +87,15 @@ interface WherebyEmbedElementEventMap {
     participantupdate: CustomEvent<{ count: number }>;
     join: CustomEvent;
     leave: CustomEvent<{ removed: boolean }>;
-    participant_join: CustomEvent<{ participant: { metadata: string | null, externalId: string | null } }>;
-    participant_leave: CustomEvent<{ participant: { metadata: string | null, externalId: string | null } }>;
+    participant_join: CustomEvent<{ participant: { metadata: string | null; externalId: string | null } }>;
+    participant_leave: CustomEvent<{ participant: { metadata: string | null; externalId: string | null } }>;
     meeting_end: CustomEvent;
     microphone_toggle: CustomEvent<{ enabled: boolean }>;
     camera_toggle: CustomEvent<{ enabled: boolean }>;
     chat_toggle: CustomEvent<{ open: boolean }>;
     people_toggle: CustomEvent<{ open: boolean }>;
     pip_toggle: CustomEvent<{ open: boolean }>;
-    grant_device_permission: CustomEvent<{ granted: boolean}>;
+    grant_device_permission: CustomEvent<{ granted: boolean }>;
     deny_device_permission: CustomEvent<{ denied: boolean }>;
     screenshare_toggle: CustomEvent<{ enabled: boolean }>;
     streaming_status_change: CustomEvent<{ status: string }>;
@@ -113,6 +115,7 @@ interface WherebyEmbedElementEventMap {
 interface WherebyEmbedElementCommands {
     endMeeting: () => void;
     leaveRoom: () => void;
+    openSettings: (settingsPane?: SettingsPane) => void;
     startRecording: () => void;
     stopRecording: () => void;
     startStreaming: () => void;
@@ -239,6 +242,9 @@ define("WherebyEmbed", {
     },
     leaveRoom() {
         this._postCommand("leave_room");
+    },
+    openSettings(settingsPane: SettingsPane = "media") {
+        this._postCommand("open_settings", [settingsPane]);
     },
     startRecording() {
         this._postCommand("start_recording");

--- a/packages/browser-sdk/src/stories/prebuilt-ui.stories.tsx
+++ b/packages/browser-sdk/src/stories/prebuilt-ui.stories.tsx
@@ -98,6 +98,9 @@ const WherebyEmbed = ({
         <p>
             <p>Camera: {cameraEnabled ? "ENABLED" : "DISABLED"}</p>
             <p>Meeting ended: {meetingEnded ? "TRUE" : "FALSE"}</p>
+            <button onClick={() => elmRef.current?.openSettings()}>
+                "Open Settings"
+            </button>
             <whereby-embed
                 audio={offOn(audio)}
                 avatarUrl={avatarUrl}


### PR DESCRIPTION
### Description

**Summary:**

This is a command for the embed element that allows developers to set up their own button to open the settings pane.

**Related Issue:**

None

### Testing

1. Create a localstack room to use in story book
2. Add a supported command for the button under sdk/packages/browser-sdk/src/stories/prebuilt-ui.stories.tsx
3. Run yarn dev and navigate to Prebuilt-UI Stories -> Embed Element Example
4. Click button, settings page should open to the defined pane

### Screenshots/GIFs (if applicable)

N/A

### Checklist

-   [x ] My code follows the project's coding standards.
-   [ x] Prefixed the PR title and commit messages with the service or package name
-   [ x] I have written unit tests (if applicable).
-   [ x] I have updated the documentation (if applicable).
-   [ x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

Supported values for this command are any of the following [theme, integrations, streaming, effects, notifications, advanced, media]
