### PR TITLE
core: Add connection monitor events insightsStats

### DIFF
--- a/.changeset/fifty-horses-swim.md
+++ b/.changeset/fifty-horses-swim.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/core": minor
+"@whereby.com/media": patch
+---
+
+Add connection monitor rtc events handling

--- a/packages/core/src/redux/index.ts
+++ b/packages/core/src/redux/index.ts
@@ -7,6 +7,7 @@ export * from "./slices/app";
 export * from "./slices/authorization";
 export * from "./slices/chat";
 export * from "./slices/cloudRecording";
+export * from "./slices/connectionMonitor";
 export * from "./slices/deviceCredentials";
 export * from "./slices/localMedia";
 export * from "./slices/localParticipant";

--- a/packages/core/src/redux/slices/__tests__/connectionMonitor.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/connectionMonitor.unit.ts
@@ -1,0 +1,79 @@
+import {
+    selectShouldStartConnectionMonitor,
+    selectShouldStopConnectionMonitor,
+    connectionMonitorStarted,
+    connectionMonitorStopped,
+    connectionMonitorSlice,
+} from "../connectionMonitor";
+
+describe("connectionMonitorSlice", () => {
+    describe("reducers", () => {
+        describe("connectionMonitorStarted", () => {
+            it("should set running to true and set callback function", () => {
+                const stopCallbackFunction = () => {};
+
+                const result = connectionMonitorSlice.reducer(
+                    undefined,
+                    connectionMonitorStarted({ stopIssueSubscription: stopCallbackFunction }),
+                );
+
+                expect(result).toEqual({
+                    running: true,
+                    stopCallbackFunction,
+                });
+            });
+        });
+        describe("connectionMonitorStopped", () => {
+            it("should set running to false and clear callback function", () => {
+                const stopCallbackFunction = () => {};
+
+                connectionMonitorSlice.reducer(
+                    undefined,
+                    connectionMonitorStarted({ stopIssueSubscription: stopCallbackFunction }),
+                );
+
+                const result = connectionMonitorSlice.reducer(undefined, connectionMonitorStopped());
+
+                expect(result).toEqual({
+                    running: false,
+                    stopCallbackFunction: undefined,
+                });
+            });
+        });
+    });
+    describe("reactors", () => {
+        describe("selectShouldStartConnectionMonitor", () => {
+            it.each`
+                roomConnectionStatus | isRunning | expected
+                ${"ready"}           | ${false}  | ${false}
+                ${"connecting"}      | ${false}  | ${false}
+                ${"connected"}       | ${true}   | ${false}
+                ${"connected"}       | ${false}  | ${true}
+            `(
+                "should return $expected when roomConnectionStatus=$roomConnectionStatus, isRunning=$isRunning",
+                ({ roomConnectionStatus, isRunning, expected }) => {
+                    expect(selectShouldStartConnectionMonitor.resultFunc(roomConnectionStatus, isRunning)).toEqual(
+                        expected,
+                    );
+                },
+            );
+        });
+
+        describe("selectShouldStopConnectionMonitor", () => {
+            it.each`
+                roomConnectionStatus | isRunning | expected
+                ${"ready"}           | ${true}   | ${false}
+                ${"connected"}       | ${true}   | ${false}
+                ${"left"}            | ${true}   | ${true}
+                ${"kicked"}          | ${true}   | ${true}
+            `(
+                "should return $expected when roomConnectionStatus=$roomConnectionStatus, isRunning=$isRunning",
+                ({ roomConnectionStatus, isRunning, expected }) => {
+                    expect(selectShouldStopConnectionMonitor.resultFunc(roomConnectionStatus, isRunning)).toEqual(
+                        expected,
+                    );
+                },
+            );
+        });
+    });
+});

