### PR TITLE
media: createVegaConnectionManager

### DIFF
--- a/.changeset/fair-bananas-explode.md
+++ b/.changeset/fair-bananas-explode.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": minor
+---
+
+media: Adds vega connection manager

--- a/packages/media/src/utils/ServerSocket.ts
+++ b/packages/media/src/utils/ServerSocket.ts
@@ -161,6 +161,13 @@ export class ServerSocket {
         };
     }
 
+    onEngineEvent(eventName: string, handler: Function) {
+        this._socket.io?.on(eventName, handler);
+        return () => {
+            this._socket.io?.off(eventName, handler);
+        };
+    }
+
     /**
      * Register a new event handler to be triggered only once.
      *

--- a/packages/media/src/webrtc/VegaConnectionManager.ts
+++ b/packages/media/src/webrtc/VegaConnectionManager.ts
@@ -1,0 +1,245 @@
+import VegaConnection from "./VegaConnection";
+
+// used for analytics, and for reconnecting to last successful host
+type ConnectionInfo = {
+    host: string;
+    dc: string;
+    initialHost: string;
+    initialDC: string;
+    initialHostIndex: number;
+    initialDCIndex: number;
+    failedDCs: string[];
+    numFailedDCs: number;
+    failedHosts: string[];
+    numFailedHosts: number;
+    usedDCs: string[];
+    numUsedDCs: number;
+    usedHosts: string[];
+    numUsedHosts: number;
+    numConnections: number;
+};
+const timeNextServer = 500;
+const minTimeNextServerSameDC = 2000;
+const timeToWaitForEarlyServerClose = 100;
+
+type HostListEntry = {
+    host: string;
+    dc: string;
+};
+export type HostListEntryOptionalDC = {
+    host: string;
+    dc?: string;
+};
+
+// converts serialized hostlists and hostlists with undefined DCs to a proper format
+export function convertToProperHostList(hostList: string | HostListEntryOptionalDC[]) {
+    if (typeof hostList === "string") {
+        return hostList
+            .split(",")
+            .filter(Boolean)
+            .map((hostString) => {
+                const [dc, host] = /\|/.test(hostString) ? hostString.split("|") : ["", hostString];
+                return { host, dc };
+            });
+    }
+    return hostList.filter((item) => item.host).map((item) => ({ host: item.host, dc: item.dc || "" }));
+}
+// responsible for checking and nominating (delivering) 1 working sfu websocket connection
+// it will use a prioritized list of hosts to try
+export function createVegaConnectionManager(config: {
+    initialHostList: string | any[];
+    getUrlForHost?: (host: string) => string;
+    onConnected?: (vegaConnection: VegaConnection, info: ConnectionInfo) => void;
+    onDisconnected?: () => void;
+    onFailed?: () => void;
+}) {
+    let connectionInfo: ConnectionInfo;
+    let lastDisconnectTime: number | undefined;
+    let lastNetworkUpTime: number | undefined;
+    let lastNetworkPossiblyDownTime: number | undefined;
+
+    let hostList = [] as HostListEntry[];
+
+    const updateHostList = (updatedHostList: string | HostListEntryOptionalDC[]) => {
+        hostList = convertToProperHostList(updatedHostList);
+    };
+
+    let connectionAttemptInProgress = false;
+    let hasPendingConnectionAttempt = false;
+
+    // connect() will try all hosts maximum once. if one of the hosts get connected, the others will be aborted
+    // if all fails and the onFailed is run, it is the callers responsibility to retry, maybe after a delay.
+    // next time the list of host might be different.
+    // if connect() is called after being previously connected, it will retry the same host it used to be
+    // connected to, until network has been up for 3s, earliest 3s after the sfu disconnect
+    // this way it should recover to the same server if network loss, which might not be detected yet (it can
+    // lag 2s behind because of the noop probing on signal)
+    const connect = () => {
+        // do not allow parallell runs of this. If one or more runs are attempted while running, run it ONCE more after done
+        if (connectionAttemptInProgress) {
+            hasPendingConnectionAttempt = true;
+            return;
+        }
+        connectionAttemptInProgress = true;
+        hasPendingConnectionAttempt = false;
+
+        // default to testing all hosts in hostlist
+        let targetHostList = hostList;
+
+        if (connectionInfo) {
+            // but if we are reconnecting we might want to only try the last successful host
+            const now = Date.now();
+            const isLongEnoughSinceDisconnect = now - 3000 > (lastDisconnectTime || 0);
+            const isNetworkUp = !lastNetworkPossiblyDownTime || (lastNetworkUpTime || 0) > lastNetworkPossiblyDownTime;
+            const hasNetworkBeenUpLongEnough = isNetworkUp && now - 3000 > (lastNetworkUpTime || 0);
+
+            if (!isLongEnoughSinceDisconnect || !hasNetworkBeenUpLongEnough) {
+                // this is shortly after a disconnect and we're not sure if network is up
+                // so we retry only the last successful host for now
+                targetHostList = [{ host: connectionInfo.host, dc: connectionInfo.dc }];
+            }
+        }
+
+        // create lookup for finding index of DC
+        // purely for analytics purpose
+        const dcIndexByDC = {} as Record<string, number>;
+        let currentDCIndex = 0;
+        targetHostList.forEach(({ dc }) => {
+            if (typeof dcIndexByDC[dc] === "undefined") dcIndexByDC[dc] = currentDCIndex++;
+        });
+
+        // setup connection attempts for all hosts, with delays according to priority and DC
+        // a new host might be tested before the previous is resolved, so multiple connections might exist in parallell
+        // the first host that is connected will be used
+        let timeBeforeConnect = 0;
+        const prevTimeBeforeConnectByDC = {} as Record<string, number>;
+        let nominatedConnection: VegaConnection | undefined;
+        let connectionsToResolve = targetHostList.length;
+        let hasNotifiedDisconnect = false;
+        let wasConnected = false;
+        targetHostList.forEach(({ host, dc }, index) => {
+            if (index > 0) {
+                timeBeforeConnect += timeNextServer;
+                const minTimeBeforeConnect = (prevTimeBeforeConnectByDC[dc] || 0) + minTimeNextServerSameDC;
+                timeBeforeConnect = Math.max(timeBeforeConnect, minTimeBeforeConnect);
+            }
+            prevTimeBeforeConnectByDC[dc] = timeBeforeConnect;
+
+            setTimeout(() => {
+                if (wasConnected) return;
+                const vegaConnection = new VegaConnection(config.getUrlForHost?.(host) || host);
+                let wasClosed = false;
+                vegaConnection.on("open", () => {
+                    // we are connected, but proxies or full/busy servers may close, so we wait a bit
+                    setTimeout(() => {
+                        if (wasClosed) return;
+                        if (!nominatedConnection && !wasConnected) {
+                            nominatedConnection = vegaConnection;
+                            wasConnected = true;
+
+                            const thisRoundFailedHosts = [
+                                ...new Set(
+                                    targetHostList
+                                        .slice(0, index)
+                                        .filter((o) => o.host !== host)
+                                        .map((o) => o.host),
+                                ),
+                            ];
+                            const thisRoundFailedDCs = [
+                                ...new Set(
+                                    targetHostList
+                                        .slice(0, index)
+                                        .filter((o) => o.dc !== dc)
+                                        .map((o) => o.dc),
+                                ),
+                            ];
+                            if (!connectionInfo) {
+                                connectionInfo = {
+                                    host,
+                                    dc,
+                                    initialHost: host,
+                                    initialDC: dc,
+                                    initialHostIndex: index,
+                                    initialDCIndex: dcIndexByDC[dc],
+                                    failedHosts: thisRoundFailedHosts,
+                                    failedDCs: thisRoundFailedDCs,
+                                    usedHosts: [host],
+                                    usedDCs: [dc],
+                                    numConnections: 1,
+                                    numUsedDCs: 1,
+                                    numUsedHosts: 1,
+                                    numFailedDCs: 0, // calculate this later
+                                    numFailedHosts: 0, // calculate this later
+                                };
+                            } else {
+                                connectionInfo = {
+                                    ...connectionInfo,
+                                    host,
+                                    dc,
+                                    failedHosts: [
+                                        ...new Set([...thisRoundFailedHosts, ...connectionInfo.failedHosts]),
+                                    ].filter(
+                                        (failedHost) =>
+                                            failedHost !== host && !connectionInfo.usedHosts.includes(failedHost),
+                                    ),
+                                    failedDCs: [
+                                        ...new Set([...thisRoundFailedDCs, ...connectionInfo.failedDCs]),
+                                    ].filter(
+                                        (failedDC) => failedDC !== dc && !connectionInfo.usedDCs.includes(failedDC),
+                                    ),
+                                    usedHosts: [...new Set([...connectionInfo.usedHosts, host])],
+                                    usedDCs: [...new Set([...connectionInfo.usedDCs, dc])],
+                                    numConnections: connectionInfo.numConnections + 1,
+                                };
+                            }
+                            // update convenient props (posthog cannot query on length of set)
+                            connectionInfo.numUsedDCs = connectionInfo.usedDCs.length;
+                            connectionInfo.numUsedHosts = connectionInfo.usedHosts.length;
+                            connectionInfo.numFailedDCs = connectionInfo.failedDCs.length;
+                            connectionInfo.numFailedHosts = connectionInfo.failedHosts.length;
+
+                            // if we have a pending connect() abort it as we're already connected
+                            hasPendingConnectionAttempt = false;
+                            connectionAttemptInProgress = false;
+
+                            config.onConnected?.(vegaConnection, connectionInfo);
+                        } else {
+                            vegaConnection.close();
+                        }
+                    }, timeToWaitForEarlyServerClose);
+                });
+                vegaConnection.on("close", () => {
+                    wasClosed = true;
+                    if (vegaConnection === nominatedConnection) {
+                        // the nominated connection was closed
+                        nominatedConnection = undefined;
+                        lastDisconnectTime = Date.now();
+                        hasNotifiedDisconnect = true;
+                        config.onDisconnected?.();
+                    }
+                    connectionsToResolve--;
+                    if (connectionsToResolve === 0 && !hasNotifiedDisconnect) {
+                        connectionAttemptInProgress = false;
+                        if (hasPendingConnectionAttempt) {
+                            // if we have a pending connect attempt we don't notify about this fail, we instead trigger a new attempt
+                            setTimeout(connect, 0);
+                        } else {
+                            config.onFailed?.();
+                        }
+                    }
+                });
+            }, timeBeforeConnect);
+        });
+    };
+
+    updateHostList(config.initialHostList);
+
+    const networkIsUp = () => {
+        lastNetworkUpTime = Math.max(Date.now(), lastNetworkUpTime || 0);
+    };
+    const networkIsPossiblyDown = () => {
+        lastNetworkPossiblyDownTime = Date.now();
+    };
+
+    return { connect, updateHostList, networkIsUp, networkIsPossiblyDown };
+}

--- a/packages/media/src/webrtc/rtcManagerEvents.ts
+++ b/packages/media/src/webrtc/rtcManagerEvents.ts
@@ -12,6 +12,7 @@ export default {
     NEW_PC: "new_pc",
     SFU_CONNECTION_OPEN: "sfu_connection_open",
     SFU_CONNECTION_CLOSED: "sfu_connection_closed",
+    SFU_CONNECTION_INFO: "sfu_connection_info",
     COLOCATION_SPEAKER: "colocation_speaker",
     DOMINANT_SPEAKER: "dominant_speaker",
     PC_SLD_FAILURE: "pc_sld_failure",

--- a/packages/media/tests/webrtc/VegaConnectionManager.spec.ts
+++ b/packages/media/tests/webrtc/VegaConnectionManager.spec.ts
@@ -1,0 +1,434 @@
+import { convertToProperHostList, createVegaConnectionManager } from "../../src/webrtc/VegaConnectionManager";
+import VegaConnection from "../../src/webrtc/VegaConnection";
+import { EventEmitter } from "events";
+
+describe("convertToProperHostList", () => {
+    it("converts a serialized string of hosts to an array of hosts", () => {
+        expect(convertToProperHostList("host1:23,dc_a|host2,dc_b|sfu.bhost.com:999")).toStrictEqual([
+            { host: "host1:23", dc: "" },
+            { host: "host2", dc: "dc_a" },
+            { host: "sfu.bhost.com:999", dc: "dc_b" },
+        ]);
+    });
+
+    it("makes sure DCs are initialized to blank string if not provided", () => {
+        expect(
+            convertToProperHostList([
+                { host: "host1", dc: "a" },
+                { host: "host2" },
+                { host: "host3" },
+                { host: "host4", dc: "" },
+            ]),
+        ).toStrictEqual([
+            { host: "host1", dc: "a" },
+            { host: "host2", dc: "" },
+            { host: "host3", dc: "" },
+            { host: "host4", dc: "" },
+        ]);
+    });
+});
+
+// creates mock VegaConnection with events emitted at timings specified in url
+// example: 'host1 open:100 close:400' will fire open 100ms after construction, and close 400ms after construction
+jest.mock("../../src/webrtc/VegaConnection.ts", () => {
+    return jest.fn().mockImplementation((url) => {
+        const emitter = new EventEmitter();
+        url.replace(/(open|close):(\d+)/gi, (_: any, eventName: any, timing: any) => {
+            setTimeout(() => {
+                emitter.emit(eventName);
+            }, parseInt(timing));
+        });
+        return {
+            on: (eventName: string, listener: any) => emitter.on(eventName, listener),
+            close: () => emitter.emit("close"),
+            url,
+        };
+    });
+});
+
+describe("createVegaConnectionManager", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.clearAllMocks();
+    });
+
+    it("works sending a single host as a string", () => {
+        const onConnected = jest.fn();
+        const { connect } = createVegaConnectionManager({
+            initialHostList: "host1 open:100",
+            onConnected,
+        });
+        connect();
+        jest.runAllTimers();
+        expect(onConnected).toHaveBeenCalledTimes(1);
+        expect(onConnected).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                url: "host1 open:100",
+            }),
+            expect.anything(),
+        );
+        expect(VegaConnection).toHaveBeenCalledTimes(1);
+    });
+
+    it("works sending a multiple hosts as a string", () => {
+        const onConnected = jest.fn();
+        const { connect } = createVegaConnectionManager({
+            initialHostList: "host1 close:100,host2 open:100",
+            onConnected,
+        });
+        connect();
+        jest.runAllTimers();
+        expect(onConnected).toHaveBeenCalledTimes(1);
+        expect(onConnected).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                url: "host2 open:100",
+            }),
+            expect.anything(),
+        );
+        expect(VegaConnection).toHaveBeenCalledTimes(2);
+    });
+
+    it("tries connecting to hosts in order provided with delays between them", () => {
+        const { connect } = createVegaConnectionManager({
+            initialHostList: [
+                { host: "host1", dc: "a" },
+                { host: "host2", dc: "b" },
+                { host: "host3", dc: "a" },
+            ],
+        });
+        connect();
+        jest.advanceTimersToNextTimer();
+        expect(VegaConnection).toHaveBeenCalledTimes(1);
+        expect(VegaConnection).toHaveBeenNthCalledWith(1, "host1");
+        jest.advanceTimersToNextTimer();
+        expect(VegaConnection).toHaveBeenCalledTimes(2);
+        expect(VegaConnection).toHaveBeenNthCalledWith(2, "host2");
+        jest.advanceTimersToNextTimer();
+        expect(VegaConnection).toHaveBeenCalledTimes(3);
+        expect(VegaConnection).toHaveBeenNthCalledWith(3, "host3");
+    });
+
+    it("emits successful connection and doesn't attempt to connect to other hosts after if fast enough", () => {
+        const onConnected = jest.fn();
+        const { connect } = createVegaConnectionManager({
+            initialHostList: [
+                { host: "host1", dc: "a" },
+                { host: "host2 open:100", dc: "b" },
+                { host: "host3", dc: "a" },
+                { host: "host4", dc: "a" },
+            ],
+            onConnected,
+        });
+        connect();
+        jest.runAllTimers();
+        expect(onConnected).toHaveBeenCalledTimes(1);
+        expect(onConnected).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                url: "host2 open:100",
+            }),
+            expect.anything(),
+        );
+        expect(VegaConnection).toHaveBeenCalledTimes(2);
+    });
+
+    it("tries multiple hosts in parallel if slow, but only emits the one that opens first (even if all opens)", () => {
+        const onConnected = jest.fn();
+        const { connect } = createVegaConnectionManager({
+            initialHostList: [
+                { host: "host1 open:7000", dc: "a" },
+                { host: "host2 open:5000", dc: "b" },
+                { host: "host3 open:2000", dc: "c" },
+                { host: "host4 open:5000", dc: "d" },
+            ],
+            onConnected,
+        });
+        connect();
+        jest.runAllTimers();
+        expect(onConnected).toHaveBeenCalledTimes(1);
+        expect(onConnected).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                url: "host3 open:2000",
+            }),
+            expect.anything(),
+        );
+        expect(VegaConnection).toHaveBeenCalledTimes(4);
+    });
+
+    it("emits failed if all hosts fail", () => {
+        const onConnected = jest.fn();
+        const onFailed = jest.fn();
+        const { connect } = createVegaConnectionManager({
+            initialHostList: [
+                { host: "host1 close:100", dc: "a" },
+                { host: "host2 close:100", dc: "b" },
+                { host: "host3 close:100", dc: "c" },
+                { host: "host4 close:100", dc: "d" },
+            ],
+            onConnected,
+            onFailed,
+        });
+        connect();
+        jest.runAllTimers();
+        expect(onConnected).toHaveBeenCalledTimes(0);
+        expect(VegaConnection).toHaveBeenCalledTimes(4);
+        expect(onFailed).toHaveBeenCalledTimes(1);
+    });
+
+    it("doesn't run multiple times if called while in progress, if one of the hosts connect", () => {
+        const onConnected = jest.fn();
+        const onFailed = jest.fn();
+        const { connect } = createVegaConnectionManager({
+            initialHostList: [
+                { host: "host1 close:100", dc: "a" },
+                { host: "host2 close:100", dc: "b" },
+                { host: "host3 open:100", dc: "c" },
+                { host: "host4 close:100", dc: "d" },
+            ],
+            onConnected,
+            onFailed,
+        });
+        connect();
+        jest.advanceTimersToNextTimer();
+        connect(); // is ignored
+        jest.advanceTimersToNextTimer();
+        connect(); // is ignored
+        connect(); // is ignored
+        jest.runAllTimers();
+        expect(VegaConnection).toHaveBeenCalledTimes(3);
+        expect(onConnected).toHaveBeenCalledTimes(1);
+        expect(onFailed).toHaveBeenCalledTimes(0);
+    });
+
+    it("will run (only) once more, if connect() is called again while first round is in progress, if all fails, so hostlist or network can change followed by a new connect()", () => {
+        const onConnected = jest.fn();
+        const onFailed = jest.fn();
+        const { connect, updateHostList } = createVegaConnectionManager({
+            initialHostList: [
+                { host: "host1 close:100", dc: "a" },
+                { host: "host2 close:100", dc: "b" },
+                { host: "host3 close:100", dc: "c" },
+                { host: "host4 close:100", dc: "d" },
+            ],
+            onConnected,
+            onFailed,
+        });
+        connect();
+        jest.advanceTimersToNextTimer();
+        updateHostList([
+            { host: "host1 close:100", dc: "a" },
+            { host: "host2 close:100", dc: "b" },
+            { host: "host3new open:100", dc: "c" },
+            { host: "host4 close:100", dc: "d" }, // never attempted as previous connects
+        ]);
+        connect();
+        jest.advanceTimersToNextTimer();
+        connect();
+        connect();
+        connect(); // sum of all these connects will result in 1 extra run, with updated hostlist
+        jest.runAllTimers();
+        expect(onConnected).toHaveBeenCalledTimes(1);
+        expect(onConnected).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                url: "host3new open:100",
+            }),
+            expect.anything(),
+        );
+        expect(VegaConnection).toHaveBeenCalledTimes(7);
+        expect(onFailed).toHaveBeenCalledTimes(0);
+    });
+
+    it("will treat a close shortly after open as a failed connection", () => {
+        const onConnected = jest.fn();
+        const { connect } = createVegaConnectionManager({
+            initialHostList: [
+                { host: "host1", dc: "a" },
+                { host: "host2 open:100 close:150", dc: "b" }, // failed connection
+                { host: "host3 open:100", dc: "c" },
+                { host: "host4", dc: "d" },
+            ],
+            onConnected,
+        });
+        connect();
+        jest.runAllTimers();
+        expect(onConnected).toHaveBeenCalledTimes(1);
+        expect(onConnected).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                url: "host3 open:100",
+            }),
+            expect.anything(),
+        );
+        expect(VegaConnection).toHaveBeenCalledTimes(3);
+    });
+
+    it("will treat a close long after open as a successful connection, and emit disconnected not failed when closing", () => {
+        const onConnected = jest.fn();
+        const onDisconnected = jest.fn();
+        const onFailed = jest.fn();
+        const { connect } = createVegaConnectionManager({
+            initialHostList: [
+                { host: "host1", dc: "a" },
+                { host: "host2 open:100 close:5000", dc: "b" }, // successful connection, closes later
+                { host: "host3 open:100", dc: "c" },
+                { host: "host4", dc: "d" },
+            ],
+            onConnected,
+            onDisconnected,
+            onFailed,
+        });
+        connect();
+        jest.runAllTimers();
+        expect(onConnected).toHaveBeenCalledTimes(1);
+        expect(onConnected).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                url: "host2 open:100 close:5000",
+            }),
+            expect.anything(),
+        );
+        expect(onFailed).toHaveBeenCalledTimes(0);
+        expect(onDisconnected).toHaveBeenCalledTimes(1);
+        expect(VegaConnection).toHaveBeenCalledTimes(2);
+    });
+
+    it("will retry the last connected host shortly after network problems, the old or updated hostlist after a while", () => {
+        const onConnected = jest.fn();
+        const onDisconnected = jest.fn();
+        const { connect, updateHostList } = createVegaConnectionManager({
+            initialHostList: [
+                { host: "badhost1 close:100", dc: "a" },
+                { host: "goodhost1 open:100 close:5000", dc: "b" },
+                { host: "badhost2 close:5000", dc: "c" },
+            ],
+            onConnected,
+            onDisconnected,
+        });
+        connect();
+        jest.runAllTimers();
+        expect(onConnected).toHaveBeenCalledTimes(1);
+        expect(onConnected).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                url: "goodhost1 open:100 close:5000",
+            }),
+            expect.anything(),
+        );
+        expect(VegaConnection).toHaveBeenCalledTimes(2);
+        expect(onDisconnected).toHaveBeenCalledTimes(1);
+
+        // at this point vega connection is just closed
+
+        // we got updated hostlist
+        updateHostList([
+            { host: "newbadhost1 close:100", dc: "a" },
+            { host: "newbadhost2 close:100", dc: "b" },
+            { host: "newgoodhost1 open:100", dc: "c" },
+        ]);
+
+        // reconnect attempt shorty after
+        jest.advanceTimersByTime(1000);
+        connect();
+
+        jest.runAllTimers();
+        expect(onConnected).toHaveBeenCalledTimes(2); // connected for the 2nd time
+        expect(onConnected).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                url: "goodhost1 open:100 close:5000", // but same host
+            }),
+            expect.anything(),
+        );
+        expect(VegaConnection).toHaveBeenCalledTimes(3); // only 1 more connection is tested
+        expect(onDisconnected).toHaveBeenCalledTimes(2); // and disconnects after a while
+
+        // we are closed again
+        // but this time we wait longer before connect
+        jest.advanceTimersByTime(5000);
+        connect();
+
+        jest.runAllTimers();
+        expect(onConnected).toHaveBeenCalledTimes(3); // connected for the 3rd time
+        expect(onConnected).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                url: "newgoodhost1 open:100", // the updated host is used now
+            }),
+            expect.anything(),
+        );
+        expect(VegaConnection).toHaveBeenCalledTimes(6); // 3 more connection are tested
+    });
+
+    it("will provide analytics, updated and aggregated across multiple calls to connect()", () => {
+        const onConnected = jest.fn();
+        const { connect, updateHostList } = createVegaConnectionManager({
+            initialHostList: [
+                { host: "host1 close:100", dc: "a" },
+                { host: "host2 open:100 close:5000", dc: "b" },
+                { host: "host3 open:100", dc: "c" },
+                { host: "host4 open:100", dc: "d" },
+            ],
+            onConnected,
+        });
+        connect();
+        jest.runAllTimers();
+        const initialExpectedAnalytics = {
+            host: "host2 open:100 close:5000",
+            dc: "b",
+            initialHost: "host2 open:100 close:5000",
+            initialDC: "b",
+            initialHostIndex: 1,
+            initialDCIndex: 1,
+            usedHosts: ["host2 open:100 close:5000"],
+            usedDCs: ["b"],
+            failedHosts: ["host1 close:100"], // only this has failed, the rest we dont know
+            failedDCs: ["a"], // only this has failed, the rest we dont know
+            numConnections: 1, // we have only connected once
+            numUsedHosts: 1,
+            numUsedDCs: 1,
+            numFailedHosts: 1,
+            numFailedDCs: 1,
+        };
+        expect(onConnected).toHaveBeenCalledTimes(1);
+        expect(onConnected).toHaveBeenLastCalledWith(
+            expect.anything(),
+            expect.objectContaining(initialExpectedAnalytics),
+        );
+
+        connect();
+        jest.runAllTimers();
+        expect(onConnected).toHaveBeenCalledTimes(2);
+        expect(onConnected).toHaveBeenNthCalledWith(
+            2,
+            expect.anything(),
+            expect.objectContaining({ ...initialExpectedAnalytics, numConnections: 2 }),
+        );
+
+        updateHostList([
+            { host: "host1 close:100", dc: "a" },
+            { host: "host2 close:100", dc: "b" },
+            { host: "host3 close:100", dc: "c" },
+            { host: "host4 close:100", dc: "d" },
+            { host: "host5 open:100 close:5000", dc: "a" },
+        ]);
+        jest.advanceTimersByTime(5000);
+        connect();
+        jest.runAllTimers();
+        expect(onConnected).toHaveBeenCalledTimes(3);
+        expect(onConnected).toHaveBeenNthCalledWith(
+            3,
+            expect.anything(),
+            expect.objectContaining({
+                ...initialExpectedAnalytics,
+                numConnections: 3,
+                host: "host5 open:100 close:5000",
+                dc: "a",
+                usedHosts: [...initialExpectedAnalytics.usedHosts, "host5 open:100 close:5000"],
+                usedDCs: ["b", "a"],
+                numUsedHosts: 2,
+                numUsedDCs: 2,
+                failedHosts: ["host1 close:100", "host2 close:100", "host3 close:100", "host4 close:100"], // host2 close is not the same as host2 open
+                failedDCs: ["c", "d"], // a didn't fail afterall as we connected second round
+                numFailedHosts: 4,
+                numFailedDCs: 2,
+            }),
+        );
+    });
+});


### PR DESCRIPTION
### Description
This adds a connection manager that allows multiple failover hosts to be tested/used. When activated by feature `sfuConnectionManagerOn`, it will replace the old `connect()` logic with a new one. If using multiple hosts they must be specified in `sfuServers` (originating from signal), or `sfuServersOverride` (from prefs), otherwise it will use a single host (but new connect()) like before.

Testing instructions in PWA PR
