### PR TITLE
common: Split package names on comma instead of newline in slack mess…

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -19,7 +19,7 @@ runs:
           env:
               JSON: ${{ inputs.published_packages }}
           run: |
-              PACKAGES=$(echo "$JSON" | jq -r 'map(.name + "@" + .version) | join("\n")')
+              PACKAGES=$(echo "$JSON" | jq -r 'map(.name + "@" + .version) | join(", ")')
               echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
 
         - name: Send slack message


### PR DESCRIPTION
…age action

### Description

Should fix the failing pipeline whenever 2 or more packages are released. Splitting on comma instead of newline.

Output:
```bash
PACKAGES=$(echo "$JSON" | jq -r 'map(.name + "@" + .version) | join(", ")')

@whereby.com/browser-sdk@3.5.0, @whereby.com/core@0.23.0
```


**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
