### PR TITLE
Enforce TURN for dial-in peer connections

### DIFF
--- a/.changeset/lemon-socks-promise.md
+++ b/.changeset/lemon-socks-promise.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": patch
+---
+
+Enforce turn tls for dial-in peerconnections

--- a/.changeset/two-yaks-fly.md
+++ b/.changeset/two-yaks-fly.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Add property to acceptnewstream interface

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -189,6 +189,7 @@ export const doConnectRtc = createAppThunk(() => (dispatch, getState) => {
         serverSocket: socket,
         webrtcProvider,
         features: {
+            isNodeSdk,
             lowDataModeEnabled: false,
             sfuServerOverrideHost: undefined,
             turnServerOverrideHost: undefined,
@@ -234,11 +235,13 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
             (state === "new_accept" && shouldAcceptNewClients) ||
             (state === "old_accept" && !shouldAcceptNewClients) // these are done to enable broadcast in legacy/p2p
         ) {
+            const enforceTurnProtocol = participant.isDialIn ? "onlytls" : undefined;
             rtcManager.acceptNewStream({
                 streamId: streamId === "0" ? clientId : streamId,
                 clientId,
                 shouldAddLocalVideo: streamId === "0",
                 activeBreakout,
+                enforceTurnProtocol,
             });
         } else if (state === "new_accept" || state === "old_accept") {
             // do nothing - let this be marked as done_accept as the rtcManager

--- a/packages/media/src/webrtc/types.ts
+++ b/packages/media/src/webrtc/types.ts
@@ -1,3 +1,5 @@
+import { TurnTransportProtocol } from "../utils";
+
 /* 
     RTC
 */
@@ -12,11 +14,13 @@ export interface RtcManager {
         clientId,
         shouldAddLocalVideo,
         streamId,
+        enforceTurnProtocol
     }: {
         activeBreakout: boolean;
         clientId: string;
         shouldAddLocalVideo: boolean;
         streamId: string;
+        enforceTurnProtocol?: TurnTransportProtocol
     }) => void;
     addNewStream(streamId: string, stream: MediaStream, isAudioEnabled: boolean, isVideoEnabled: boolean): void;
     disconnect(streamId: string, activeBreakout: boolean | null, eventClaim?: string): void;


### PR DESCRIPTION
### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->
* if we are an Node.JS SDK app, let RtcManager know so we can customise ICE negotiation.
* if remote participant is dial-in, enforce TURN TLS. Will be changed to TURN UDP in RtcManager if we are an Node.JS SDK app.

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
