### PR TITLE
react-native-sdk: Add event listeners for Whereby events

### DIFF
--- a/.changeset/fuzzy-terms-prove.md
+++ b/.changeset/fuzzy-terms-prove.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/react-native-sdk": minor
+---
+
+Add event listeners


### PR DESCRIPTION
### Description

Adds event listeners for events happening in the room. There's a catch-all listener `onWherebyEvent`, that will trigger on any Whereby event, and there's specific listeners for each one, like `onReady` for example. All of them are typed, and we expose the `WherebyEvent` type as well, so that it can be used (see the react native example app for example usage).

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

Test by running the react native example app, and see the event log.

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
