### PR TITLE
browser-sdk: Fix infinite loop issue with leave room fn

### DIFF
--- a/.changeset/hip-knives-draw.md
+++ b/.changeset/hip-knives-draw.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": minor
+---
+
+Fix typings and leave room function dependencies

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -137,7 +137,7 @@ export function useRoomConnection(
         [whenConnectedToRoom],
     );
     const joinRoom = React.useCallback(() => dispatch(doAppStart(roomConfig)), [dispatch]);
-    const leaveRoom = React.useCallback(() => whenConnectedToRoom(() => doAppStop()), [whenConnectedToRoom]);
+    const leaveRoom = React.useCallback(() => dispatch(doAppStop()), [dispatch]);
     const lockRoom = React.useCallback(
         (locked: boolean) => whenConnectedToRoom(() => doLockRoom({ locked })),
         [whenConnectedToRoom],

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -72,26 +72,26 @@ export interface UseRoomConnectionOptions extends Omit<RoomConnectionOptions, "l
 }
 
 export interface RoomConnectionActions {
-    toggleLowDataMode(enabled?: boolean): void;
-    toggleRaiseHand(enabled?: boolean): void;
-    askToSpeak(participantId: string): void;
-    acceptWaitingParticipant(participantId: string): void;
-    knock(): void;
-    joinRoom(): void;
-    leaveRoom(): void;
-    lockRoom(locked: boolean): void;
-    muteParticipants(clientIds: string[]): void;
-    kickParticipant(clientId: string): void;
-    endMeeting(stayBehind?: boolean): void;
-    rejectWaitingParticipant(participantId: string): void;
-    sendChatMessage(text: string): void;
-    setDisplayName(displayName: string): void;
-    startCloudRecording(): void;
-    startScreenshare(): void;
-    stopCloudRecording(): void;
-    stopScreenshare(): void;
-    toggleCamera(enabled?: boolean): void;
-    toggleMicrophone(enabled?: boolean): void;
-    spotlightParticipant(clientId: string): void;
-    removeSpotlight(clientId: string): void;
+    toggleLowDataMode: (enabled?: boolean) => void;
+    toggleRaiseHand: (enabled?: boolean) => void;
+    askToSpeak: (participantId: string) => void;
+    acceptWaitingParticipant: (participantId: string) => void;
+    knock: () => void;
+    joinRoom: () => void;
+    leaveRoom: () => void;
+    lockRoom: (locked: boolean) => void;
+    muteParticipants: (clientIds: string[]) => void;
+    kickParticipant: (clientId: string) => void;
+    endMeeting: (stayBehind?: boolean) => void;
+    rejectWaitingParticipant: (participantId: string) => void;
+    sendChatMessage: (text: string) => void;
+    setDisplayName: (displayName: string) => void;
+    startCloudRecording: () => void;
+    startScreenshare: () => void;
+    stopCloudRecording: () => void;
+    stopScreenshare: () => void;
+    toggleCamera: (enabled?: boolean) => void;
+    toggleMicrophone: (enabled?: boolean) => void;
+    spotlightParticipant: (clientId: string) => void;
+    removeSpotlight: (clientId: string) => void;
 }


### PR DESCRIPTION
### Description
 Fixes #404 
 
 Fix typings for `useRoomConnection` actions. These are currently defined as "class member functions" instead of "function-valued properties". The actions object is actually a record with function-valued properties, which is the reason for this change.

The other issue mentioned in #404 is actually different to the typing issue. The infinite loop will currently happen when creating a `useEffect` like this:
```
    useEffect(() => {
        joinRoom();
        return () => leaveRoom();
    }, [joinRoom, leaveRoom]);
 ```

This is because of the dependencies in `whenConnectedToRoom`, which currently depends on `roomConnectionStatus`, which changes frequently and will therefore recreate the function, which in turn will trigger the useEffect. This is not correct, and we should not depend on changes to `roomConnectionStatus` in the `useCallback` dependency array. This PR moves the room connection status check out, in a `useMemo` fn, and makes the `whenConnectedToRoom` only depend on `dispatch`. This avoids the infinite loop problem, and the above useEffect will only run once on mount and once on unmount.


**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

On main:
1. Download this snippet as `tmp-video-experience-use-effect.patch`:
```diff
diff --git a/packages/browser-sdk/src/stories/components/VideoExperience.tsx b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
index 59bdaa1c..4ff43a4b 100644
--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -77,11 +77,11 @@ export default function VideoExperience({
     } = actions;
 
     useEffect(() => {
-        if (!joinRoomOnLoad) return;
+        // if (!joinRoomOnLoad) return;
 
         joinRoom();
         return () => leaveRoom();
-    }, []);
+    }, [joinRoom, leaveRoom]);
 
     function showIncomingChatMessageNotification({ message }: ChatMessageEvent) {
         toast(message, {
```
2. Apply the patch `git apply tmp-video-experience-use-effect.patch`
3. Run `yarn build && yarn dev`
4. Open the "Room connection Only" story
5. Verify that you get in to a infinite loop (Maximum call stack exceeded)
6. Check out this branch, apply the patch again
7. Repeat steps 3 - 4
8. Verify that there is no infinite loop, and that you are automatically connected to the room

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
