### PR TITLE
media: enforce onlyudp for all nodejs clients

### DIFF
--- a/.changeset/sour-kiwis-guess.md
+++ b/.changeset/sour-kiwis-guess.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/media": minor
+"@whereby.com/core": minor
+---
+
+Enforce onlyudp tuurn for all nodejs clients

--- a/packages/core/src/RoomParticipant.ts
+++ b/packages/core/src/RoomParticipant.ts
@@ -13,6 +13,7 @@ interface RoomParticipantData {
     isVideoEnabled: boolean;
     stickyReaction?: StickyReaction | null;
     isDialIn: boolean;
+    isNodeSdk: boolean;
 }
 
 export default class RoomParticipant {
@@ -24,6 +25,7 @@ export default class RoomParticipant {
     public readonly isVideoEnabled: boolean;
     public readonly stickyReaction?: StickyReaction | null;
     public readonly isDialIn: boolean;
+    public readonly isNodeSdk: boolean;
 
     constructor({
         displayName,
@@ -33,6 +35,7 @@ export default class RoomParticipant {
         isVideoEnabled,
         stickyReaction,
         isDialIn,
+        isNodeSdk,
     }: RoomParticipantData) {
         this.displayName = displayName;
         this.id = id;
@@ -41,6 +44,7 @@ export default class RoomParticipant {
         this.isVideoEnabled = isVideoEnabled;
         this.stickyReaction = stickyReaction;
         this.isDialIn = isDialIn;
+        this.isNodeSdk = isNodeSdk;
     }
 }
 
@@ -77,6 +81,7 @@ export interface RemoteParticipant {
     externalId: string | null;
     stickyReaction?: StickyReaction | null;
     isDialIn: boolean;
+    isNodeSdk: boolean;
 }
 
 export class LocalParticipant extends RoomParticipant {
@@ -90,8 +95,9 @@ export class LocalParticipant extends RoomParticipant {
         isVideoEnabled,
         stickyReaction,
         isDialIn,
+        isNodeSdk,
     }: RoomParticipantData) {
-        super({ displayName, id, stream, isAudioEnabled, isVideoEnabled, stickyReaction, isDialIn });
+        super({ displayName, id, stream, isAudioEnabled, isVideoEnabled, stickyReaction, isDialIn, isNodeSdk });
     }
 }
 

--- a/packages/core/src/__mocks__/appMocks.ts
+++ b/packages/core/src/__mocks__/appMocks.ts
@@ -85,6 +85,7 @@ export const randomSignalClient = ({
     startedCloudRecordingAt = null,
     externalId = null,
     isDialIn = false,
+    isNodeSdk = false,
 }: Partial<SignalClient> = {}): SignalClient => {
     return {
         displayName,
@@ -96,6 +97,7 @@ export const randomSignalClient = ({
         startedCloudRecordingAt,
         externalId,
         isDialIn,
+        isNodeSdk,
     };
 };
 
@@ -109,6 +111,7 @@ export const randomLocalParticipant = ({
     isScreenSharing = false,
     roleName = "visitor",
     isDialIn = false,
+    isNodeSdk = false,
 }: Partial<LocalParticipantState> = {}): LocalParticipantState => {
     return {
         id,
@@ -121,6 +124,7 @@ export const randomLocalParticipant = ({
         isScreenSharing,
         roleName,
         isDialIn,
+        isNodeSdk,
     };
 };
 
@@ -137,6 +141,7 @@ export const randomRemoteParticipant = ({
     presentationStream = null,
     externalId = null,
     isDialIn = false,
+    isNodeSdk = false,
 }: Partial<RemoteParticipant> = {}): RemoteParticipant => {
     return {
         id,
@@ -151,6 +156,7 @@ export const randomRemoteParticipant = ({
         presentationStream,
         externalId,
         isDialIn,
+        isNodeSdk,
     };
 };
 

--- a/packages/core/src/redux/slices/__tests__/authorization.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/authorization.unit.ts
@@ -50,6 +50,7 @@ describe("authorizationSlice", () => {
                                 startedCloudRecordingAt: null,
                                 externalId: null,
                                 isDialIn: false,
+                                isNodeSdk: false,
                             },
                         ],
                         knockers: [],

--- a/packages/core/src/redux/slices/__tests__/cloudRecording.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/cloudRecording.unit.ts
@@ -42,6 +42,7 @@ describe("cloudRecordingSlice", () => {
                         startedCloudRecordingAt: "2021-01-01T00:00:00.000Z",
                         externalId: null,
                         isDialIn: false,
+                        isNodeSdk: false,
                     },
                 }),
             );

--- a/packages/core/src/redux/slices/__tests__/remoteParticipants.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/remoteParticipants.unit.ts
@@ -32,6 +32,7 @@ describe("remoteParticipantsSlice", () => {
                                     startedCloudRecordingAt: null,
                                     externalId: null,
                                     isDialIn: false,
+                                    isNodeSdk: false,
                                 },
                             ],
                             knockers: [],
@@ -56,6 +57,7 @@ describe("remoteParticipantsSlice", () => {
                         presentationStream: null,
                         externalId: null,
                         isDialIn: false,
+                        isNodeSdk: false,
                     },
                 ]);
             });
@@ -86,6 +88,7 @@ describe("remoteParticipantsSlice", () => {
                     presentationStream: null,
                     externalId: null,
                     isDialIn: false,
+                    isNodeSdk: false,
                 },
             ]);
         });

