### PR TITLE
browser-sdk: Fix missing audio when remote participant disables video

### DIFF
--- a/.changeset/modern-lies-wash.md
+++ b/.changeset/modern-lies-wash.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": patch
+---
+
+Fix VideoGrid missing audio when remote participant video is disabled

--- a/packages/browser-sdk/src/lib/react/Grid/VideoMutedIndicator/index.tsx
+++ b/packages/browser-sdk/src/lib/react/Grid/VideoMutedIndicator/index.tsx
@@ -1,41 +1,48 @@
 import * as React from "react";
 
 import { Avatar } from "../../Avatar";
+import { useAudioElement } from "../../hooks/useAudioElement";
 
 interface Props {
     avatarUrl?: string;
     displayName: string;
     isSmallCell: boolean;
     withRoundedCorners: boolean;
+    stream?: MediaStream | null;
+    muted?: boolean;
 }
 
-function VideoMutedIndicator({ avatarUrl, displayName, isSmallCell, withRoundedCorners }: Props) {
+function VideoMutedIndicator({ avatarUrl, displayName, isSmallCell, withRoundedCorners, stream, muted }: Props) {
+    const audioElRef = useAudioElement({ stream, muted });
     return (
-        <div
-            style={{
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                justifyContent: "center",
-                position: "absolute",
-                top: 0,
-                left: 0,
-                height: "100%",
-                width: "100%",
-                borderRadius: withRoundedCorners ? "8px" : "0",
-            }}
-        >
+        <>
             <div
                 style={{
-                    height: isSmallCell ? 60 : 80,
-                    width: isSmallCell ? 60 : 80,
-                    pointerEvents: "none",
-                    position: "relative",
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    height: "100%",
+                    width: "100%",
+                    borderRadius: withRoundedCorners ? "8px" : "0",
                 }}
             >
-                <Avatar variant={"square"} avatarUrl={avatarUrl} name={displayName} size={isSmallCell ? 60 : 80} />
+                <div
+                    style={{
+                        height: isSmallCell ? 60 : 80,
+                        width: isSmallCell ? 60 : 80,
+                        pointerEvents: "none",
+                        position: "relative",
+                    }}
+                >
+                    <Avatar variant={"square"} avatarUrl={avatarUrl} name={displayName} size={isSmallCell ? 60 : 80} />
+                </div>
             </div>
-        </div>
+            <audio ref={audioElRef} autoPlay playsInline />
+        </>
     );
 }
 

--- a/packages/browser-sdk/src/lib/react/Grid/index.tsx
+++ b/packages/browser-sdk/src/lib/react/Grid/index.tsx
@@ -67,12 +67,14 @@ const GridVideoView = React.forwardRef<WherebyVideoElement, GridVideoViewProps>(
 
     const s = stream || participant.stream;
 
-    if (!s) {
+    if (!s || !participant.isVideoEnabled) {
         return (
             <VideoMutedIndicator
                 isSmallCell={false}
                 displayName={participant?.displayName || "Guest"}
                 withRoundedCorners
+                muted={participant.isLocalClient}
+                stream={participant.stream}
             />
         );
     }
@@ -112,26 +114,16 @@ function renderCellView({ cellView, enableParticipantMenu, render }: RenderCellV
         case "video":
             return (
                 <GridCell participant={participant}>
-                    {participant.isVideoEnabled ? (
-                        <>
-                            {render ? (
-                                render({ participant })
-                            ) : (
-                                <>
-                                    <GridVideoView />
-                                    {enableParticipantMenu ? (
-                                        <DefaultParticipantMenu participant={participant} />
-                                    ) : null}
-                                </>
-                            )}
-                        </>
-                    ) : (
-                        <VideoMutedIndicator
-                            isSmallCell={false}
-                            displayName={participant?.displayName || "Guest"}
-                            withRoundedCorners
-                        />
-                    )}
+                    <>
+                        {render ? (
+                            render({ participant })
+                        ) : (
+                            <>
+                                <GridVideoView />
+                                {enableParticipantMenu ? <DefaultParticipantMenu participant={participant} /> : null}
+                            </>
+                        )}
+                    </>
                 </GridCell>
             );
     }

--- a/packages/browser-sdk/src/lib/react/VideoView.tsx
+++ b/packages/browser-sdk/src/lib/react/VideoView.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { debounce, doRtcReportStreamResolution } from "@whereby.com/core";
-import { selectCurrentSpeakerDeviceId } from "@whereby.com/core";
-import { useAppDispatch, useAppSelector } from "./Provider/hooks";
+import { useAppDispatch } from "./Provider/hooks";
+import { useAudioElement } from "./hooks/useAudioElement";
 
 interface VideoViewSelfProps {
     stream: MediaStream;
@@ -19,15 +19,12 @@ export type WherebyVideoElement = HTMLVideoElement & {
 export type VideoViewProps = VideoViewSelfProps &
     React.DetailedHTMLProps<React.VideoHTMLAttributes<WherebyVideoElement>, WherebyVideoElement>;
 
-type AudioElement = HTMLAudioElement & { setSinkId?: (deviceId: string) => void };
-
 export const VideoView = React.forwardRef<WherebyVideoElement, VideoViewProps>(
     ({ muted, mirror = false, stream, onVideoResize, ...rest }, ref) => {
         const dispatch = useAppDispatch();
-        const currentSpeakerId = useAppSelector(selectCurrentSpeakerDeviceId);
 
         const videoEl = React.useRef<WherebyVideoElement>(null);
-        const audioEl = React.useRef<AudioElement>(null);
+        const audioEl = useAudioElement({ muted, stream });
 
         React.useImperativeHandle(ref, () => {
             return Object.assign(videoEl.current!, {
@@ -101,20 +98,6 @@ export const VideoView = React.forwardRef<WherebyVideoElement, VideoViewProps>(
                 videoEl.current.muted = Boolean(muted);
             }
         }, [muted, stream, videoEl]);
-
-        React.useEffect(() => {
-            if (!audioEl.current || muted || !stream || !currentSpeakerId) {
-                return;
-            }
-
-            if (audioEl.current.srcObject !== stream) {
-                audioEl.current.srcObject = stream;
-            }
-
-            if (audioEl.current.setSinkId) {
-                audioEl.current.setSinkId(currentSpeakerId);
-            }
-        }, [stream, audioEl, currentSpeakerId, muted]);
 
         return (
             <>

--- a/packages/browser-sdk/src/lib/react/hooks/useAudioElement.ts
+++ b/packages/browser-sdk/src/lib/react/hooks/useAudioElement.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from "react";
+import { useAppSelector } from "../Provider/hooks";
+import { selectCurrentSpeakerDeviceId } from "@whereby.com/core";
+
+export type AudioElement = HTMLAudioElement & { setSinkId?: (deviceId: string) => void };
+export const useAudioElement = ({ stream, muted }: { stream?: MediaStream | null; muted?: boolean }) => {
+    const audioEl = useRef<AudioElement>(null);
+    const currentSpeakerId = useAppSelector(selectCurrentSpeakerDeviceId);
+
+    useEffect(() => {
+        if (!audioEl.current || muted || !stream || !currentSpeakerId) {
+            return;
+        }
+
+        if (audioEl.current.srcObject !== stream) {
+            audioEl.current.srcObject = stream;
+        }
+
+        if (audioEl.current.setSinkId) {
+            audioEl.current.setSinkId(currentSpeakerId);
+        }
+    }, [stream, audioEl, currentSpeakerId, muted]);
+
+    return audioEl;
+};


### PR DESCRIPTION
### Description

**Summary:**
In the VideoGrid we were checking `participant.isVideoMuted`, and if so rendering the `VideoMutedIndicator` instead of a `GridVideoView`

However this meant that the `<audio/>` element was no longer rendered, so we pass some more props to VideoMutedIndicator and now the audio works :tada:
<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**
https://linear.app/whereby/issue/PAN-1753/camera-and-microphone-controls-issue-nextjs-sdk
<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->
1. in a test app with the current browser-sdk version, render the VideoGrid. Join a room from that app and a PWA app
2. mute the audio from the PWA app tab (i.e. make sure you can't hear the test app participant from the PWA app browser)
3. with video and mic enabled everywhere, make sure you can hear the PWA app user from the test app browser
4. mute the video on the PWA app, see that it is no longer audible
5. add this canary to your test app and repeat the above process - see the audio remains now


### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x ] My code follows the project's coding standards.
-   [ x Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information
I considered adding the `VideoMutedIndicator` to the `VideoView` component, and then relying on it to render the audio when video is muted. However this would have changed the behaviour of the `VideoView` and maybe that's not ideal

I think this way is a little less disruptive, but actually the current behaviour of rendering a black box in `VideoView` when `isVideoMuted` is a little sucky, so maybe we should add it in there and avoid this `<audio/>` duplication?

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
