### PR TITLE
media: Only use Safari17 handler when flag is eanbled

### DIFF
--- a/.changeset/cyan-elephants-shake.md
+++ b/.changeset/cyan-elephants-shake.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Fix Safari17 Mediasoup handler selection logic

--- a/packages/media/src/utils/__tests__/getMediasoupDevice.spec.ts
+++ b/packages/media/src/utils/__tests__/getMediasoupDevice.spec.ts
@@ -63,13 +63,36 @@ describe("getMediasoupClient", () => {
         });
     });
 
-    describe.each(["AppleCoreMedia", "AppleWebkit", "Safari", "iphone", "ipad"])(
-        "when the userAgent matches %s",
-        (userAgent) => {
-            beforeEach(() => {
-                (global as any).userAgent.mockReturnValue(userAgent);
-            });
+    describe.each(["applecoremedia", "applewebkit", "safari"])("when the userAgent matches %s", (userAgent) => {
+        beforeEach(() => {
+            (global as any).userAgent.mockReturnValue(userAgent);
+        });
 
+        it("returns a Safari12 device", () => {
+            const factory = jest.fn();
+            Safari17.createFactory.mockImplementation(() => factory);
+
+            getMediasoupDevice({ safari17HandlerOn: false });
+
+            expect(mediasoupClient.Device).toHaveBeenCalledWith({ handlerName: "Safari12" });
+        });
+    });
+
+    describe.each(["iphone", "ipad"])("when the userAgent matches %s", (userAgent) => {
+        beforeEach(() => {
+            (global as any).userAgent.mockReturnValue(userAgent);
+        });
+
+        it("returns a Safari12 device", () => {
+            const factory = jest.fn();
+            Safari17.createFactory.mockImplementation(() => factory);
+
+            getMediasoupDevice({ safari17HandlerOn: false });
+
+            expect(mediasoupClient.Device).toHaveBeenCalledWith({ handlerName: "Safari12" });
+        });
+
+        describe("when the safari17HandlerOn feature is enabled", () => {
             it("returns a Safari17 device", () => {
                 const factory = jest.fn();
                 Safari17.createFactory.mockImplementation(() => factory);
@@ -78,6 +101,6 @@ describe("getMediasoupClient", () => {
 
                 expect(mediasoupClient.Device).toHaveBeenCalledWith({ handlerFactory: factory });
             });
-        },
-    );
+        });
+    });
 });

--- a/packages/media/src/utils/getMediasoupDevice.ts
+++ b/packages/media/src/utils/getMediasoupDevice.ts
@@ -12,7 +12,7 @@ export const getMediasoupDevice = (features: Record<string, boolean | undefined>
     }
 
     let handlerName: SupportedDevice =
-        detectDevice() || (/applecoremedia|applewebkit|safari/i.test(navigator.userAgent) ? "Safari17" : undefined);
+        detectDevice() || (/applecoremedia|applewebkit|safari/i.test(navigator.userAgent) ? "Safari12" : undefined);
 
     if (handlerName === "Safari12" && typeof navigator === "object" && typeof navigator.userAgent === "string") {
         const uaParser = new UAParser(navigator.userAgent);
@@ -26,7 +26,13 @@ export const getMediasoupDevice = (features: Record<string, boolean | undefined>
 
     // Since custom browsers on iOS/iPadOS are using webkit under the hood, we must use
     // the Safari handler even if detected as something else (like Chrome)
-    if (/iphone|ipad/i.test(navigator.userAgent)) handlerName = "Safari17";
+    if (/iphone|ipad/i.test(navigator.userAgent)) {
+        if (features.safari17HandlerOn) {
+            handlerName = "Safari17";
+        } else {
+            handlerName = "Safari12";
+        }
+    }
 
     if (handlerName === "Safari17") {
         // we use a custom patched version of the Safari handler that fixes simulcast bandwidth limiting


### PR DESCRIPTION
-------

### Description

**Summary:**
There were some browser edge cases where Safari17 handler was being returned with the flag disabled, which is bad
<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. add this canary to PWA and go to an SFU room in iOS Safari and another browser
1. make sure you can hear the iOS safari client
2. 
<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->