### PR TITLE
media: add flag to enable ICE renomination

### DIFF
--- a/.changeset/five-camels-type.md
+++ b/.changeset/five-camels-type.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": minor
+---
+
+Add flag to enable ICE renomination

--- a/packages/media/src/webrtc/P2pRtcManager.ts
+++ b/packages/media/src/webrtc/P2pRtcManager.ts
@@ -6,7 +6,7 @@ import { PROTOCOL_REQUESTS, RELAY_MESSAGES, PROTOCOL_RESPONSES } from "../model/
 import * as CONNECTION_STATUS from "../model/connectionStatusConstants";
 import { RtcStream } from "../model/RtcStream";
 import { getOptimalBitrate } from "../utils/optimalBitrate";
-import { setCodecPreferenceSDP, addAbsCaptureTimeExtMap, cleanSdp } from "./sdpModifier";
+import { setCodecPreferenceSDP, addAbsCaptureTimeExtMap, cleanSdp, enableIceRenomination } from "./sdpModifier";
 import adapterRaw from "webrtc-adapter";
 import ipRegex from "../utils/ipRegex";
 import { Address6 } from "ip-address";
@@ -490,6 +490,7 @@ export default class P2pRtcManager implements RtcManager {
                     ? MAXIMUM_TURN_BANDWIDTH_UNLIMITED
                     : MAXIMUM_TURN_BANDWIDTH,
                 deprioritizeH264Encoding,
+                iceRenominationOn: this._features.iceRenominationOn,
             });
 
             this.totalSessionsCreated++;
@@ -958,11 +959,15 @@ export default class P2pRtcManager implements RtcManager {
 
     _setCodecPreferences(
         pc: RTCPeerConnection,
-        { vp9On, av1On, redOn }: { 
-            vp9On?: boolean, 
-            av1On?: boolean, 
-            redOn?: boolean, 
-        }
+        {
+            vp9On,
+            av1On,
+            redOn,
+        }: {
+            vp9On?: boolean;
+            av1On?: boolean;
+            redOn?: boolean;
+        },
     ) {
         try {
             // audio
@@ -994,7 +999,7 @@ export default class P2pRtcManager implements RtcManager {
                 if (RTCRtpReceiver.getCapabilities === undefined) return;
                 const capabilities: any = RTCRtpReceiver.getCapabilities("video");
                 if (vp9On || av1On) {
-                    capabilities.codecs = sortCodecsByMimeType(capabilities.codecs, { vp9On, av1On })
+                    capabilities.codecs = sortCodecsByMimeType(capabilities.codecs, { vp9On, av1On });
                 }
 
                 // If not implemented return

--- a/packages/media/src/webrtc/sdpModifier.ts
+++ b/packages/media/src/webrtc/sdpModifier.ts
@@ -151,6 +151,22 @@ export function deprioritizeH264(sdp: any) {
         .join("");
 }
 
+// replace `a=ice-options:trickle` with `a=ice-options:trickle renomination`
+// https://datatracker.ietf.org/doc/html/draft-thatcher-ice-renomination-00
+export function enableIceRenomination(sdp: any) {
+    const renominationRegex = /a=ice-options:.*renomination/;
+    const isRenominationAlreadyEnabled = SDPUtils.splitLines(sdp.trim()).some((line) => renominationRegex.test(line));
+    if (isRenominationAlreadyEnabled) {
+        return sdp;
+    }
+
+    return (
+        SDPUtils.splitLines(sdp.trim())
+            .map((line) => (line === "a=ice-options:trickle" ? "a=ice-options:trickle renomination" : line))
+            .join("\r\n") + "\r\n"
+    );
+}
+
 // TODO: currently assumes video, look at track.kind
 // ensures that SSRCs in new description match ssrcs in old description
 export function replaceSSRCs(currentDescription: any, newDescription: any) {

--- a/packages/media/tests/webrtc/sdpModifier.spec.ts
+++ b/packages/media/tests/webrtc/sdpModifier.spec.ts
@@ -67,6 +67,40 @@ describe("sdpModifier", () => {
         });
     });
 
+    describe("enableIceRenomination", () => {
+        it("returns the original sdp if it already has ice-options:tickle renomination", () => {
+            const sdp = getVideoSdpString() + "a=ice-options:trickle renomination\r\n";
+
+            const modifiedSdp = sdpModifier.enableIceRenomination(sdp);
+
+            expect(modifiedSdp).toEqual(sdp);
+        });
+
+        it("returns the original sdp if it already has ice-options:renomination", () => {
+            const sdp = getVideoSdpString() + "a=ice-options:renomination\r\n";
+
+            const modifiedSdp = sdpModifier.enableIceRenomination(sdp);
+
+            expect(modifiedSdp).toEqual(sdp);
+        });
+
+        it("returns the original sdp if it has no ice-options:tickle", () => {
+            const sdp = getVideoSdpString();
+
+            const modifiedSdp = sdpModifier.enableIceRenomination(sdp);
+
+            expect(modifiedSdp).toEqual(sdp);
+        });
+
+        it("appends renomination to ice-options:tickle in the sdp", () => {
+            const sdp = getVideoSdpString() + "a=ice-options:trickle\r\n";
+
+            const modifiedSdp = sdpModifier.enableIceRenomination(sdp);
+
+            expect(modifiedSdp).toEqual(getVideoSdpString() + "a=ice-options:trickle renomination\r\n");
+        });
+    });
+
     describe("add RTP Header Extension", () => {
         const createSdpFromExtmap = (extmap: any) => {
             return (


### PR DESCRIPTION
### Description

**Summary:**

Enable `renomination` if the `iceRenominationOn` feature is enabled.

### Testing

1. Enable `iceRenominationOn`
2. Join the room 2x
3. Go to chrome://webrtc-internals and inspect the local and remote descriptions: the `renomination` keyword should appear in a `a=ice-options` line.

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

Read more about the renomination draft here: https://datatracker.ietf.org/doc/html/draft-thatcher-ice-renomination-01
