### PR TITLE
core: Export `rtcEvents` from package

### DIFF
--- a/.changeset/nice-spiders-taste.md
+++ b/.changeset/nice-spiders-taste.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": patch
+---
+
+Export rtcEvents from core package

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -23,7 +23,6 @@ import {
     doSetDevice,
     doSwitchLocalStream,
 } from "../localMedia";
-import { rtcEvents } from "./actions";
 import { StreamStatusUpdate } from "./types";
 import { signalEvents } from "../signalConnection/actions";
 import { doStartScreenshare, stopScreenshare } from "../localScreenshare";
@@ -41,6 +40,8 @@ function isDeferrable({ client, breakoutCurrentId }: { client?: RemoteParticipan
     if (!client.isAudioEnabled && !client.isVideoEnabled) return true;
     return false;
 }
+import { rtcEvents } from "./actions";
+export { rtcEvents } from "./actions";
 
 export const createWebRtcEmitter = (dispatch: AppDispatch) => {
     return {


### PR DESCRIPTION
### Description

Export the internal `rtcEvents` from the core package.

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
