### PR TITLE
react-native-sdk: Move webview dependency to normal dependencies

### DIFF
--- a/.changeset/pink-turkeys-juggle.md
+++ b/.changeset/pink-turkeys-juggle.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/react-native-sdk": minor
+---
+
+Add react-native-webview as a dependency

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -63,7 +63,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@whereby.com/core": "0.25.0"
+    "@whereby.com/core": "0.25.0",
+    "react-native-webview": "13.8.6"
   },
   "devDependencies": {
     "@react-native/eslint-config": "^0.73.1",
@@ -74,7 +75,6 @@
     "react": "18.2.0",
     "react-native": "0.74.5",
     "react-native-builder-bob": "^0.30.0",
-    "react-native-webview": "13.8.6",
     "typescript": "^5.2.2"
   },
   "resolutions": {


### PR DESCRIPTION
### Description
`react-native-webview` should be listed as a normal dependency and not a dev dependency, so that consumers installs it when installing the SDK.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
