### PR TITLE
react-native-sdk: Add Android media permission example to RN demo app

### DIFF
--- a/apps/react-native-webview-example/app/room/index.tsx
+++ b/apps/react-native-webview-example/app/room/index.tsx
@@ -1,16 +1,40 @@
 import * as React from "react";
-import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { ScrollView, StyleSheet, Text, View, Alert, Platform } from "react-native";
 import { WherebyEmbed, WherebyEmbedRef } from "@whereby.com/react-native-sdk/embed";
+import { Audio } from "expo-av";
+import { Camera } from 'expo-camera';
+
 const ROOM_URL = "";
 
 export default function Room() {
     const wherebyRoomRef = React.useRef<WherebyEmbedRef>(null);
     const scrollRef = React.useRef<ScrollView>(null);
     const [eventLogEntries, setEventLogEntries] = React.useState<any[]>([]);
+    const [hasPermissionForAndroid, setHasPermissionForAndroid] = React.useState<boolean>(false);
 
     function handleWherebyEvent(event: any) {
         setEventLogEntries((prev) => [...prev, event]);
         scrollRef.current?.scrollToEnd({ animated: true });
+    }
+
+    React.useEffect(() => {
+        (async () => {
+            if (Platform.OS === 'android') {
+                const cameraStatus = await Camera.requestCameraPermissionsAsync();
+                const audioStatus = await Audio.requestPermissionsAsync();
+
+                if (cameraStatus.status === 'granted' && audioStatus.status === 'granted') {
+                    setHasPermissionForAndroid(true);
+                } else {
+                    Alert.alert("Permissions Required", "Camera and microphone permissions are required.");
+                    setHasPermissionForAndroid(false);
+                }
+            }
+        })();
+    }, []);
+
+    if (Platform.OS === 'android' && !hasPermissionForAndroid) {
+        return <View />;
     }
 
     return (

--- a/apps/react-native-webview-example/package.json
+++ b/apps/react-native-webview-example/package.json
@@ -18,6 +18,8 @@
     "@react-navigation/native": "^6.0.2",
     "@whereby.com/react-native-sdk": "*",
     "expo": "^51.0.31",
+    "expo-av": "~14.0.7",
+    "expo-camera": "~15.0.15",
     "expo-constants": "~16.0.2",
     "expo-font": "~12.0.9",
     "expo-linking": "~6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10276,6 +10276,18 @@ expo-asset@~10.0.10:
     invariant "^2.2.4"
     md5-file "^3.2.3"
 
+expo-av@~14.0.7:
+  version "14.0.7"
+  resolved "https://registry.yarnpkg.com/expo-av/-/expo-av-14.0.7.tgz#deb967325e58b2c4d408f5d76a7ccb269442cba1"
+  integrity sha512-FvKZxyy+2/qcCmp+e1GTK3s4zH8ZO1RfjpqNxh7ARlS1oH8HPtk1AyZAMo52tHz3yQ3UIqxQ2YbI9CFb4065lA==
+
+expo-camera@~15.0.15:
+  version "15.0.15"
+  resolved "https://registry.yarnpkg.com/expo-camera/-/expo-camera-15.0.15.tgz#2959963b65219ca5d101327b3298b4170a4e107b"
+  integrity sha512-zJS0rfOwGfyDrccMsFaLH9s0mW0f6czw+W+RHvbyAdAmoAh6ZtzZRGbosKIYoRsn/8L7ajNp01seJUjsT0FtzA==
+  dependencies:
+    invariant "^2.2.4"
+
 expo-constants@~16.0.0, expo-constants@~16.0.2:
   version "16.0.2"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-16.0.2.tgz#eb5a1bddb7308fd8cadac8fc44decaf4784cac5e"


### PR DESCRIPTION
### Description

**Summary:**
Add brief example on how to explicitly handle media permissions on Android platform, from the host (demo) app. 
No changeset added since this touches the demo app only. 

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
Initial step: Set the `ROOM_URL` in `apps/react-native-webview-example/app/room/index.tsx`
1. Using an Android device: try to join the room using current master branch and confirm that the screen is stuck when asking for permissions. Checkout this current branch and re-run the app: now the permissions are explicitly granted and you are able to join the room normally. 
2. Confirm that the iOS app is not affected and you are still able to join a room normally. 


<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
