### PR TITLE
media: Option for adding google and cloudflare stun servers

### DIFF
--- a/.changeset/metal-shirts-sparkle.md
+++ b/.changeset/metal-shirts-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": minor
+---
+
+media: Option for adding google and cloudflare stun servers


### PR DESCRIPTION
### Description

This adds options for adding google and cloudflare stun servers for P2P calls. Testing instructions in PWA PR

(most of the changes are by prettier)
