### PR TITLE
core: only enforce turn from the node client side

### DIFF
--- a/.changeset/rude-rabbits-hunt.md
+++ b/.changeset/rude-rabbits-hunt.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/media": minor
+"@whereby.com/core": minor
+---
+
+Only enforce TURN from the Node client side

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -217,6 +217,7 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
     const state = getState();
     const rtcManager = selectRtcConnectionRaw(state).rtcManager;
     const remoteClients = selectRemoteClients(state);
+    const isNodeSdk = selectAppIsNodeSdk(state);
 
     if (!rtcManager) {
         throw new Error("No rtc manager");
@@ -235,7 +236,7 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
             (state === "new_accept" && shouldAcceptNewClients) ||
             (state === "old_accept" && !shouldAcceptNewClients) // these are done to enable broadcast in legacy/p2p
         ) {
-            const enforceTurnProtocol = participant.isDialIn ? "onlytls" : undefined;
+            const enforceTurnProtocol = isNodeSdk ? "onlyudp" : undefined;
             rtcManager.acceptNewStream({
                 streamId: streamId === "0" ? clientId : streamId,
                 clientId,


### PR DESCRIPTION
-------

### Description
after fixing the dial-in stream ID issue, we found p2p dial-in to dial-in agents weren't working consistently.
Simplifying the TURN enforcement logic and updating Werift in the worker seems to improve the situation 

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
requires local TURN:
https://github.com/whereby/local-stack/pull/347

1. in recording-service, `yarn workspace dial-in-worker add @whereby.com/core@0.0.0-canary-20240924101328`
1. `yarn dial-in:build-for-local-stack`
1. join a p2p room with via dial-in and dial-in simulator
1. send test audio from the simulator, it should be audible on the phone
1. listen for audio in the simulator, speak into the phone, it should be audible
1. both participants should be audible from a PWA client

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->