### PR TITLE
media: fix vp9On for modifyMediaCapabilities

### DIFF
--- a/.changeset/poor-comics-hear.md
+++ b/.changeset/poor-comics-hear.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Fix vp9On flag in modifyMediaCapabilities

--- a/packages/media/src/webrtc/VegaRtcManager/index.ts
+++ b/packages/media/src/webrtc/VegaRtcManager/index.ts
@@ -466,7 +466,7 @@ export default class VegaRtcManager implements RtcManager {
             const { routerRtpCapabilities } = await this._vegaConnection.request("getCapabilities");
 
             if (!this._routerRtpCapabilities) {
-                modifyMediaCapabilities(routerRtpCapabilities, this._features);
+                modifyMediaCapabilities(routerRtpCapabilities, { ...this._features, vp9On: this._features.sfuVp9On });
 
                 this._routerRtpCapabilities = routerRtpCapabilities;
                 await this._mediasoupDevice?.load({ routerRtpCapabilities });


### PR DESCRIPTION
### Description
Fixes a missed vp9On flag change for modifyMediaCapabilities
**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. in local stack pwa, `yarn add @whereby.com/media` to get the latest (broken, oops) media version
1. join an SFU room with `?stats&sfuVp9On` in two clients and see the stream doesn't work
1. `yarn add @whereby.com/media@0.0.0-canary-20250328175521` and rejoin the room from both clients, see the stream works and is VP9

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x ] My code follows the project's coding standards.
-   [ x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [x ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