--- a/packages/core/src/redux/slices/localParticipant.ts
+++ b/packages/core/src/redux/slices/localParticipant.ts
@@ -29,6 +29,7 @@ const initialState: LocalParticipantState = {
     clientClaim: undefined,
     stickyReaction: undefined,
     isDialIn: false,
+    isNodeSdk: false,
 };
 
 /**

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -11,6 +11,7 @@ import {
     selectAppExternalId,
     selectAppIsActive,
     selectAppIsDialIn,
+    selectAppIsNodeSdk,
 } from "./app";
 import { selectRoomKey, setRoomKey } from "./authorization";
 
@@ -150,6 +151,7 @@ export const doKnockRoom = createAppThunk(() => (dispatch, getState) => {
     const roomKey = selectRoomKey(state);
     const displayName = selectAppDisplayName(state);
     const isDialIn = selectAppIsDialIn(state);
+    const isNodeSdk = selectAppIsNodeSdk(state);
     const userAgent = selectAppUserAgent(state);
     const externalId = selectAppExternalId(state);
     const organizationId = selectOrganizationId(state);
@@ -164,6 +166,7 @@ export const doKnockRoom = createAppThunk(() => (dispatch, getState) => {
         displayName,
         isCoLocated: false,
         isDialIn,
+        isNodeSdk,
         isDevicePermissionDenied: false,
         kickFromOtherRooms: false,
         organizationId,
@@ -185,11 +188,11 @@ export const doConnectRoom = createAppThunk(() => (dispatch, getState) => {
     const userAgent = selectAppUserAgent(state);
     const externalId = selectAppExternalId(state);
     const isDialIn = selectAppIsDialIn(state);
+    const isNodeSdk = selectAppIsNodeSdk(state);
     const organizationId = selectOrganizationId(state);
     const isCameraEnabled = selectIsCameraEnabled(getState());
     const isMicrophoneEnabled = selectIsMicrophoneEnabled(getState());
     const clientClaim = selectLocalParticipantClientClaim(getState());
-
     socket?.emit("join_room", {
         avatarUrl: null,
         config: {
@@ -200,6 +203,7 @@ export const doConnectRoom = createAppThunk(() => (dispatch, getState) => {
         displayName,
         isCoLocated: false,
         isDialIn,
+        isNodeSdk,
         isDevicePermissionDenied: false,
         kickFromOtherRooms: false,
         organizationId,

--- a/packages/media/src/utils/types.ts
+++ b/packages/media/src/utils/types.ts
@@ -56,6 +56,7 @@ export interface SignalClient {
     startedCloudRecordingAt: string | null;
     externalId: string | null;
     isDialIn: boolean;
+    isNodeSdk: boolean;
 }
 
 export interface Spotlight {

--- a/packages/media/src/webrtc/P2pRtcManager.ts
+++ b/packages/media/src/webrtc/P2pRtcManager.ts
@@ -270,7 +270,7 @@ export default class P2pRtcManager implements RtcManager {
             () => this._clearMediaServersRefresh(),
 
             this._serverSocket.on(PROTOCOL_RESPONSES.NEW_CLIENT, (data: NewClientEvent) => {
-                if (data.client.isDialIn && !this._nodeJsClients.includes(data.client.id)) {
+                if (data.client.isNodeSdk && !this._nodeJsClients.includes(data.client.id)) {
                     this._nodeJsClients.push(data.client.id);
                 }
             }),


### PR DESCRIPTION
-------

### Description

**Summary:**
previously we only did so for dial in clients, but the captioner also
requires this

sadly testing this locally captions don't work for the dial in agent... but that's not really reflective of what happens in prod is it? 

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**
https://linear.app/whereby/issue/COB-1015/live-captions-doesnt-work-for-a-dialed-in-user-after-disconnection
<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
Requires some signal changes
https://github.com/whereby/video-conference/pull/14941

1. run that signal branch in local stack local-dev
1. add the canary media and core releases to the captioner and dial in modules in recording-service
1. in that repo, `yarn captioner:build-for-local-stack` and `yarn dial-in:build-for-local-stack` 
1. join a dial-in enabled p2p room and open the network tab of the browser dev tools
1. filter for Websocket connections, and have a look at the signal websocket messages
![image](https://github.com/user-attachments/assets/a71c25ae-d65c-4fbf-8583-c89c06caa826)
1. enable captions, look for the `new_client` signal message and see it has `isNodeSdk: true` and `isDialIn: false`
![image](https://github.com/user-attachments/assets/6255b097-ea0f-4d8d-b3e0-842f0c3be01d)
1. dial into the room, see the `new_client` signal message has `isNodeSdk: true` and `isDialIn: true`
![image](https://github.com/user-attachments/assets/5849ed0f-dc06-4aa7-be8d-f3dc1fcdb762)

This proves we get the flag, but I'm unsure how to check turn udp is enforced...
<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->