### PR TITLE
media: fix chrome setCodecPreferences

### DIFF
--- a/.changeset/nine-rats-kiss.md
+++ b/.changeset/nine-rats-kiss.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": minor
+---
+
+Fix setCodecPreferences in Chrome on Mac

--- a/packages/media/src/utils/__tests__/mediaSettings.spec.ts
+++ b/packages/media/src/utils/__tests__/mediaSettings.spec.ts
@@ -1,0 +1,170 @@
+import { sortCodecsByMimeType } from "../mediaSettings";
+import { type Codec } from "../mediaSettings";
+
+describe("sortCodecsByMimeType", () => {
+    const codecs: Codec[] = [
+        {
+            clockRate: 90000,
+            mimeType: "video/VP8",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/rtx",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/VP9",
+            sdpFmtpLine: "profile-id=0",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/VP9",
+            sdpFmtpLine: "profile-id=2",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/VP9",
+            sdpFmtpLine: "profile-id=1",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/VP9",
+            sdpFmtpLine: "profile-id=3",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/H264",
+            sdpFmtpLine:
+                "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/H264",
+            sdpFmtpLine:
+                "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/H264",
+            sdpFmtpLine:
+                "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/H264",
+            sdpFmtpLine:
+                "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/H264",
+            sdpFmtpLine:
+                "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/H264",
+            sdpFmtpLine:
+                "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=4d001f",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/H264",
+            sdpFmtpLine:
+                "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=f4001f",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/H264",
+            sdpFmtpLine:
+                "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=f4001f",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/AV1",
+            sdpFmtpLine: "level-idx=5;profile=0;tier=0",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/AV1",
+            sdpFmtpLine: "level-idx=5;profile=1;tier=0",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/H264",
+            sdpFmtpLine:
+                "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=64001f",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/H264",
+            sdpFmtpLine:
+                "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=64001f",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/red",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/ulpfec",
+        },
+        {
+            clockRate: 90000,
+            mimeType: "video/flexfec-03",
+            sdpFmtpLine: "repair-window=10000000",
+        },
+    ];
+    describe("with no flags enabled", () => {
+        it("returns the array unchanged", () => {
+            expect(sortCodecsByMimeType(codecs, {})).toEqual(codecs);
+        });
+    });
+
+    describe("with vp9On enabled", () => {
+        it("returns the sorted array", () => {
+            const sorted = sortCodecsByMimeType(codecs, { vp9On: true });
+            expect(sorted.findIndex((codec: Codec) => !!codec.mimeType.match(/vp9/i)))
+                .toEqual(0);
+        });
+
+        it("leaves the rest of the array in order", () => {
+            const removeVp9 = (codec: Codec) => !codec.mimeType.match(/vp9/i)
+            const sortedFiltered = sortCodecsByMimeType(codecs, { av1On: true, vp9On: true }).filter(removeVp9);
+            const unsortedFiltered = codecs.filter(removeVp9)
+            expect(sortedFiltered).toEqual(unsortedFiltered)
+        })
+    });
+
+    describe("with av1On enabled", () => {
+        it("returns the sorted array", () => {
+            const sorted = sortCodecsByMimeType(codecs, { av1On: true });
+            expect(sorted.findIndex((codec: Codec) => !!codec.mimeType.match(/av1/i)))
+                .toEqual(0);
+        });
+
+        it("leaves the rest of the array in order", () => {
+            const removeAv1 = (codec: Codec) => !codec.mimeType.match(/av1/i)
+            const sortedFiltered = sortCodecsByMimeType(codecs, { av1On: true, vp9On: true }).filter(removeAv1);
+            const unsortedFiltered = codecs.filter(removeAv1)
+            expect(sortedFiltered).toEqual(unsortedFiltered)
+        })
+    });
+
+    describe("with av1On and vp9On enabled", () => {
+        it("prioritises AV1", () => {
+            const sorted = sortCodecsByMimeType(codecs, { av1On: true, vp9On: true });
+            expect(sorted.findIndex((codec: Codec) => !!codec.mimeType.match(/av1/i)))
+                .toEqual(0);
+            expect(sorted.findIndex((codec: Codec) => !!codec.mimeType.match(/vp9/i)))
+                .toEqual(2);
+        });
+
+        it("leaves the rest of the array in order", () => {
+            const removeVp9AndAv1 = (codec: Codec) => !codec.mimeType.match(/vp9|av1/i)
+            const sortedFiltered = sortCodecsByMimeType(codecs, { av1On: true, vp9On: true }).filter(removeVp9AndAv1);
+            const unsortedFiltered = codecs.filter(removeVp9AndAv1)
+            expect(sortedFiltered).toEqual(unsortedFiltered)
+        })
+    })
+});

--- a/packages/media/src/utils/mediaSettings.ts
+++ b/packages/media/src/utils/mediaSettings.ts
@@ -127,3 +127,31 @@ export const modifyMediaCapabilities = (routerRtpCapabilities: any, features: an
         );
     }
 };
+
+function getPreferredOrder(availableCodecs: string[], { vp9On, av1On }: { vp9On?: boolean, av1On?: boolean }) {
+    if (vp9On) {
+        availableCodecs.unshift("video/vp9")
+    }
+
+    if (av1On) {
+        availableCodecs.unshift("video/av1")
+    }
+    return availableCodecs
+}
+
+export interface Codec { clockRate: number; mimeType: string; sdpFmtpLine?: string }
+
+export function sortCodecsByMimeType(
+    codecs: Codec[],
+    features: { vp9On?: boolean, av1On?: boolean }
+) {
+    const availableCodecs = codecs.map(({ mimeType }) => mimeType).filter((value, index, array) => array.indexOf(value) === index)
+    const preferredOrder = getPreferredOrder(availableCodecs, features)
+    return codecs.sort((a, b) => {
+        const indexA = preferredOrder.indexOf(a.mimeType.toLowerCase());
+        const indexB = preferredOrder.indexOf(b.mimeType.toLowerCase());
+        const orderA = indexA >= 0 ? indexA : Number.MAX_VALUE;
+        const orderB = indexB >= 0 ? indexB : Number.MAX_VALUE;
+        return orderA - orderB;
+    });
+}


### PR DESCRIPTION
-------

### Description

**Summary:**
We were getting the preferred codecs from RTCRtpSender, but Chrome on Mac
supports sending a higher version of H264 than it can receive. See here:

https://groups.google.com/g/discuss-webrtc/c/QS7y-7zR5ok

This was causing chrome to fail to set our preferred codecs with an
error like:

InvalidModificationError: Failed to execute 'setCodecPreferences' on
'RTCRtpTransceiver': Invalid codec preferences: invalid codec with name
"H264".

So instead we get the capabilities from RTCRtpReceiver, sort
them for our preferred codecs when the relative flags areenabled
(instead of adding newcodecs), then set them on the transceiver.
This allows us to enable both AV1 and VP9 flags simultaneously, where
before an early VP9 entry would break the loop, leaving AV1 stuck near
the bottom of the codec list.

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**
https://linear.app/whereby/issue/COB-1481/test-how-much-vp9-improves-the-experience-in-p2p-scenarios
and maybe https://linear.app/whereby/issue/COB-1286/fix-redon-vp9on-setcodecpreferences-exceptions

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. open a p2p room in two chrome clients with ?stats, see they use the vp8 codec
1. enable vp9On for this room, rejoin both clients and see they use vp9
1. enable av1On for this room, rejoin both clients and see they use AV1
1. join from a bunch of other clients and browsers, see that chrome/safari _should_ use AV1 while Firefox and mobile Safari use VP9

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->