### PR TITLE
media: Refactor RTCStats WebSocket connect timing

### DIFF
--- a/.changeset/wet-trainers-run.md
+++ b/.changeset/wet-trainers-run.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/media": minor
+"@whereby.com/core": patch
+---
+
+Refactor RTCStats WebSocket connect timing

--- a/packages/core/src/redux/slices/__tests__/rtcConnection.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/rtcConnection.unit.ts
@@ -13,16 +13,24 @@ describe("rtcConnectionSlice", () => {
             const x = () => oneOf(true, false);
 
             it.each`
-                dispatcherCreated | isCreatingDispatcher | signalSocket | expected
-                ${true}           | ${x()}               | ${{}}        | ${false}
-                ${x()}            | ${true}              | ${{}}        | ${false}
-                ${x()}            | ${x()}               | ${undefined} | ${false}
-                ${false}          | ${false}             | ${{}}        | ${true}
+                rtcStatus     | appIsActive | dispatcherCreated | isCreatingDispatcher | signalSocket | expected
+                ${"inactive"} | ${true}     | ${true}           | ${x()}               | ${{}}        | ${false}
+                ${"inactive"} | ${true}     | ${x()}            | ${true}              | ${{}}        | ${false}
+                ${"inactive"} | ${true}     | ${x()}            | ${x()}               | ${undefined} | ${false}
+                ${"active"}   | ${true}     | ${false}          | ${false}             | ${{}}        | ${false}
+                ${"inactive"} | ${false}    | ${false}          | ${false}             | ${{}}        | ${false}
+                ${"inactive"} | ${true}     | ${false}          | ${false}             | ${{}}        | ${true}
             `(
-                "should return $expected when rtcDispatcherCreated=$rtcDispatcherCreated, rtcIsCreatingDispatcher=$rtcIsCreatingDispatcher, signalSocket=$signalSocket",
-                ({ dispatcherCreated, isCreatingDispatcher, signalSocket, expected }) => {
+                "should return $expected when rtcStatus=$rtcStatus, appIsActive=$appIsActive dispatcherCreated=$dispatcherCreated, isCreatingDispatcher=$isCreatingDispatcher, signalSocket=$signalSocket",
+                ({ rtcStatus, appIsActive, dispatcherCreated, isCreatingDispatcher, signalSocket, expected }) => {
                     expect(
-                        selectShouldConnectRtc.resultFunc(dispatcherCreated, isCreatingDispatcher, signalSocket),
+                        selectShouldConnectRtc.resultFunc(
+                            rtcStatus,
+                            appIsActive,
+                            dispatcherCreated,
+                            isCreatingDispatcher,
+                            signalSocket,
+                        ),
                     ).toEqual(expected);
                 },
             );

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -380,11 +380,13 @@ startAppListening({
 });
 
 export const selectShouldConnectRtc = createSelector(
+    selectRtcStatus,
+    selectAppIsActive,
     selectRtcDispatcherCreated,
     selectRtcIsCreatingDispatcher,
     selectSignalConnectionSocket,
-    (dispatcherCreated, isCreatingDispatcher, signalSocket) => {
-        if (!dispatcherCreated && !isCreatingDispatcher && signalSocket) {
+    (rtcStatus, appIsActive, dispatcherCreated, isCreatingDispatcher, signalSocket) => {
+        if (appIsActive && rtcStatus === "inactive" && !dispatcherCreated && !isCreatingDispatcher && signalSocket) {
             return true;
         }
         return false;

--- a/packages/core/src/redux/slices/signalConnection/index.ts
+++ b/packages/core/src/redux/slices/signalConnection/index.ts
@@ -136,6 +136,7 @@ export const signalConnectionSlice = createSlice({
         socketDisconnected: (state) => {
             return {
                 ...state,
+                socket: null,
                 deviceIdentified: false,
                 status: "disconnected",
             };

--- a/packages/core/src/redux/tests/store/signalConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/signalConnection.spec.ts
@@ -64,6 +64,7 @@ describe("signalConnectionSlice", () => {
             expect(mockServerSocket.disconnect).toHaveBeenCalled();
             expect(diff(before, after)).toEqual({
                 deviceIdentified: false,
+                socket: null,
                 status: "disconnected",
             });
         });

--- a/packages/media/src/webrtc/P2pRtcManager.ts
+++ b/packages/media/src/webrtc/P2pRtcManager.ts
@@ -898,7 +898,6 @@ export default class P2pRtcManager implements RtcManager {
     }
 
     _connect(clientId: string) {
-        this.rtcStatsReconnect();
         let session = this._getSession(clientId);
         let initialBandwidth = (session && session.bandwidth) || 0;
         if (session) {

--- a/packages/media/src/webrtc/RtcManagerDispatcher.ts
+++ b/packages/media/src/webrtc/RtcManagerDispatcher.ts
@@ -53,11 +53,12 @@ export default class RtcManagerDispatcher {
                 } else {
                     rtcManager = new P2pRtcManager(config);
                 }
+                rtcManager.rtcStatsReconnect();
                 rtcManager.setupSocketListeners();
                 emitter.emit(CONNECTION_STATUS.EVENTS.RTC_MANAGER_CREATED, { rtcManager });
                 this.currentManager = rtcManager;
                 serverSocket.setRtcManager(rtcManager);
-            }
+            },
         );
     }
 

--- a/packages/media/src/webrtc/VegaRtcManager/index.ts
+++ b/packages/media/src/webrtc/VegaRtcManager/index.ts
@@ -1379,9 +1379,6 @@ export default class VegaRtcManager implements RtcManager {
     acceptNewStream({ streamId, clientId }: { streamId: string; clientId: string }) {
         logger.info("acceptNewStream()", { streamId, clientId });
 
-        // make sure we have rtcStats connection
-        this.rtcStatsReconnect();
-
         const clientState = this._getOrCreateClientState(clientId);
         const isScreenShare = streamId !== clientId;
 

--- a/packages/media/src/webrtc/rtcStatsService.ts
+++ b/packages/media/src/webrtc/rtcStatsService.ts
@@ -42,6 +42,10 @@ function rtcStatsConnection(wsURL: string, logger: any = console) {
     const connection = {
         connected: false,
         trace: (...args: any) => {
+            if (!ws) {
+                return;
+            }
+
             args.push(Date.now());
 
             if (args[0] === "customEvent" && args[2].type === "roomSessionId") {
@@ -176,7 +180,7 @@ function rtcStatsConnection(wsURL: string, logger: any = console) {
             };
         },
     };
-    connection.connect();
+
     return connection;
 }
 

--- a/packages/media/src/webrtc/types.ts
+++ b/packages/media/src/webrtc/types.ts
@@ -1,6 +1,6 @@
 import { TurnTransportProtocol } from "../utils";
 
-/* 
+/*
     RTC
 */
 export enum RtcEventNames {
@@ -26,6 +26,7 @@ export interface RtcManager {
     disconnect(streamId: string, activeBreakout: boolean | null, eventClaim?: string): void;
     disconnectAll(): void;
     rtcStatsDisconnect(): void;
+    rtcStatsReconnect(): void;
     replaceTrack(oldTrack: CustomMediaStreamTrack, newTrack: CustomMediaStreamTrack): void;
     removeStream(streamId: string, _stream: MediaStream, requestedByClientId: string | null): void;
     shouldAcceptStreamsFromBothSides?: () => boolean;
@@ -76,7 +77,7 @@ export type RtcEvents = {
     remote_stream_track_removed: void;
 };
 
-/* 
+/*
     Media Devices
 */
 


### PR DESCRIPTION
### Description

Refactor of the RTCStats WebSocket connect timing so that the rtcstats service is only connected when an RTC Manager has also been created (i.e. remove connection on initialization of RTCStats WebSocket).

This fixes two bugs in the SDK:

* The rtcstats websocket connection is now only connected when a joinRoom action is invoked. Previously the rtcstats websocket connection was opened before any invocation of SDK code and would remain sitting idly open until a joinRoom action was triggered.
* The rtcstats websocket connection now re-opens correctly on a leave->re-join->... flow within the app (and on every subsequent re-join).

### Testing

1. Download this branch and run: `yarn build && yarn dev`
2. When Storybook opens in a browser window, navigate to the "Custom UI > Room Connection Only" story
3. Open the developer tools and then focus the "Network" tab
4. Add a filter for `wss://rtcstats.srv.whereby.com/iframe.html` in the Developer tools Network tab.
5. Initially no request to `wss://rtcstats.srv.whereby.com/iframe.html` should be present
6. Click "Join room" button in the story
7. A request to `wss://rtcstats.srv.whereby.com/iframe.html` should now be visible in the Network tab of the developer tools.
8. Click "Leave room" button in the story
9. Click "Re-join left room" in the story
10. A new request to `wss://rtcstats.srv.whereby.com/iframe.html` should now also be visible in the Network tab of the developer tools.
11. Repeat the leave/re-join steps (Steps 8 + 9 above) as many times as needed to confirm that a new connection is established on each re-join.

### Screenshots/GIFs (if applicable)

<img width="793" alt="developer_tools_network_tab_with_rtcstats_filter" src="https://github.com/user-attachments/assets/a68746d5-7133-45a9-910d-86520504890e">

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
