### PR TITLE
Simplify TURN enforcement

### DIFF
--- a/.changeset/rude-rabbits-hunt.md
+++ b/.changeset/rude-rabbits-hunt.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/media": minor
+"@whereby.com/core": minor
+---
+
+Only enforce TURN from the Node client side

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -217,7 +217,6 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
     const state = getState();
     const rtcManager = selectRtcConnectionRaw(state).rtcManager;
     const remoteClients = selectRemoteClients(state);
-    const isNodeSdk = selectAppIsNodeSdk(state);
 
     if (!rtcManager) {
         throw new Error("No rtc manager");
@@ -236,13 +235,11 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
             (state === "new_accept" && shouldAcceptNewClients) ||
             (state === "old_accept" && !shouldAcceptNewClients) // these are done to enable broadcast in legacy/p2p
         ) {
-            const enforceTurnProtocol = isNodeSdk ? "onlyudp" : undefined;
             rtcManager.acceptNewStream({
                 streamId: streamId === "0" ? clientId : streamId,
                 clientId,
                 shouldAddLocalVideo: streamId === "0",
                 activeBreakout,
-                enforceTurnProtocol,
             });
         } else if (state === "new_accept" || state === "old_accept") {
             // do nothing - let this be marked as done_accept as the rtcManager
@@ -278,7 +275,7 @@ export const doRtcReportStreamResolution = createAppThunk(
             }
 
             dispatch(resolutionReported({ streamId, width, height }));
-        },
+        }
 );
 
 export const doRtcManagerCreated = createAppThunk((payload: RtcManagerCreatedPayload) => (dispatch) => {
@@ -389,7 +386,7 @@ export const selectShouldConnectRtc = createSelector(
             return true;
         }
         return false;
-    },
+    }
 );
 
 createReactor([selectShouldConnectRtc], ({ dispatch }, shouldConnectRtc) => {
@@ -407,7 +404,7 @@ export const selectShouldInitializeRtc = createSelector(
             return true;
         }
         return false;
-    },
+    }
 );
 
 createReactor([selectShouldInitializeRtc], ({ dispatch }, shouldInitializeRtc) => {
@@ -478,7 +475,7 @@ export const selectStreamsToAccept = createSelector(
             }
         }
         return upd;
-    },
+    }
 );
 
 createReactor(
@@ -487,5 +484,5 @@ createReactor(
         if (0 < streamsToAccept.length && !isAcceptingStreams) {
             dispatch(doHandleAcceptStreams(streamsToAccept));
         }
-    },
+    }
 );

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -217,6 +217,7 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
     const state = getState();
     const rtcManager = selectRtcConnectionRaw(state).rtcManager;
     const remoteClients = selectRemoteClients(state);
