### PR TITLE
media: Split vp9On and av1On flags to be room mode aware

### DIFF
--- a/.changeset/silent-pillows-hear.md
+++ b/.changeset/silent-pillows-hear.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Split vp9On and av1On flags to separate P2P and SFU flags

--- a/packages/media/src/utils/mediaSettings.ts
+++ b/packages/media/src/utils/mediaSettings.ts
@@ -65,8 +65,8 @@ const SCREEN_SHARE_SETTINGS_VP9 = {
     encodings: [{ dtx: true }],
 };
 
-export const getMediaSettings = (kind: string, isScreenShare: boolean, features: any) => {
-    const { lowDataModeEnabled, simulcastScreenshareOn, vp9On, lowBandwidth } = features;
+export const getMediaSettings = (kind: string, isScreenShare: boolean, features: { lowDataModeEnabled?: boolean, simulcastScreenshareOn?: boolean, lowBandwidth?: boolean, vp9On?: boolean }) => {
+    const { lowDataModeEnabled, simulcastScreenshareOn, lowBandwidth, vp9On } = features;
 
     if (kind === "audio") {
         return AUDIO_SETTINGS;
@@ -90,7 +90,7 @@ export const getMediaSettings = (kind: string, isScreenShare: boolean, features:
     }
 };
 
-export const modifyMediaCapabilities = (routerRtpCapabilities: any, features: any) => {
+export const modifyMediaCapabilities = (routerRtpCapabilities: any, features: { vp9On?: boolean , h264On?: boolean }) => {
     const { vp9On, h264On } = features;
 
     if (vp9On) {

--- a/packages/media/src/webrtc/P2pRtcManager.ts
+++ b/packages/media/src/webrtc/P2pRtcManager.ts
@@ -926,11 +926,11 @@ export default class P2pRtcManager implements RtcManager {
         pc: RTCPeerConnection,
         {
             p2pVp9On,
-            av1On,
+            p2pAv1On,
             redOn,
         }: {
             p2pVp9On?: boolean;
-            av1On?: boolean;
+            p2pAv1On?: boolean;
             redOn?: boolean;
         },
     ) {
@@ -963,8 +963,11 @@ export default class P2pRtcManager implements RtcManager {
                 // If not implemented return
                 if (RTCRtpReceiver.getCapabilities === undefined) return;
                 const capabilities: any = RTCRtpReceiver.getCapabilities("video");
-                if (p2pVp9On || av1On) {
-                    capabilities.codecs = sortCodecsByMimeType(capabilities.codecs, { vp9On: p2pVp9On, av1On });
+                if (p2pVp9On || p2pAv1On) {
+                    capabilities.codecs = sortCodecsByMimeType(capabilities.codecs, {
+                        vp9On: p2pVp9On,
+                        av1On: p2pAv1On,
+                    });
                 }
 
                 // If not implemented return
@@ -990,11 +993,11 @@ export default class P2pRtcManager implements RtcManager {
         }
         session.isOperationPending = true;
 
-        const { p2pVp9On, av1On, redOn, rtpAbsCaptureTimeOn, cleanSdpOn } = this._features;
+        const { p2pVp9On, p2pAv1On, redOn, rtpAbsCaptureTimeOn, cleanSdpOn } = this._features;
 
         // Set codec preferences to video transceivers
-        if (p2pVp9On || av1On || redOn) {
-            this._setCodecPreferences(pc, { p2pVp9On, av1On, redOn });
+        if (p2pVp9On || p2pAv1On || redOn) {
+            this._setCodecPreferences(pc, { p2pVp9On, p2pAv1On, redOn });
         }
         pc.createOffer(constraints || this.offerOptions)
             .then((offer: any) => {

--- a/packages/media/src/webrtc/VegaRtcManager/index.ts
+++ b/packages/media/src/webrtc/VegaRtcManager/index.ts
@@ -711,7 +711,7 @@ export default class VegaRtcManager implements RtcManager {
                     track: this._micTrack,
                     disableTrackOnPause: false,
                     stopTracks: false,
-                    ...getMediaSettings("audio", false, this._features),
+                    ...getMediaSettings("audio", false, { ...this._features, vp9On: this._features.sfuVp9On } ),
                     appData: {
                         streamId: OUTBOUND_CAM_OUTBOUND_STREAM_ID,
                         sourceClientId: this._selfId,
@@ -909,7 +909,7 @@ export default class VegaRtcManager implements RtcManager {
                     track: this._webcamTrack,
                     disableTrackOnPause: false,
                     stopTracks: false,
-                    ...getMediaSettings("video", false, this._features),
+                    ...getMediaSettings("video", false, { ...this._features, vp9On: this._features.sfuVp9On }),
                     appData: {
                         streamId: OUTBOUND_CAM_OUTBOUND_STREAM_ID,
                         sourceClientId: this._selfId,
@@ -1028,7 +1028,7 @@ export default class VegaRtcManager implements RtcManager {
                     track: this._screenVideoTrack,
                     disableTrackOnPause: false,
                     stopTracks: false,
-                    ...getMediaSettings("video", true, this._features),
+                    ...getMediaSettings("video", false, { ...this._features, vp9On: this._features.sfuVp9On }),
                     appData: {
                         streamId: OUTBOUND_SCREEN_OUTBOUND_STREAM_ID,
                         sourceClientId: this._selfId,
@@ -1113,7 +1113,7 @@ export default class VegaRtcManager implements RtcManager {
                     track: this._screenAudioTrack,
                     disableTrackOnPause: false,
                     stopTracks: false,
-                    ...getMediaSettings("audio", true, this._features),
+                    ...getMediaSettings("audio", false, { ...this._features, vp9On: this._features.sfuVp9On } ),
                     appData: {
                         streamId: OUTBOUND_SCREEN_OUTBOUND_STREAM_ID,
                         sourceClientId: this._selfId,

--- a/packages/media/src/webrtc/sdpModifier.ts
+++ b/packages/media/src/webrtc/sdpModifier.ts
@@ -10,7 +10,7 @@ const logger = new Logger();
 const browserName = adapter.browserDetails.browser;
 const browserVersion = adapter.browserDetails.version;
 
-export function setCodecPreferenceSDP(sdp: any, vp9On: any, redOn: any) {
+export function setCodecPreferenceSDP(sdp: any, vp9On?: boolean, redOn?: boolean) {
     try {
         const sdpObject = sdpTransform.parse(sdp);
         if (Array.isArray(sdpObject?.media)) {


### PR DESCRIPTION
### Description
So we can control these independently

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. add the media canary to your local PWA on this branch https://github.com/whereby/pwa/pull/4324
2. join a p2p room with `?debug&stats` in two chrome clients
3. see the video streams are VP8
4. add the `p2pVp9On` flag to both URLs, see VP9 codec is used
5. add add the `p2pAv1On` flag to both URLs, see AV1 codec is used
6. remove the flags and add `sfuVp9On&sfuAv1On` and see the streams go back to VP8
7. with those two flags on, in the console run `store.selectFeatureSfuAv1On()` and `storeSelectFeatureSfuVp9On()` and see both are true

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->