### PR TITLE
common: Exclude captioner in breakout groups

### DIFF
--- a/.changeset/sour-steaks-push.md
+++ b/.changeset/sour-steaks-push.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/media": patch
+"@whereby.com/core": patch
+---
+
+Exclude captioner in breakout groups

--- a/packages/core/src/redux/slices/__tests__/app.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/app.unit.ts
@@ -7,6 +7,7 @@ describe("appSlice", () => {
                 const initialConfig = {
                     isNodeSdk: true,
                     isDialIn: true,
+                    ignoreBreakoutGroups: true,
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",
                     displayName: "displayName",
@@ -19,6 +20,7 @@ describe("appSlice", () => {
                 expect(result).toEqual({
                     isActive: true,
                     isDialIn: true,
+                    ignoreBreakoutGroups: true,
                     roomName: "/roomName",
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",
@@ -44,6 +46,7 @@ describe("appSlice", () => {
                 expect(result).toEqual({
                     isActive: true,
                     isDialIn: false,
+                    ignoreBreakoutGroups: false,
                     roomName: "/roomName",
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",

--- a/packages/core/src/redux/slices/app.ts
+++ b/packages/core/src/redux/slices/app.ts
@@ -10,6 +10,7 @@ import { coreVersion } from "../../version";
 export interface AppConfig {
     isNodeSdk?: boolean;
     isDialIn?: boolean;
+    ignoreBreakoutGroups?: boolean;
     displayName: string;
     localMediaOptions?: LocalMediaOptions;
     roomKey: string | null;
@@ -22,6 +23,7 @@ export interface AppState {
     isNodeSdk: boolean;
     isActive: boolean;
     isDialIn: boolean;
+    ignoreBreakoutGroups: boolean;
     roomUrl: string | null;
     roomName: string | null;
     displayName: string | null;
@@ -34,6 +36,7 @@ export const initialState: AppState = {
     isNodeSdk: false,
     isActive: false,
     isDialIn: false,
+    ignoreBreakoutGroups: false,
     roomName: null,
     roomUrl: null,
     displayName: null,
@@ -82,3 +85,4 @@ export const selectAppUserAgent = (state: RootState) => state.app.userAgent;
 export const selectAppExternalId = (state: RootState) => state.app.externalId;
 export const selectAppIsNodeSdk = (state: RootState) => state.app.isNodeSdk;
 export const selectAppInitialConfig = (state: RootState) => state.app.initialConfig;
+export const selectAppIgnoreBreakoutGroups = (state: RootState) => state.app.ignoreBreakoutGroups;

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -13,7 +13,7 @@ import { selectSignalConnectionRaw, selectSignalConnectionSocket, socketReconnec
 import { createReactor, startAppListening } from "../../listenerMiddleware";
 import { selectRemoteClients, selectRemoteParticipants, streamStatusUpdated } from "../remoteParticipants";
 import { RemoteParticipant, StreamState } from "../../../RoomParticipant";
-import { selectAppIsNodeSdk, selectAppIsActive, doAppStop } from "../app";
+import { selectAppIsNodeSdk, selectAppIsActive, doAppStop, selectAppIgnoreBreakoutGroups } from "../app";
 
 import {
     selectIsCameraEnabled,
@@ -478,7 +478,8 @@ export const selectStreamsToAccept = createSelector(
     selectRemoteClients,
     selectBreakoutCurrentId,
     selectSpotlights,
-    (rtcStatus, remoteParticipants, breakoutCurrentId, spotlights) => {
+    selectAppIgnoreBreakoutGroups,
+    (rtcStatus, remoteParticipants, breakoutCurrentId, spotlights, ignoreBreakoutGroups) => {
         if (rtcStatus !== "ready") {
             return [];
         }
@@ -509,7 +510,8 @@ export const selectStreamsToAccept = createSelector(
                 if (
                     (!client.breakoutGroup && !breakoutCurrentId) || // Accept when both in falsy group
                     client.breakoutGroup === breakoutCurrentId || // Accept all in same breakout group
-                    ("" === client.breakoutGroup && clientSpotlight) // Accept remote spotlights outside groups
+                    ("" === client.breakoutGroup && clientSpotlight) || // Accept remote spotlights outside groups
+                    ignoreBreakoutGroups // Accept all when ignoring breakout groups
                 ) {
                     // Already connected
                     if (state === "done_accept") continue;

--- a/packages/core/src/redux/tests/store/rtcConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/rtcConnection.spec.ts
@@ -80,6 +80,7 @@ describe("actions", () => {
                             isNodeSdk: true,
                             isActive: false,
                             isDialIn: false,
+                            ignoreBreakoutGroups: false,
                             roomName: null,
                             roomUrl: null,
                             displayName: null,

--- a/packages/media/src/utils/types.ts
+++ b/packages/media/src/utils/types.ts
@@ -31,7 +31,8 @@ export type RoleName =
     | "granted_viewer"
     | "host"
     | "recorder"
-    | "streamer";
+    | "streamer"
+    | "captioner";
 
 export interface ClientRole {
     roleName: RoleName;


### PR DESCRIPTION
### Description

Ensure that captioner workers accepts all streams, regardless of breakout groups.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
Testing instuctions in the related PR here: https://github.com/whereby/recording-service/pull/729
<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
