### PR TITLE
browser-sdk: Add custom redux context

### DIFF
--- a/.changeset/silly-students-hope.md
+++ b/.changeset/silly-students-hope.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": minor
+---
+
+Add custom redux context

--- a/packages/browser-sdk/src/lib/react/Provider/hooks.ts
+++ b/packages/browser-sdk/src/lib/react/Provider/hooks.ts
@@ -1,5 +1,5 @@
-import { useDispatch, useSelector } from "react-redux";
 import { RootState, AppDispatch } from "@whereby.com/core";
+import { useDispatch, useSelector } from ".";
 
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
 export const useAppSelector = useSelector.withTypes<RootState>();

--- a/packages/browser-sdk/src/lib/react/Provider/index.tsx
+++ b/packages/browser-sdk/src/lib/react/Provider/index.tsx
@@ -1,6 +1,19 @@
 import * as React from "react";
-import { Provider as ReduxProvider } from "react-redux";
+import {
+    Provider as ReduxProvider,
+    createStoreHook,
+    createDispatchHook,
+    createSelectorHook,
+    ReactReduxContextValue,
+} from "react-redux";
 import { createServices, createStore } from "@whereby.com/core";
+import { Action } from "@reduxjs/toolkit";
+
+const WherebyContext = React.createContext<ReactReduxContextValue<unknown, Action> | null>(null);
+
+export const useStore = createStoreHook(WherebyContext);
+export const useDispatch = createDispatchHook(WherebyContext);
+export const useSelector = createSelectorHook(WherebyContext);
 
 export interface ProviderProps {
     children: React.ReactNode;
@@ -10,7 +23,11 @@ function Provider({ children }: ProviderProps) {
     const services = createServices();
     const store = createStore({ injectServices: services });
 
-    return <ReduxProvider store={store}>{children}</ReduxProvider>;
+    return (
+        <ReduxProvider context={WherebyContext} store={store}>
+            {children}
+        </ReduxProvider>
+    );
 }
 
 export { Provider };

--- a/packages/browser-sdk/src/stories/custom-ui-with-redux.stories.tsx
+++ b/packages/browser-sdk/src/stories/custom-ui-with-redux.stories.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import VideoExperience from "./components/VideoExperience";
+import "./styles.css";
+import { Provider as WherebyProvider } from "../lib/react/Provider";
+import { StoryFn } from "@storybook/react";
+import { decremented, incremented, Provider, selectCount } from "./redux-store";
+import { useDispatch, useSelector } from "react-redux";
+
+// This is to test that the SDK works with a redux store in the consumer app, without interfering with the SDK's own redux store.
+const defaultArgs = {
+    title: "Examples/Custom UI with Redux",
+    argTypes: {
+        displayName: { control: "text" },
+        roomUrl: { control: "text", type: { required: true } },
+        externalId: { control: "text" },
+    },
+    args: {
+        displayName: "SDK",
+        roomUrl: process.env.STORYBOOK_ROOM,
+    },
+    decorators: [
+        (Story: StoryFn) => (
+            <WherebyProvider>
+                <Provider>
+                    <Story />
+                </Provider>
+            </WherebyProvider>
+        ),
+    ],
+};
+
+export default defaultArgs;
+
+const roomRegEx = new RegExp(/^https:\/\/.*\/.*/);
+
+export const RoomConnectionWithRedux = ({ roomUrl, displayName }: { roomUrl: string; displayName?: string }) => {
+    if (!roomUrl || !roomUrl.match(roomRegEx)) {
+        return <p>Set room url on the Controls panel</p>;
+    }
+    const dispatch = useDispatch();
+    const count = useSelector(selectCount);
+
+    return (
+        <>
+            <button onClick={() => dispatch(incremented())}>Increment</button>
+            <button onClick={() => dispatch(decremented())}>Decrement</button>
+            <p>Count: {count}</p>
+            <VideoExperience displayName={displayName} roomName={roomUrl} />
+        </>
+    );
+};

--- a/packages/browser-sdk/src/stories/redux-store.tsx
+++ b/packages/browser-sdk/src/stories/redux-store.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+
+import { createSlice, configureStore } from "@reduxjs/toolkit";
+import { Provider as ReduxProvider } from "react-redux";
+
+const counterSlice = createSlice({
+    name: "counter",
+    initialState: {
+        value: 0,
+    },
+    reducers: {
+        incremented: (state) => {
+            state.value += 1;
+        },
+        decremented: (state) => {
+            state.value -= 1;
+        },
+    },
+});
+
+export const { incremented, decremented } = counterSlice.actions;
+
+export const selectCount = (state: RootState) => state.value;
+
+const store = configureStore({
+    reducer: counterSlice.reducer,
+});
+
+type RootState = ReturnType<typeof store.getState>;
+
+const Provider = ({ children }: { children: React.ReactNode }) => {
+    return <ReduxProvider store={store}>{children}</ReduxProvider>;
+};
+
+export { Provider };


### PR DESCRIPTION
### Description

Currently, we don't support consumer apps using a redux store. This is because our redux context will interfere with their redux context, and you will get an error like this:
![image](https://github.com/user-attachments/assets/0ef4f855-1245-4b32-98d6-6dd85e4e6d83)

We can solve this by using a custom redux context, as done in this PR. I've added a storybook entry that has it's own small redux store, so we can test this. 

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. Download this snippet as `tmp_redux_patch.patch`, and apply it with `git apply tmp_redux_patch.patch`.
```diff
diff --git a/packages/browser-sdk/src/lib/react/Provider/hooks.ts b/packages/browser-sdk/src/lib/react/Provider/hooks.ts
index ecd2d03c..0ae6be21 100644
--- a/packages/browser-sdk/src/lib/react/Provider/hooks.ts
+++ b/packages/browser-sdk/src/lib/react/Provider/hooks.ts
@@ -1,5 +1,5 @@
+import { useDispatch, useSelector } from "react-redux";
 import { RootState, AppDispatch } from "@whereby.com/core";
-import { useDispatch, useSelector } from ".";
 
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
 export const useAppSelector = useSelector.withTypes<RootState>();
diff --git a/packages/browser-sdk/src/lib/react/Provider/index.tsx b/packages/browser-sdk/src/lib/react/Provider/index.tsx
index 866b9e7f..afca7432 100644
--- a/packages/browser-sdk/src/lib/react/Provider/index.tsx
+++ b/packages/browser-sdk/src/lib/react/Provider/index.tsx
@@ -1,19 +1,6 @@
 import * as React from "react";
-import {
-    Provider as ReduxProvider,
-    createStoreHook,
-    createDispatchHook,
-    createSelectorHook,
-    ReactReduxContextValue,
-} from "react-redux";
+import { Provider as ReduxProvider } from "react-redux";
 import { createServices, createStore } from "@whereby.com/core";
-import { Action } from "@reduxjs/toolkit";
-
-const WherebyContext = React.createContext<ReactReduxContextValue<unknown, Action> | null>(null);
-
-export const useStore = createStoreHook(WherebyContext);
-export const useDispatch = createDispatchHook(WherebyContext);
-export const useSelector = createSelectorHook(WherebyContext);
 
 export interface ProviderProps {
     children: React.ReactNode;
@@ -23,11 +10,7 @@ function Provider({ children }: ProviderProps) {
     const services = createServices();
     const store = createStore({ injectServices: services });
 
-    return (
-        <ReduxProvider context={WherebyContext} store={store}>
-            {children}
-        </ReduxProvider>
-    );
+    return <ReduxProvider store={store}>{children}</ReduxProvider>;
 }
 
 export { Provider };
```

This will just revert the changes in this PR, but keep the redux storybook entry (so that you can see how it fails).
2. `yarn build && yarn dev`
3. Go to the `Examples / Custom UI with Redux` story
4. Verify that it crashes and you get a similar message in the console as the post screenshot above.
5. `git stash`, remove the patch, and run `yarn build && yarn dev`
6. Go to the `Examples / Custom UI with Redux` story
7. Verify that you can connect to the room, and that both the SDK redux actions and the app's (increment/decrement) works as expected.

### Screenshots/GIFs (if applicable)

![image](https://github.com/user-attachments/assets/a2105ded-1cfa-49c4-b6ba-d8a264336f4c)


### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
