### PR TITLE
media: fix isScreenshare flag when sending sfu screenshare

### DIFF
--- a/.changeset/clever-planets-clap.md
+++ b/.changeset/clever-planets-clap.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Fix getMediaSettings call for vega screenshares

--- a/packages/media/src/webrtc/VegaRtcManager/index.ts
+++ b/packages/media/src/webrtc/VegaRtcManager/index.ts
@@ -1038,7 +1038,7 @@ export default class VegaRtcManager implements RtcManager {
                     track: this._screenVideoTrack,
                     disableTrackOnPause: false,
                     stopTracks: false,
-                    ...getMediaSettings("video", false, { ...this._features, vp9On: this._features.sfuVp9On }),
+                    ...getMediaSettings("video", true, { ...this._features, vp9On: this._features.sfuVp9On }),
                     appData: {
                         streamId: OUTBOUND_SCREEN_OUTBOUND_STREAM_ID,
                         sourceClientId: this._selfId,
@@ -1123,7 +1123,7 @@ export default class VegaRtcManager implements RtcManager {
                     track: this._screenAudioTrack,
                     disableTrackOnPause: false,
                     stopTracks: false,
-                    ...getMediaSettings("audio", false, { ...this._features, vp9On: this._features.sfuVp9On }),
+                    ...getMediaSettings("audio", true, { ...this._features, vp9On: this._features.sfuVp9On }),
                     appData: {
                         streamId: OUTBOUND_SCREEN_OUTBOUND_STREAM_ID,
                         sourceClientId: this._selfId,


### PR DESCRIPTION
### Description
I updated the calls to getMediaSettings when I added these new codec flags and accidentally changed a true to a false 🙃 
**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->
1. add current media lib to local-stack PWA and run the screen-premium e2e suite, it should fail saying the stream resolution isn't correct
2. add this canary to PWA and repeat the test, it should pass

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x ] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
