### PR TITLE
Remove TURN enforcement, change node client mediasoup device handler

### DIFF
--- a/.changeset/strange-apples-divide.md
+++ b/.changeset/strange-apples-divide.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/media": minor
+"@whereby.com/core": minor
+---
+
+Remove TURN enforcement, change node mediasoup device handler

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -235,13 +235,11 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
             (state === "new_accept" && shouldAcceptNewClients) ||
             (state === "old_accept" && !shouldAcceptNewClients) // these are done to enable broadcast in legacy/p2p
         ) {
-            const enforceTurnProtocol = participant.isDialIn ? "onlytls" : undefined;
             rtcManager.acceptNewStream({
                 streamId: streamId === "0" ? clientId : streamId,
                 clientId,
                 shouldAddLocalVideo: streamId === "0",
                 activeBreakout,
-                enforceTurnProtocol,
             });
         } else if (state === "new_accept" || state === "old_accept") {
             // do nothing - let this be marked as done_accept as the rtcManager
@@ -277,7 +275,7 @@ export const doRtcReportStreamResolution = createAppThunk(
             }
 
             dispatch(resolutionReported({ streamId, width, height }));
-        },
+        }
 );
 
 export const doRtcManagerCreated = createAppThunk((payload: RtcManagerCreatedPayload) => (dispatch) => {
@@ -390,7 +388,7 @@ export const selectShouldConnectRtc = createSelector(
             return true;
         }
         return false;
-    },
+    }
 );
 
 createReactor([selectShouldConnectRtc], ({ dispatch }, shouldConnectRtc) => {
@@ -408,7 +406,7 @@ export const selectShouldInitializeRtc = createSelector(
             return true;
         }
         return false;
-    },
+    }
 );
 
 createReactor([selectShouldInitializeRtc], ({ dispatch }, shouldInitializeRtc) => {
@@ -479,7 +477,7 @@ export const selectStreamsToAccept = createSelector(
             }
         }
         return upd;
-    },
+    }
 );
 
 createReactor(
@@ -488,5 +486,5 @@ createReactor(
         if (0 < streamsToAccept.length && !isAcceptingStreams) {
             dispatch(doHandleAcceptStreams(streamsToAccept));
         }
-    },
+    }
 );

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -13,7 +13,7 @@ import { createReactor, startAppListening } from "../../listenerMiddleware";
 import { selectRemoteClients, streamStatusUpdated } from "../remoteParticipants";
 import { StreamState } from "../../../RoomParticipant";
 import { selectAppIsNodeSdk, selectAppIsActive, doAppStop } from "../app";
-import { Chrome111 as MediasoupDeviceHandler } from "mediasoup-client/lib/handlers/Chrome111.js";
+import { Safari12 as MediasoupDeviceHandler } from "mediasoup-client/lib/handlers/Safari12.js";
 import {
     selectIsCameraEnabled,
     selectIsMicrophoneEnabled,
@@ -275,7 +275,7 @@ export const doRtcReportStreamResolution = createAppThunk(
             }
 
             dispatch(resolutionReported({ streamId, width, height }));
-        }
+        },
 );
 
 export const doRtcManagerCreated = createAppThunk((payload: RtcManagerCreatedPayload) => (dispatch) => {
@@ -388,7 +388,7 @@ export const selectShouldConnectRtc = createSelector(
             return true;
         }
         return false;
-    }
+    },
 );
 
 createReactor([selectShouldConnectRtc], ({ dispatch }, shouldConnectRtc) => {
@@ -406,7 +406,7 @@ export const selectShouldInitializeRtc = createSelector(
             return true;
         }
         return false;
-    }
+    },
 );
 
 createReactor([selectShouldInitializeRtc], ({ dispatch }, shouldInitializeRtc) => {
@@ -477,7 +477,7 @@ export const selectStreamsToAccept = createSelector(
             }
         }
         return upd;
-    }
+    },
 );
 
 createReactor(
@@ -486,5 +486,5 @@ createReactor(
         if (0 < streamsToAccept.length && !isAcceptingStreams) {
             dispatch(doHandleAcceptStreams(streamsToAccept));
         }
-    }
+    },
 );

--- a/packages/media/src/webrtc/types.ts
+++ b/packages/media/src/webrtc/types.ts
@@ -14,13 +14,11 @@ export interface RtcManager {
         clientId,
         shouldAddLocalVideo,
         streamId,
-        enforceTurnProtocol,
     }: {
         activeBreakout: boolean;
         clientId: string;
         shouldAddLocalVideo: boolean;
         streamId: string;
-        enforceTurnProtocol?: TurnTransportProtocol;
     }) => void;
     addNewStream(streamId: string, stream: MediaStream, isAudioEnabled: boolean, isVideoEnabled: boolean): void;
     disconnect(streamId: string, activeBreakout: boolean | null, eventClaim?: string): void;


### PR DESCRIPTION
### Description

**Summary:**
There were many problems with p2p node clients, so we tried a new webrtc implementation in node: https://github.com/WonderInventions/node-webrtc

After adding this, we had some problems with SFU rooms. We fixed it by using a different mediasoup device handler.
This lib also removes the need for TURN enforcement on p2p node agents
<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**
https://linear.app/whereby/issue/COB-1012/p2p-no-audio-if-there-are-more-than-1-dialed-in-users
<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
I'll add notes for testing on the recording-service side
<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->