### PR TITLE
Fix P2P SDP negotiation with non-human-role clients

### DIFF
--- a/.changeset/nine-maps-appear.md
+++ b/.changeset/nine-maps-appear.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": patch
+---
+
+Avoid filtering out non-human-role clients in remoteclients state

--- a/packages/core/src/redux/slices/remoteParticipants.ts
+++ b/packages/core/src/redux/slices/remoteParticipants.ts
@@ -211,10 +211,7 @@ export const remoteParticipantsSlice = createSlice({
 
             return {
                 ...state,
-                remoteParticipants: clients
-                    .filter((c) => c.id !== selfId)
-                    .filter((c) => !NON_PERSON_ROLES.includes(c.role.roleName))
-                    .map((c) => createRemoteParticipant(c)),
+                remoteParticipants: clients.filter((c) => c.id !== selfId).map((c) => createRemoteParticipant(c)),
             };
         });
         builder.addCase(rtcEvents.streamAdded, (state, action) => {
@@ -222,10 +219,6 @@ export const remoteParticipantsSlice = createSlice({
         });
         builder.addCase(signalEvents.newClient, (state, action) => {
             const { client } = action.payload;
-
-            if (NON_PERSON_ROLES.includes(client.role.roleName)) {
-                return state;
-            }
 
             return addParticipant(state, createRemoteParticipant(client, true));
         });
@@ -305,6 +298,10 @@ export const doRequestAudioEnable = createAppAuthorizedThunk(
  */
 
 export const selectRemoteParticipantsRaw = (state: RootState) => state.remoteParticipants;
+
+/**
+ * This includes non human roles such as recorder.
+ */
 export const selectRemoteClients = (state: RootState) => state.remoteParticipants.remoteParticipants;
 
 export const selectRemoteParticipants = createSelector(selectRemoteClients, (clients) =>


### PR DESCRIPTION
### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->
We need to keep remote clients with non-human-roles in our remote state. For instance, we need to ask them for an SDP offer in P2P or a PeerConnection wont be established.

closes #359 

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