--- a/packages/core/src/redux/slices/connectionMonitor.ts
+++ b/packages/core/src/redux/slices/connectionMonitor.ts
@@ -1,0 +1,168 @@
+import { PayloadAction, createSelector, createSlice } from "@reduxjs/toolkit";
+import { setClientProvider, subscribeIssues } from "@whereby.com/media";
+import { RootState } from "../store";
+import { createAppThunk } from "../thunk";
+import { createReactor } from "../listenerMiddleware";
+import { selectRoomConnectionStatus } from "./roomConnection";
+import { selectRtcManager } from "./rtcConnection";
+import { selectAllClientViews } from "./room";
+
+/**
+ * Reducer
+ */
+
+export interface ConnectionMonitorStart {
+    stopIssueSubscription: () => void;
+}
+
+export interface ConnectionMonitorState {
+    running: boolean;
+    stopCallbackFunction?: () => void;
+}
+
+const initialState: ConnectionMonitorState = {
+    running: false,
+};
+
+export const connectionMonitorSlice = createSlice({
+    name: "connectionMonitor",
+    initialState,
+    reducers: {
+        connectionMonitorStarted: (state, action: PayloadAction<ConnectionMonitorStart>) => {
+            return {
+                ...state,
+                running: true,
+                stopCallbackFunction: action.payload.stopIssueSubscription,
+            };
+        },
+        connectionMonitorStopped: (state) => {
+            return {
+                ...state,
+                running: false,
+            };
+        },
+    },
+});
+
+/**
+ * Action creators
+ */
+
+export const { connectionMonitorStarted, connectionMonitorStopped } = connectionMonitorSlice.actions;
+
+export const doStartConnectionMonitor = createAppThunk(() => (dispatch, getState) => {
+    setClientProvider(() => {
+        const state = getState();
+
+        const clientViews = selectAllClientViews(state).map((clientView) => ({
+            id: clientView.id,
+            clientId: clientView.clientId,
+            // isAudioOnlyModeEnabled: clientView.isAudioOnlyModeEnabled, // not yet supported in SDK
+            isLocalClient: clientView.isLocalClient,
+            audio: {
+                enabled: clientView.isAudioEnabled,
+                track: clientView.stream?.getAudioTracks()[0],
+            },
+            video: {
+                enabled: clientView.isVideoEnabled,
+                track: clientView.stream?.getVideoTracks()[0],
+            },
+            isPresentation: clientView.isPresentation,
+        }));
+
+        return clientViews;
+    });
+
+    const issueMonitorSubscription = subscribeIssues({
+        onUpdatedIssues: (issuesAndMetricsByClients) => {
+            const state = getState();
+            const rtcManager = selectRtcManager(state);
+
+            if (!rtcManager) {
+                return;
+            }
+
+            // gather a selection of aggregate metrics
+            let lossSend = 0;
+            let lossReceive = 0;
+            let bitrateSend = 0;
+            let bitrateReceive = 0;
+            Object.entries(issuesAndMetricsByClients.aggregated.metrics).forEach(
+                ([key, value]: [string, { curMax: number; curSum: number }]) => {
+                    if (/loc.*packetloss/.test(key)) lossSend = Math.max(lossSend, value.curMax);
+                    if (/rem.*packetloss/.test(key)) lossReceive = Math.max(lossReceive, value.curMax);
+                    if (/loc.*bitrate/.test(key)) bitrateSend += value.curSum;
+                    if (/rem.*bitrate/.test(key)) bitrateReceive += value.curSum;
+                },
+            );
+
+            // send the selection of aggregate metrics to rtcstats
+            rtcManager.sendStatsCustomEvent("insightsStats", {
+                ls: Math.round(lossSend * 1000) / 1000,
+                lr: Math.round(lossReceive * 1000) / 1000,
+                bs: Math.round(bitrateSend),
+                br: Math.round(bitrateReceive),
+                cpu: issuesAndMetricsByClients.aggregated.metrics["global-cpu-pressure"]?.curSum,
+                _time: Date.now(),
+            });
+        },
+    });
+
+    dispatch(connectionMonitorStarted({ stopIssueSubscription: issueMonitorSubscription.stop }));
+});
+
+export const doStopConnectionMonitor = createAppThunk(() => (dispatch, getState) => {
+    const state = getState();
+    const stopCallbackFn = selectStopCallbackFunction(state);
+    if (stopCallbackFn) {
+        stopCallbackFn();
+    }
+    dispatch(connectionMonitorStopped());
+});
+
+/**
+ * Selectors
+ */
+
+export const selectConnectionMonitorIsRunning = (state: RootState) => state.connectionMonitor.running;
+export const selectStopCallbackFunction = (state: RootState) => state.connectionMonitor.stopCallbackFunction;
+
+export const selectShouldStartConnectionMonitor = createSelector(
+    selectRoomConnectionStatus,
+    selectConnectionMonitorIsRunning,
+    (roomConnectionStatus, isRunning) => {
+        if (!isRunning && roomConnectionStatus === "connected") {
+            return true;
+        }
+
+        return false;
+    },
+);
+
+export const selectShouldStopConnectionMonitor = createSelector(
+    selectRoomConnectionStatus,
+    selectConnectionMonitorIsRunning,
+    (roomConnectionStatus, isRunning) => {
+        if (isRunning && ["kicked", "left"].includes(roomConnectionStatus)) {
+            return true;
+        }
+
+        return false;
+    },
+);
+
+/**
+ * Reactors
+ */
+
+createReactor([selectShouldStartConnectionMonitor], ({ dispatch }, shouldStartConnectionMonitor) => {
+    if (shouldStartConnectionMonitor) {
+        dispatch(doStartConnectionMonitor());
+    }
+});
+
+createReactor([selectShouldStopConnectionMonitor], ({ dispatch }, shouldStartConnectionMonitor) => {
+    if (shouldStartConnectionMonitor) {
+        dispatch(doStopConnectionMonitor());
+    }
+});

