### PR TITLE
browser-sdk: Show placeholder cell when there's no stream

### DIFF
--- a/.changeset/mighty-seals-drum.md
+++ b/.changeset/mighty-seals-drum.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": patch
+---
+
+Show placeholder cell when there's no stream

--- a/packages/browser-sdk/src/lib/react/Grid/index.tsx
+++ b/packages/browser-sdk/src/lib/react/Grid/index.tsx
@@ -68,7 +68,13 @@ const GridVideoView = React.forwardRef<WherebyVideoElement, GridVideoViewProps>(
     const s = stream || participant.stream;
 
     if (!s) {
-        return null;
+        return (
+            <VideoMutedIndicator
+                isSmallCell={false}
+                displayName={participant?.displayName || "Guest"}
+                withRoundedCorners
+            />
+        );
     }
 
     return (


### PR DESCRIPTION
### Description
Show a placeholder (avatar) when there no stream for a participant in the video grid. Kind of an edge case since `isVideoEnabled` needs to be true as well, but we had a report for this from a customer. 

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
I couldn't reproduce this just by blocking media permissions (`isVideoEnabled` would be `false`). I created a patch to verify though, and this can be used to test:

1. On main: Save this snippet as `tmp_no_stream.patch`, and apply it `git apply tmp_no_stream.patch`
```diff

diff --git a/packages/core/src/redux/slices/remoteParticipants.ts b/packages/core/src/redux/slices/remoteParticipants.ts
index 3d1d9de9..2a7a835a 100644
--- a/packages/core/src/redux/slices/remoteParticipants.ts
+++ b/packages/core/src/redux/slices/remoteParticipants.ts
@@ -25,7 +25,8 @@ function createRemoteParticipant(client: SignalClient, newJoiner = false): Remot
     return {
         ...rest,
         stream: null,
-        streams: streams.map((streamId) => ({ id: streamId, state: newJoiner ? "new_accept" : "to_accept" })),
+        streams: [],
+        isVideoEnabled: true,
         isLocalParticipant: false,
         roleName: role?.roleName || "none",
         presentationStream: null,
```

2. Run `yarn build && yarn dev`
3. Go to the Video Grid UI story, and join the same room in another tab
4. Verify that you see an empty cell next to the local participant cell.
5. Checkout this branch and apply the patch again
6. Go to the Video Grid UI story, and join the same room in another tab
7. Verify that you now see an avatar for the remote participant.


### Screenshots/GIFs (if applicable)
before
![image](https://github.com/user-attachments/assets/675f66a7-fb67-45c6-884b-c1b7dcab15e9)


after
![image](https://github.com/user-attachments/assets/e214664d-6c57-46af-a410-ed78ed5b35f3)


### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
