### PR TITLE
core: Do not allow knocking if room is not locked

### DIFF
--- a/.changeset/fair-hairs-tease.md
+++ b/.changeset/fair-hairs-tease.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": patch
+---
+
+Do not allow knocking if room is not locked

--- a/packages/core/src/redux/slices/roomConnection.ts
+++ b/packages/core/src/redux/slices/roomConnection.ts
@@ -153,6 +153,12 @@ export const doKnockRoom = createAppThunk(() => (dispatch, getState) => {
     const userAgent = selectAppUserAgent(state);
     const externalId = selectAppExternalId(state);
     const organizationId = selectOrganizationId(state);
+    const connectionStatus = selectRoomConnectionStatus(state);
+
+    if (connectionStatus !== "room_locked") {
+        console.warn("Room is not locked, knock aborted");
+        return;
+    }
 
     socket?.emit("knock_room", {
         avatarUrl: null,

--- a/packages/core/src/redux/tests/store/roomConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/roomConnection.spec.ts
@@ -3,18 +3,30 @@ import { doKnockRoom, doConnectRoom } from "../../slices/roomConnection";
 import { diff } from "deep-object-diff";
 
 describe("actions", () => {
-    it("doKnockRoom", async () => {
-        const store = createStore({ withSignalConnection: true });
+    describe("doKnockRoom", () => {
+        it("should knock if room is locked", async () => {
+            const store = createStore({
+                withSignalConnection: true,
+                initialState: { roomConnection: { status: "room_locked", session: null, error: null } },
+            });
 
-        const before = store.getState().roomConnection;
+            const before = store.getState().roomConnection;
 
-        store.dispatch(doKnockRoom());
+            store.dispatch(doKnockRoom());
 
-        const after = store.getState().roomConnection;
+            const after = store.getState().roomConnection;
 
-        expect(mockSignalEmit).toHaveBeenCalledWith("knock_room", expect.any(Object));
-        expect(diff(before, after)).toEqual({
-            status: "knocking",
+            expect(mockSignalEmit).toHaveBeenCalledWith("knock_room", expect.any(Object));
+            expect(diff(before, after)).toEqual({
+                status: "knocking",
+            });
+        });
+
+        it("should abort knocking if room is not locked", async () => {
+            const store = createStore({ withSignalConnection: true });
+
+            expect(() => store.dispatch(doKnockRoom())).toThrow("Room is not locked, knock aborted");
+            expect(mockSignalEmit).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
### Description
If the room is not locked/you are already connected to the room - we should not fire a knock event and change the connection status to `knocking`. This should not happen with correct usage, but we've seen at least one question around this, so better to put in this guard. If you try to knock and the room is not locked, we just send a warning in the console and do not fire the signal event.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. Download this snippet as `tmp_knock.patch`. This will just show the knock button regardless of the connection status in storybook
```diff
diff --git a/packages/browser-sdk/src/stories/components/VideoExperience.tsx b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
index 6be36c98..69559d87 100644
--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -244,12 +244,12 @@ export default function VideoExperience({
         <div>
             {!joinRoomOnLoad && connectionStatus === "ready" && <button onClick={() => joinRoom()}>Join room</button>}
             {connectionStatus === "connecting" && <span>Connecting...</span>}
-            {connectionStatus === "room_locked" && (
-                <div style={{ color: "red" }}>
-                    <span>Room locked, please knock....</span>
-                    <button onClick={() => knock()}>Knock</button>
-                </div>
-            )}
+
+            <div style={{ color: "red" }}>
+                <span>Room locked, please knock....</span>
+                <button onClick={() => knock()}>Knock</button>
+            </div>
+
             {connectionStatus === "knocking" && <span>Knocking...</span>}
             {connectionStatus === "knock_rejected" && <span>Rejected :(</span>}
             {connectionStatus === "connected" && (
```
2. Apply the patch: `git apply tmp_knock.patch`
3. Run yarn build && yarn dev
4. Open the "Room connection Only" story
5. Join the room
6. Click the knock button, verify that the connection status does not change (check redux state)
7. Verify that you see the console warning in the dev console
8. Verify that the signal event `knock_room` is not sent.

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
