### PR TITLE
common: Move parseRoomUrlAndSubdomain to browser-sdk

### DIFF
--- a/.changeset/rare-cougars-sleep.md
+++ b/.changeset/rare-cougars-sleep.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": patch
+---
+
+embed: Remove use of core library

--- a/.changeset/spicy-phones-wait.md
+++ b/.changeset/spicy-phones-wait.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": minor
+---
+
+Remove parseRoomUrlAndSubdomain fn

--- a/packages/browser-sdk/src/lib/embed/__tests__/roomUrl.spec.ts
+++ b/packages/browser-sdk/src/lib/embed/__tests__/roomUrl.spec.ts
@@ -1,4 +1,4 @@
-import parseRoomUrlAndSubdomain from "../roomUrl";
+import { parseRoomUrlAndSubdomain } from "../roomUrl";
 
 describe("roomUrl", () => {
     describe("parseRoomUrlAndSubdomain", () => {

--- a/packages/browser-sdk/src/lib/embed/index.ts
+++ b/packages/browser-sdk/src/lib/embed/index.ts
@@ -1,7 +1,7 @@
 import { define, ref } from "heresy";
 import { ReactHTMLElement } from "react";
 
-import { parseRoomUrlAndSubdomain } from "@whereby.com/core";
+import { parseRoomUrlAndSubdomain } from "./roomUrl";
 
 type SettingsPane = "theme" | "integrations" | "streaming" | "effects" | "notifications" | "advanced" | "media" | null;
 

--- a/packages/browser-sdk/src/lib/embed/roomUrl.ts
+++ b/packages/browser-sdk/src/lib/embed/roomUrl.ts
@@ -1,4 +1,4 @@
-export default function parseRoomUrlAndSubdomain(roomAttribute?: string, subdomainAttribute?: string) {
+export function parseRoomUrlAndSubdomain(roomAttribute?: string, subdomainAttribute?: string) {
     if (!roomAttribute) {
         throw new Error("Missing room attribute");
     }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,3 @@
 export { default as getFakeMediaStream, getVideoTrack, getAudioTrack } from "./getFakeMediaStream";
 export { default as debounce } from "./debounce";
-export { default as parseRoomUrlAndSubdomain } from "./roomUrl";
 export { default as parseUnverifiedRoomKeyData } from "./roomKey";


### PR DESCRIPTION
### Description
The `parseRoomUrlAndSubdomain function is only used in the embed lib, and this function is the only import the embed lib has to core. It seems unnecessary that users importing the embed lib needs to import core because of this. We had a situation with a customer that had to define process.env in their webpack setup because of this one import. 

This PR moves the function to `browser-sdk`. This means that the `embed` package doesn't need to have a dependency to `core`. 

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. `yarn build && yarn dev`
2. Go to the prebuilt ui story
3. Verify that it works as expected

### Screenshots/GIFs (if applicable)

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

