### PR TITLE
media: rename preferHardwareDecodingOn to preferP2pHardwareDecodingOn

### DIFF
--- a/.changeset/honest-news-notice.md
+++ b/.changeset/honest-news-notice.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Rename preferHardwareDecodingOn flag to preferP2pHardwareDecodingOn

--- a/packages/media/src/utils/mediaSettings.ts
+++ b/packages/media/src/utils/mediaSettings.ts
@@ -157,10 +157,7 @@ export interface Codec {
     sdpFmtpLine?: string;
 }
 
-function sortCodecsByMimeType(
-    codecs: Codec[],
-    features: { vp9On?: boolean; av1On?: boolean; preferHardwareDecodingOn?: boolean },
-) {
+function sortCodecsByMimeType(codecs: Codec[], features: { vp9On?: boolean; av1On?: boolean }) {
     const availableCodecs = codecs
         .map(({ mimeType }) => mimeType)
         .filter((value, index, array) => array.indexOf(value) === index);

--- a/packages/media/src/webrtc/P2pRtcManager.ts
+++ b/packages/media/src/webrtc/P2pRtcManager.ts
@@ -929,8 +929,8 @@ export default class P2pRtcManager implements RtcManager {
     }
 
     async _setCodecPreferences(pc: RTCPeerConnection) {
-        const { p2pVp9On, p2pAv1On, redOn, preferHardwareDecodingOn } = this._features;
-        if (!(p2pVp9On || p2pAv1On || redOn || preferHardwareDecodingOn)) {
+        const { p2pVp9On, p2pAv1On, redOn, preferP2pHardwareDecodingOn } = this._features;
+        if (!(p2pVp9On || p2pAv1On || redOn || preferP2pHardwareDecodingOn)) {
             return;
         }
         try {
@@ -965,11 +965,11 @@ export default class P2pRtcManager implements RtcManager {
                     if (videoTransceiver.setCodecPreferences === undefined) return;
 
                     const capabilities: any = RTCRtpReceiver.getCapabilities("video");
-                    if (p2pVp9On || p2pAv1On || preferHardwareDecodingOn) {
+                    if (p2pVp9On || p2pAv1On || preferP2pHardwareDecodingOn) {
                         capabilities.codecs = await sortCodecs(capabilities.codecs, {
                             vp9On: p2pVp9On,
                             av1On: p2pAv1On,
-                            preferHardwareDecodingOn,
+                            preferHardwareDecodingOn: preferP2pHardwareDecodingOn,
                         });
                     }
 


### PR DESCRIPTION
### Description

**Summary:**
Just renames this flag to show it's only for P2P rooms
<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**
kevinhanna/cob-1630-orderfilter-codecs-by-powerefficiencyhardware-decoder
<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
add the media canary to your local stack PWA and
1. Open local-stack in two clients https://ip-127-0-0-1.hereby.dev:4443/p2p-room?stats - see they use the VP8 codec
2. add &preferHardwareDecodingOn and see they switch to some other codec depending on your hardware

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
