### PR TITLE
Using commit hashes rather than static versions in GHA

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -24,7 +24,7 @@ runs:
 
         - name: Send slack message
           id: slack
-          uses: slackapi/slack-github-action@v1.25.0
+          uses: slackapi/slack-github-action@v6c661ce58804a1a20f6dc5fbee7f0381b469e001
           with:
               channel-id: ${{ inputs.channel_id }}
               payload: |

--- a/.github/workflows/exit-prerelease.yml
+++ b/.github/workflows/exit-prerelease.yml
@@ -32,7 +32,7 @@ jobs:
               # Check if pre.json file exists. The rest of the steps will only run if this file exists
             - name: Check for pre.json file existence
               id: check_files
-              uses: andstor/file-existence-action@v3.0.0
+              uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6
               with:
                   files: ".changeset/pre.json"
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -34,7 +34,7 @@ jobs:
 
             - name: Check for pre.json file existence
               id: check_files
-              uses: andstor/file-existence-action@v3.0.0
+              uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6
               with:
                   files: ".changeset/pre.json"
 


### PR DESCRIPTION
Following the incident regarding tj-actions we have decided to use commit hashes rather than static versions in our GHAs.

No changes, the version is the same as the commit hash, this just prevents versions from being overridden with malicious code.
