### PR TITLE
media: handle sdp errors

### DIFF
--- a/.changeset/khaki-peaches-taste.md
+++ b/.changeset/khaki-peaches-taste.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": minor
+---
+
+media: Workround for some sdp errors

--- a/packages/media/src/webrtc/Session.ts
+++ b/packages/media/src/webrtc/Session.ts
@@ -38,7 +38,6 @@ export default class Session {
     shouldAddLocalVideo: any;
     signalingState: any;
     srdComplete: any;
-    pendingOffer: any;
 
     constructor({
         peerConnectionId,
@@ -218,15 +217,7 @@ export default class Session {
     }
 
     handleAnswer(message: any) {
-        // workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1394602
-        if (this.pendingOffer) {
-            const pendingOffer = this.pendingOffer;
-            delete this.pendingOffer;
-            return this.pc.setLocalDescription(pendingOffer).then(() => this.handleAnswer(message));
-        }
-        let sdp = message.sdp;
-
-        sdp = sdpModifier.filterMsidSemantic(sdp);
+        const sdp = sdpModifier.filterMsidSemantic(message.sdp);
 
         const desc = { type: message.type, sdp };
         return this._setRemoteDescription(desc).then(

--- a/packages/media/src/webrtc/rtcManagerEvents.ts
+++ b/packages/media/src/webrtc/rtcManagerEvents.ts
@@ -14,4 +14,7 @@ export default {
     SFU_CONNECTION_CLOSED: "sfu_connection_closed",
     COLOCATION_SPEAKER: "colocation_speaker",
     DOMINANT_SPEAKER: "dominant_speaker",
+    PC_SLD_FAILURE: "pc_sld_failure",
+    PC_ON_ANSWER_FAILURE: "pc_on_answer_failure",
+    PC_ON_OFFER_FAILURE: "pc_on_offer_failure",
 };


### PR DESCRIPTION
### Description
This PR adds an option to clean sdp before setLocalDescription, hopefully working around browser bugs like:
https://issues.webrtc.org/issues/41480892
(and a similar one on Firefox)
It adds events so we can track these kind of errors in our apps
It removes the pendingOffer logic as that was a workaround for a bug long time ago, and interfered with the tracking/events, and makes sure the offer isn't sent to remote end before working locally.

Testing instructions in PWA PR

