### PR TITLE
browser-sdk: Auto mute video cell of local participant in video grid

### DIFF
--- a/.changeset/khaki-humans-add.md
+++ b/.changeset/khaki-humans-add.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": patch
+---
+
+Auto mute video cell of local participant in video grid

--- a/packages/browser-sdk/src/lib/react/Grid/index.tsx
+++ b/packages/browser-sdk/src/lib/react/Grid/index.tsx
@@ -79,6 +79,7 @@ const GridVideoView = React.forwardRef<WherebyVideoElement, GridVideoViewProps>(
                 ...(isConstrained ? { objectFit: "cover" } : {}),
                 ...style,
             }}
+            muted={participant.isLocalClient}
             {...rest}
             stream={s}
             onVideoResize={handleResize}

--- a/packages/browser-sdk/src/stories/video-grid-ui.stories.tsx
+++ b/packages/browser-sdk/src/stories/video-grid-ui.stories.tsx
@@ -58,7 +58,7 @@ export const VideoGridStory = {
         }
         const [isLocalScreenshareActive, setIsLocalScreenshareActive] = React.useState(false);
 
-        const { actions } = useRoomConnection(roomUrl, { localMediaOptions: { audio: false, video: true } });
+        const { actions } = useRoomConnection(roomUrl, { localMediaOptions: { audio: true, video: true } });
         const { toggleCamera, toggleMicrophone, startScreenshare, stopScreenshare, joinRoom, leaveRoom } = actions;
 
         React.useEffect(() => {


### PR DESCRIPTION
### Description
Currently we don't auto-mute the video view of the local participant in the videogrid, which will cause echo when using the default grid. An oversight that wasn't caught because the storybook for the video grid had `audio: false` in the local media options for the room connection, meaning we never got the echo issues there..

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. Go to Video Grid story
2. Verify that there's no echo

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
