### PR TITLE
media: fix mediasoup imports

### DIFF
--- a/.changeset/real-cougars-live.md
+++ b/.changeset/real-cougars-live.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Fix mediasoup client imports in Safari17Handler

--- a/packages/media/src/utils/Safari17Handler.ts
+++ b/packages/media/src/utils/Safari17Handler.ts
@@ -1,10 +1,10 @@
 import * as sdpTransform from "sdp-transform";
 import { Logger } from "mediasoup-client/lib/Logger.js";
-import * as utils from "mediasoup-client/lib/utils";
-import * as ortc from "mediasoup-client/lib/ortc";
-import * as sdpCommonUtils from "mediasoup-client/lib/handlers/sdp/commonUtils";
-import * as ortcUtils from "mediasoup-client/lib/handlers/ortc/utils";
-import { InvalidStateError } from "mediasoup-client/lib/errors";
+import * as utils from "mediasoup-client/lib/utils.js";
+import * as ortc from "mediasoup-client/lib/ortc.js";
+import * as sdpCommonUtils from "mediasoup-client/lib/handlers/sdp/commonUtils.js";
+import * as ortcUtils from "mediasoup-client/lib/handlers/ortc/utils.js";
+import { InvalidStateError } from "mediasoup-client/lib/errors.js";
 import {
     HandlerFactory,
     HandlerInterface,
@@ -17,12 +17,12 @@ import {
     HandlerSendDataChannelResult,
     HandlerReceiveDataChannelOptions,
     HandlerReceiveDataChannelResult,
-} from "mediasoup-client/lib/handlers/HandlerInterface";
-import { RemoteSdp } from "mediasoup-client/lib/handlers/sdp/RemoteSdp";
-import { parse as parseScalabilityMode } from "mediasoup-client/lib/scalabilityModes";
-import { IceParameters, DtlsRole } from "mediasoup-client/lib/Transport";
-import { RtpCapabilities, RtpParameters } from "mediasoup-client/lib/RtpParameters";
-import { SctpCapabilities, SctpStreamParameters } from "mediasoup-client/lib/SctpParameters";
+} from "mediasoup-client/lib/handlers/HandlerInterface.js";
+import { RemoteSdp } from "mediasoup-client/lib/handlers/sdp/RemoteSdp.js";
+import { parse as parseScalabilityMode } from "mediasoup-client/lib/scalabilityModes.js";
+import { IceParameters, DtlsRole } from "mediasoup-client/lib/Transport.js";
+import { RtpCapabilities, RtpParameters } from "mediasoup-client/lib/RtpParameters.js";
+import { SctpCapabilities, SctpStreamParameters } from "mediasoup-client/lib/SctpParameters.js";
 
 const logger = new Logger("Safari17");
 


### PR DESCRIPTION
node complains about them when running recording service workers

-------

### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. add media canary to PWA and join an SFU room with url params `?safari17HandlerOn&stats` in chrome and safari
1. make sure the video streams are rate limited in both browsers (OUT rates should roughly match this:)
<img width="193" alt="image" src="https://github.com/user-attachments/assets/4b13ae85-0a1a-440b-acc5-f6d106e267a7" />

1. go to the recording-service repo, checkout `dependabot/npm_and_yarn/whereby.com/core-0.32.1` and `yarn && yarn workspace captioner-worker start` - you should see an error like:
```bash
 /Users/kevinhanna/repos/whereby/recording-service/node_modules/.bin/tsc
node:internal/process/esm_loader:34
      internalBinding('errors').triggerUncaughtException(
                                ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/kevinhanna/repos/whereby/recording-service/node_modules/mediasoup-client/lib/utils' imported from /Users/kevinhanna/repos/whereby/recording-service/src/dial-in-worker/node_modules/@whereby.com/media/dist/index.mjs
Did you mean to import mediasoup-client/lib/utils.js?
```
1. `yarn workspace captioner-worker add <core-canary> && yarn captioner-worker start` - it should start propertly and complain about a lack of a roomUrl (you might also need to add a `deviceId` to the mockClient function...)

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->