### PR TITLE
react-native-sdk: Add post commands

### DIFF
--- a/.changeset/strong-nails-boil.md
+++ b/.changeset/strong-nails-boil.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/react-native-sdk": minor
+---
+
+Add post commands

--- a/apps/react-native-webview-example/app/room/index.tsx
+++ b/apps/react-native-webview-example/app/room/index.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
-import { ScrollView, StyleSheet, Text, View, Alert, Platform } from "react-native";
+import { ScrollView, StyleSheet, Text, View, Alert, Platform, Button } from "react-native";
 import { Audio } from "expo-av";
 import { Camera } from "expo-camera";
-import { WherebyEmbed, WherebyEmbedRef, WherebyEvent } from "@whereby.com/react-native-sdk/embed";
+import { WherebyEmbed, type WherebyWebView, WherebyEvent } from "@whereby.com/react-native-sdk/embed";
 
 const ROOM_URL = "";
 
 export default function Room() {
-    const wherebyRoomRef = React.useRef<WherebyEmbedRef>(null);
+    const wherebyRoomRef = React.useRef<WherebyWebView>(null);
     const scrollRef = React.useRef<ScrollView>(null);
     const [hasPermissionForAndroid, setHasPermissionForAndroid] = React.useState<boolean>(false);
     const [eventLogEntries, setEventLogEntries] = React.useState<WherebyEvent[]>([]);
@@ -46,6 +46,24 @@ export default function Room() {
                     </Text>
                 ))}
             </ScrollView>
+            <Button
+                onPress={() => {
+                    wherebyRoomRef.current?.knock();
+                }}
+                title="Knock"
+            />
+            <Button
+                onPress={() => {
+                    wherebyRoomRef.current?.openSettings("advanced");
+                }}
+                title="Open Settings"
+            />
+            <Button
+                onPress={() => {
+                    wherebyRoomRef.current?.toggleMicrophone();
+                }}
+                title="Toggle Microphone"
+            />
             <View style={{ flex: 1, height: "100%" }}>
                 <WherebyEmbed
                     ref={wherebyRoomRef}


### PR DESCRIPTION
### Description

Add the post commands to react native SDK. Allows for commands to be triggered on the consumer react native app. 
Added 3 buttons in the example app to make it easy to test. We can remove some of them if it's too much.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

1. `yarn build` and run the react native example app
2. Test the new buttons

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
