### PR TITLE
media: allow single audio or video stream if the other is denied or n…

### DIFF
--- a/.changeset/tall-bulldogs-suffer.md
+++ b/.changeset/tall-bulldogs-suffer.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": minor
+---
+
+Refactor getStream to allow single device

--- a/packages/media/tests/webrtc/MediaDevices.spec.ts
+++ b/packages/media/tests/webrtc/MediaDevices.spec.ts
@@ -351,9 +351,102 @@ describe("getStream", () => {
         expect(mockGUM.mock.calls[1][0].audio.deviceId).toBeUndefined();
     });
 
-    it("should retry video and audio seperately on NotFoundError", async () => {
+    it("should retry video and audio seperately on NotFoundError - audioTrack not found", async () => {
         let callCount = 0;
         const e = new MockError(GUM_ERRORS.NOT_FOUND);
+        const mockGUM: any = jest.fn(() => {
+            if (callCount === 1) return Promise.resolve(helpers.createMockedMediaStream([videoTrack1]));
+            else {
+                callCount++;
+                return Promise.reject(e);
+            }
+        });
+        global.navigator.mediaDevices.getUserMedia = mockGUM;
+        const type = "exact";
+
+        const result = await MediaDevices.getStream(
+            {
+                devices,
+                videoId: vdev2.deviceId,
+                audioId: adev2.deviceId,
+                type,
+            },
+            { replaceStream: stream },
+        );
+
+        expect(result.error).toBe(e);
+        expect(result.stream).toBeDefined();
+        expect(mockGUM.mock.calls[0][0].audio).toEqual(expect.any(Object));
+        expect(mockGUM.mock.calls[0][0].video).toEqual(expect.any(Object));
+        expect(mockGUM.mock.calls[1][0].audio).toBeUndefined();
+        expect(mockGUM.mock.calls[1][0].video).toEqual(expect.any(Object));
+    });
+    it("should retry video and audio seperately on NotFoundError - videoTrack not found", async () => {
+        let callCount = 0;
+        const e = new MockError(GUM_ERRORS.NOT_FOUND);
+        const mockGUM: any = jest.fn(() => {
+            if (callCount === 2) return Promise.resolve(helpers.createMockedMediaStream([audioTrack1]));
+            else {
+                callCount++;
+                return Promise.reject(e);
+            }
+        });
+        global.navigator.mediaDevices.getUserMedia = mockGUM;
+        const type = "exact";
+
+        const result = await MediaDevices.getStream(
+            {
+                devices,
+                videoId: vdev2.deviceId,
+                audioId: adev2.deviceId,
+                type,
+            },
+            { replaceStream: stream },
+        );
+
+        expect(result.error).toBe(e);
+        expect(result.stream).toBeDefined();
+        expect(mockGUM.mock.calls[0][0].audio).toEqual(expect.any(Object));
+        expect(mockGUM.mock.calls[0][0].video).toEqual(expect.any(Object));
+        expect(mockGUM.mock.calls[1][0].audio).toBeUndefined();
+        expect(mockGUM.mock.calls[1][0].video).toEqual(expect.any(Object));
+        expect(mockGUM.mock.calls[2][0].audio).toEqual(expect.any(Object));
+        expect(mockGUM.mock.calls[2][0].video).toBeUndefined();
+    });
+
+    it("should retry video and audio seperately on NotAllowedError - audio not allowed", async () => {
+        let callCount = 0;
+        const e = new MockError(GUM_ERRORS.NOT_ALLOWED);
+        const mockGUM: any = jest.fn(() => {
+            if (callCount === 1) return Promise.resolve(helpers.createMockedMediaStream([videoTrack1]));
+            else {
+                callCount++;
+                return Promise.reject(e);
+            }
+        });
+        global.navigator.mediaDevices.getUserMedia = mockGUM;
+        const type = "exact";
+
+        const result = await MediaDevices.getStream(
+            {
+                devices,
+                videoId: vdev2.deviceId,
+                audioId: adev2.deviceId,
+                type,
+            },
+            { replaceStream: stream },
+        );
+
+        expect(result.error).toBe(e);
+        expect(result.stream).toBeDefined();
+        expect(mockGUM.mock.calls[0][0].audio).toEqual(expect.any(Object));
+        expect(mockGUM.mock.calls[0][0].video).toEqual(expect.any(Object));
+        expect(mockGUM.mock.calls[1][0].audio).toBeUndefined();
+        expect(mockGUM.mock.calls[1][0].video).toEqual(expect.any(Object));
+    });
+    it("should retry video and audio seperately on NotAllowedError - video not allowed", async () => {
+        let callCount = 0;
+        const e = new MockError(GUM_ERRORS.NOT_ALLOWED);
         const mockGUM: any = jest.fn(() => {
             if (callCount === 2) return Promise.resolve(helpers.createMockedMediaStream([audioTrack1]));
             else {


### PR DESCRIPTION
…ot found

### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->
We were facing some issues where when either the camera or microphone (only 1) was disabled, the other valid stream wasn't getting returned from getStream successfully. I did some digging in the getStream function, and discovered that we throw in quite a few places - which I _think_ is causing this error with media. We have a lot of code here to test and retry with different constraints or with just audio or video - but I don't think we were ever hitting it, since if the first or second getUserMedia call fails - then we throw and return an error. 

Since we capture and return error details in this function anyway, I would argue that we can remove most of the throws here? For now, I've just removed the problematic ones audio or video only - but worth a discussion on cleaning this up some more. Though, this code has been this way for a long time so we'd maybe need to do some more thorough testing for unintended side effects.  

NOTE: 
I discovered when doing some testing that it seems that due to some kind of privacy or permissions, if no audioinput
is allowed, then audiooutput seems to be denied as well. So if we try to join the room with just the microphone disabled, we can't see any speaker devices (they don't appear in enumerateDevices()). I haven't come up with a fix for this yet or how we should handle these scenarios 🤔  it's weird because the speaker does work, we just don't get the label etc from the device list 🙃 
<img width="334" alt="image" src="https://github.com/user-attachments/assets/7a103d8a-87ee-4848-829e-2cc4d68d213e" />


**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

1. Checkout this SDK branch, and set PWA to 'local-dev' in your local-stack config 
2. In SDK: in ./packages/media run `yarn build` and then `yarn link`
3. in PWA: run `yarn link "@whereby.com/media|"`
4. Run local-stack and navigate to any room
5. Test out joining the room with some of the following scenarios (and anything else you can think of) to ensure you get the expected behaviour: 

- Camera disabled, microphone enabled
- Camera enabled, microphone disabled
- Camera disabled, microphone disabled 

6. You should be able to join a room with just on device enabled, and you should get the "Try again" flow if both are disabled. 

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
