### PR TITLE
core: do not try to connect the room when there's a roomConnectionError

### DIFF
--- a/.changeset/eighty-dolphins-float.md
+++ b/.changeset/eighty-dolphins-float.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": minor
+---
+
+Do not try to connect the room if there's a room connection error.

--- a/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/roomConnection.unit.ts
@@ -93,20 +93,22 @@ describe("roomConnectionSlice", () => {
             const x = () => oneOf(true, false);
 
             it.each`
-                appIsActive | organizationId | roomConnectionStatus | signalIdentified | localMediaStatus | expected
-                ${true}     | ${undefined}   | ${"ready"}           | ${x()}           | ${"started"}     | ${false}
-                ${true}     | ${"orgId"}     | ${"ready"}           | ${true}          | ${"started"}     | ${true}
-                ${true}     | ${"orgId"}     | ${"connected"}       | ${x()}           | ${"started"}     | ${false}
-                ${true}     | ${"orgId"}     | ${"ready"}           | ${false}         | ${"starting"}    | ${false}
-                ${true}     | ${"orgId"}     | ${"ready"}           | ${x()}           | ${"error"}       | ${false}
+                appIsActive | organizationId | roomConnectionStatus | signalIdentified | localMediaStatus | roomConnectionError | expected
+                ${true}     | ${undefined}   | ${"ready"}           | ${x()}           | ${"started"}     | ${null}             | ${false}
+                ${true}     | ${"orgId"}     | ${"ready"}           | ${true}          | ${"started"}     | ${null}             | ${true}
+                ${true}     | ${"orgId"}     | ${"connected"}       | ${x()}           | ${"started"}     | ${null}             | ${false}
+                ${true}     | ${"orgId"}     | ${"ready"}           | ${false}         | ${"starting"}    | ${null}             | ${false}
+                ${true}     | ${"orgId"}     | ${"ready"}           | ${x()}           | ${"error"}       | ${null}             | ${false}
+                ${true}     | ${"orgId"}     | ${"ready"}           | ${true}          | ${"started"}     | ${"room_full"}      | ${false}
             `(
-                "Should return $expected when appIsActive=$appIsActive, organizationId=$organizationId, roomConnectionStatus=$roomConnectionStatus, signalIdentified=$signalIdentified, localMediaStatus=$localMediaStatus",
+                "Should return $expected when appIsActive=$appIsActive, organizationId=$organizationId, roomConnectionStatus=$roomConnectionStatus, signalIdentified=$signalIdentified, localMediaStatus=$localMediaStatus, roomConnectionError=$roomConnectionError",
                 ({
                     appIsActive,
                     organizationId,
                     roomConnectionStatus,
                     signalIdentified,
                     localMediaStatus,
+                    roomConnectionError,
                     expected,
                 }) => {
                     expect(
@@ -116,6 +118,7 @@ describe("roomConnectionSlice", () => {
                             roomConnectionStatus,
                             signalIdentified,
                             localMediaStatus,
+                            roomConnectionError,
                         ),
                     ).toEqual(expected);
                 },

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -234,6 +234,7 @@ export const selectShouldConnectRoom = createSelector(
         selectRoomConnectionStatus,
         selectSignalConnectionDeviceIdentified,
         selectLocalMediaStatus,
+        selectRoomConnectionError,
     ],
     (
         appIsActive,
@@ -241,13 +242,15 @@ export const selectShouldConnectRoom = createSelector(
         roomConnectionStatus,
         signalConnectionDeviceIdentified,
         localMediaStatus,
+        roomConnectionError,
     ) => {
         if (
             appIsActive &&
             localMediaStatus === "started" &&
             signalConnectionDeviceIdentified &&
             !!hasOrganizationIdFetched &&
-            ["ready", "reconnecting", "disconnected"].includes(roomConnectionStatus)
+            ["ready", "reconnecting", "disconnected"].includes(roomConnectionStatus) &&
+            !roomConnectionError
         ) {
             return true;
         }


### PR DESCRIPTION
### Description

**Summary:**

Extend the `selectShouldConnectRoom` to check if there's a room connection error and return `false` if there is. This should prevent the `join_room` loop if the room is full.

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

1. Join your `normal` size room as a host
2. Fill the `.env` file with your local-stack endpoints to test against local-stack
3. Build things `yarn build`
5. Start the sample app: `yarn dev:sample-app`
6. Join the room with 3 participants => should be ok
7. Try to join with the 4th participant with devtools > network > ws socket logs open. => gets a `disconnected` status and there's no sign of infinite `join_room` call loop in the ws messages.

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

There are scenarios where the `join_room` gets an error. One of them is `room_full`, but the reason can be the free trial experied, or meeting exhausted (i.e. time limit reached) or missing host, etc. As I see, currently this error state is not exposed in the `useRoomConnection`'s `state`. This is something we can/could improve.