+    const isNodeSdk = selectAppIsNodeSdk(state);
 
     if (!rtcManager) {
         throw new Error("No rtc manager");
@@ -235,7 +236,7 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
             (state === "new_accept" && shouldAcceptNewClients) ||
             (state === "old_accept" && !shouldAcceptNewClients) // these are done to enable broadcast in legacy/p2p
         ) {
-            const enforceTurnProtocol = participant.isDialIn ? "onlytls" : undefined;
+            const enforceTurnProtocol = isNodeSdk ? "onlyudp" : undefined;
             rtcManager.acceptNewStream({
                 streamId: streamId === "0" ? clientId : streamId,
                 clientId,

--- a/packages/media/src/webrtc/P2pRtcManager.ts
+++ b/packages/media/src/webrtc/P2pRtcManager.ts
@@ -155,7 +155,7 @@ export default class P2pRtcManager implements RtcManager {
         stream: MediaStream,
         audioPaused: boolean,
         videoPaused: boolean,
-        beforeEffectTracks: CustomMediaStreamTrack[] = [],
+        beforeEffectTracks: CustomMediaStreamTrack[] = []
     ) {
         if (stream === this.localStreams[streamId]) {
             // this can happen after reconnect. We do not want to add the stream to the
@@ -377,7 +377,7 @@ export default class P2pRtcManager implements RtcManager {
         this._forEachPeerConnection((session: any) => {
             if (session.hasConnectedPeerConnection()) {
                 this._withForcedRenegotiation(session, () =>
-                    session.setAudioOnly(this._isAudioOnlyMode, this._screenshareVideoTrackIds),
+                    session.setAudioOnly(this._isAudioOnlyMode, this._screenshareVideoTrackIds)
                 );
             }
         });
@@ -523,14 +523,12 @@ export default class P2pRtcManager implements RtcManager {
         isOfferer,
         peerConnectionId,
         shouldAddLocalVideo,
-        enforceTurnProtocol,
     }: {
         clientId: string;
         initialBandwidth: any;
         isOfferer: any;
         peerConnectionId: string;
         shouldAddLocalVideo: boolean;
-        enforceTurnProtocol?: TurnTransportProtocol;
     }) {
         if (!peerConnectionId) {
             throw new Error("peerConnectionId is missing");
@@ -570,7 +568,8 @@ export default class P2pRtcManager implements RtcManager {
                 return entry;
             });
         }
-        if (enforceTurnProtocol || this._features.useOnlyTURN) {
+
+        if (this._features.useOnlyTURN) {
             peerConnectionConfig.iceTransportPolicy = "relay";
             const filter = (
                 {
@@ -578,10 +577,10 @@ export default class P2pRtcManager implements RtcManager {
                     onlytcp: /^turn:.*transport=tcp$/,
                     onlytls: /^turns:.*transport=tcp$/,
                 } as any
-            )[enforceTurnProtocol || this._features.useOnlyTURN];
+            )[this._features.useOnlyTURN];
             if (filter) {
                 peerConnectionConfig.iceServers = peerConnectionConfig.iceServers.filter(
-                    (entry: any) => entry.url && entry.url.match(filter),
+                    (entry: any) => entry.url && entry.url.match(filter)
                 );
             }
         }
@@ -801,7 +800,7 @@ export default class P2pRtcManager implements RtcManager {
                 const pendingActions = this._pendingActionsForConnectedPeerConnections;
                 if (!pendingActions) {
                     logger.warn(
-                        `No pending action is created to repalce track, because the pending actions array is null`,
+                        `No pending action is created to repalce track, because the pending actions array is null`
                     );
                     return;
                 }
@@ -863,7 +862,7 @@ export default class P2pRtcManager implements RtcManager {
         }
         this._fetchMediaServersTimer = setTimeout(
             () => this._emitServerEvent(PROTOCOL_REQUESTS.FETCH_MEDIASERVER_CONFIG),
-            mediaserverConfigTtlSeconds * 1000,
+            mediaserverConfigTtlSeconds * 1000
         );
     }
 
@@ -899,14 +898,12 @@ export default class P2pRtcManager implements RtcManager {
         } else {
             initialBandwidth = this._changeBandwidthForAllClients(true);
         }
-        const enforceTurnProtocol = this._features.isNodeSdk ? "onlyudp" : undefined;
 
         session = this._createP2pSession({
             clientId,
             initialBandwidth,
             shouldAddLocalVideo: true,
             isOfferer: true,
-            enforceTurnProtocol,
         });
         this._negotiatePeerConnection(clientId, session);
         return Promise.resolve(session);
@@ -935,7 +932,7 @@ export default class P2pRtcManager implements RtcManager {
             this._negotiatePeerConnection(
                 clientId,
                 session,
-                Object.assign({}, this.offerOptions, { iceRestart: true }),
+                Object.assign({}, this.offerOptions, { iceRestart: true })
             );
         }
     }
@@ -1130,13 +1127,11 @@ export default class P2pRtcManager implements RtcManager {
         initialBandwidth,
         shouldAddLocalVideo = false,
         isOfferer = false,
-        enforceTurnProtocol,
     }: {
         clientId: string;
         initialBandwidth: number;
         shouldAddLocalVideo: boolean;
         isOfferer: boolean;
-        enforceTurnProtocol?: TurnTransportProtocol;
     }) {
         const session = this._createSession({
             peerConnectionId: clientId,
@@ -1144,7 +1139,6 @@ export default class P2pRtcManager implements RtcManager {
             initialBandwidth,
             shouldAddLocalVideo,
             isOfferer,
-            enforceTurnProtocol,
         });
         const pc = session.pc;
 
@@ -1277,12 +1271,10 @@ export default class P2pRtcManager implements RtcManager {
         streamId,
         clientId,
         shouldAddLocalVideo,
-        enforceTurnProtocol,
     }: {
         streamId: string;
         clientId: string;
         shouldAddLocalVideo?: boolean;
-        enforceTurnProtocol?: TurnTransportProtocol;
     }) {
         let session = this._getSession(clientId);
         if (session && streamId !== clientId) {
@@ -1304,7 +1296,6 @@ export default class P2pRtcManager implements RtcManager {
             clientId,
             initialBandwidth,
             shouldAddLocalVideo: !!shouldAddLocalVideo,
-            enforceTurnProtocol,
             isOfferer: false,
         });
         this._emitServerEvent(RELAY_MESSAGES.READY_TO_RECEIVE_OFFER, {

--- a/packages/media/src/webrtc/P2pRtcManager.ts
+++ b/packages/media/src/webrtc/P2pRtcManager.ts
@@ -285,6 +285,10 @@ export default class P2pRtcManager implements RtcManager {
                     logger.warn("No RTCPeerConnection on ICE_CANDIDATE", data);
                     return;
                 }
+                if (data.message.candidate.match(/relay/)) {
+                    console.debug("Discarding relay candidate", data.message.candidate);
+                    return;
+                }
                 session.addIceCandidate(data.message);
             }),
 
@@ -551,7 +555,7 @@ export default class P2pRtcManager implements RtcManager {
         constraints.optional.push({ rtcStatsConferenceId: this._roomName });
 
         const peerConnectionConfig: any = {
-            iceServers: this._iceServers,
+            iceServers: [],
         };
         if (this._features.turnServerOverrideHost) {
             const host = this._features.turnServerOverrideHost;

--- a/packages/media/src/webrtc/types.ts
+++ b/packages/media/src/webrtc/types.ts
@@ -14,13 +14,11 @@ export interface RtcManager {
         clientId,
         shouldAddLocalVideo,
         streamId,
-        enforceTurnProtocol,
     }: {
         activeBreakout: boolean;
         clientId: string;
         shouldAddLocalVideo: boolean;
         streamId: string;
-        enforceTurnProtocol?: TurnTransportProtocol;
     }) => void;
     addNewStream(streamId: string, stream: MediaStream, isAudioEnabled: boolean, isVideoEnabled: boolean): void;
     disconnect(streamId: string, activeBreakout: boolean | null, eventClaim?: string): void;


### PR DESCRIPTION
### Description
After fixing the stream ID issue, testing showed a simplified TURN enforcement behaviour seems to work better (coupled with an updated werift version...)
**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**
https://linear.app/whereby/issue/COB-1015/live-captions-doesnt-work-for-a-dialed-in-user-after-disconnection
https://linear.app/whereby/issue/COB-1012/p2p-no-audio-if-there-are-more-than-1-dialed-in-users
<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
add the canary media and core versions to your dial-in-worker and captioner-worker workspaces in recording-service, then test dial-in and captions in a p2p room in local-stack

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->