### PR TITLE
Handle headerbytes missing in rtcstatsreport

### DIFF
--- a/.changeset/eighty-crews-care.md
+++ b/.changeset/eighty-crews-care.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Handle headerBytes missing from rtcstatsreport

--- a/packages/media/src/webrtc/stats/StatsMonitor/metrics.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/metrics.ts
@@ -94,8 +94,11 @@ export function captureCommonSsrcMetrics(
 
         const byteCountDiff = currentSsrcStats.bytesReceived - (prevSsrcStats?.bytesReceived || 0);
         ssrcMetrics.byteCount = (ssrcMetrics.byteCount || 0) + byteCountDiff;
-        const headerByteCountDiff = currentSsrcStats.headerBytesReceived - (prevSsrcStats?.headerBytesReceived || 0);
-        ssrcMetrics.headerByteCount = (ssrcMetrics.headerByteCount || 0) + headerByteCountDiff;
+        let headerByteCountDiff = 0;
+        if (currentSsrcStats.headerBytesReceived) {
+            headerByteCountDiff = currentSsrcStats.headerBytesReceived - (prevSsrcStats?.headerBytesReceived || 0);
+            ssrcMetrics.headerByteCount = (ssrcMetrics.headerByteCount || 0) + headerByteCountDiff;
+        }
         const totalBytesDiff = byteCountDiff + headerByteCountDiff;
         ssrcMetrics.bitrate = (8000 * totalBytesDiff) / timeDiff;
         ssrcMetrics.mediaRatio = byteCountDiff / totalBytesDiff;
@@ -117,8 +120,11 @@ export function captureCommonSsrcMetrics(
 
         const byteCountDiff = currentSsrcStats.bytesSent - (prevSsrcStats?.bytesSent || 0);
         ssrcMetrics.byteCount = (ssrcMetrics.byteCount || 0) + byteCountDiff;
-        const headerByteCountDiff = currentSsrcStats.headerBytesSent - (prevSsrcStats?.headerBytesSent || 0);
-        ssrcMetrics.headerByteCount = (ssrcMetrics.headerByteCount || 0) + headerByteCountDiff;
+        let headerByteCountDiff = 0;
+        if (currentSsrcStats.headerBytesSent) {
+            headerByteCountDiff = currentSsrcStats.headerBytesSent - (prevSsrcStats?.headerBytesSent || 0);
+            ssrcMetrics.headerByteCount = (ssrcMetrics.headerByteCount || 0) + headerByteCountDiff;
+        }
         const totalBytesDiff = byteCountDiff + headerByteCountDiff;
         ssrcMetrics.bitrate = (8000 * totalBytesDiff) / timeDiff;
         ssrcMetrics.mediaRatio = byteCountDiff / totalBytesDiff;


### PR DESCRIPTION
### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->
This handles the case when headerBytes is missing in RTCStatsReport. Without this change, bitrate will be calculated as NaN in some browsers and our issue detectors don't work.

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
