### PR TITLE
Handle missing features in BandwidthTester

### DIFF
--- a/.changeset/swift-pandas-study.md
+++ b/.changeset/swift-pandas-study.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Fix property access of undefined bug in BandwidthTester

--- a/packages/media/src/webrtc/BandwidthTester.ts
+++ b/packages/media/src/webrtc/BandwidthTester.ts
@@ -37,7 +37,7 @@ export default class BandwidthTester extends EventEmitter {
 
         this._vegaConnection = null;
 
-        this._mediasoupDevice = getMediasoupDevice(features);
+        this._mediasoupDevice = getMediasoupDevice(this._features);
 
         this._routerRtpCapabilities = null;
 


### PR DESCRIPTION
### Description
The `getMediasoupDevice` call was throwing because we don't actually pass features into the BandwidthTester from PWA
**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. add this canary to PWA
1. run a bandwidth test

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->