### PR TITLE
core: Add js files in package.json

### DIFF
--- a/.changeset/loud-donkeys-exercise.md
+++ b/.changeset/loud-donkeys-exercise.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": patch
+---
+
+Add .js files to the files array in package.json

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
         "access": "public"
     },
     "files": [
+        "dist/*.js",
         "dist/*.cjs",
         "dist/*.mjs",
         "dist/*.d.ts",


### PR DESCRIPTION
### Description

We generate `legacy-esm.js` but currently don't list `.js` files in the package.json, so it's not included in the NPM package.

Fixes #483 


**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