--- a/packages/core/src/redux/slices/connectionMonitor.ts
+++ b/packages/core/src/redux/slices/connectionMonitor.ts
@@ -35,10 +35,9 @@ export const connectionMonitorSlice = createSlice({
                 stopCallbackFunction: action.payload.stopIssueSubscription,
             };
         },
-        connectionMonitorStopped: (state) => {
+        connectionMonitorStopped: () => {
             return {
-                ...state,
-                running: false,
+                ...initialState,
             };
         },
     },

--- a/packages/core/src/redux/store.ts
+++ b/packages/core/src/redux/store.ts
@@ -6,6 +6,7 @@ import { appSlice, doAppStart } from "./slices/app";
 import { authorizationSlice } from "./slices/authorization";
 import { chatSlice } from "./slices/chat";
 import { cloudRecordingSlice } from "./slices/cloudRecording";
+import { connectionMonitorSlice } from "./slices/connectionMonitor";
 import { deviceCredentialsSlice } from "./slices/deviceCredentials";
 import { localMediaSlice } from "./slices/localMedia";
 import { localParticipantSlice } from "./slices/localParticipant";
@@ -29,6 +30,7 @@ const appReducer = combineReducers({
     authorization: authorizationSlice.reducer,
     chat: chatSlice.reducer,
     cloudRecording: cloudRecordingSlice.reducer,
+    connectionMonitor: connectionMonitorSlice.reducer,
     deviceCredentials: deviceCredentialsSlice.reducer,
     localMedia: localMediaSlice.reducer,
     localParticipant: localParticipantSlice.reducer,

--- a/packages/core/src/redux/tests/store/connectionMonitor.spec.ts
+++ b/packages/core/src/redux/tests/store/connectionMonitor.spec.ts
@@ -1,0 +1,49 @@
+import { createStore } from "../store.setup";
+import { doStartConnectionMonitor, doStopConnectionMonitor } from "../../slices/connectionMonitor";
+import { setClientProvider, subscribeIssues } from "@whereby.com/media";
+
+jest.mock("@whereby.com/media", () => {
+    return {
+        __esModule: true,
+        setClientProvider: jest.fn(),
+        subscribeIssues: jest.fn().mockImplementation(() => {
+            return {
+                stop: jest.fn(),
+            };
+        }),
+    };
+});
+
+describe("connectionMonitorSlice", () => {
+    describe("actions", () => {
+        it("doStartConnectionMonitor", () => {
+            const store = createStore();
+
+            store.dispatch(doStartConnectionMonitor());
+
+            const after = store.getState().connectionMonitor;
+
+            expect(setClientProvider).toHaveBeenCalledTimes(1);
+            expect(subscribeIssues).toHaveBeenCalledTimes(1);
+
+            expect(after.stopCallbackFunction).not.toHaveBeenCalled();
+        });
+
+        it("doStopConnectionMonitor", () => {
+            const mockStopIssueSubscription = jest.fn();
+
+            const store = createStore({
+                initialState: {
+                    connectionMonitor: {
+                        running: true,
+                        stopCallbackFunction: mockStopIssueSubscription,
+                    },
+                },
+            });
+
+            store.dispatch(doStopConnectionMonitor());
+
+            expect(mockStopIssueSubscription).toHaveBeenCalledTimes(1);
+        });
+    });
+});


### PR DESCRIPTION
### Description

Add connection monitor to send `insightsStats` custom events to the rtcstats server at regular 2 second intervals.

### Testing

1. Download this branch and run: `yarn build && yarn dev`
2. When Storybook opens in a browser window, navigate to the "Custom UI > Room Connection Only" story
3. Open the developer tools and then focus the "Network" tab
4. Add a filter for wss://rtcstats.srv.whereby.com/iframe.html in the Developer tools Network tab.
5. Click "Join room" button in the story
6. Also join the room from another browser tab with a second participant.
7. In the developer tools opened in Step 3 above, you should now see `insightsStats` flowing from the story to the rtcstats server.

### Screenshots/GIFs (if applicable)

<img width="912" alt="developer_tools_network_tab_with_rtcstats_filter_and_insightStats_flowing" src="https://github.com/user-attachments/assets/24e00884-0034-4480-8710-d4b4a838dd34">

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

