### PR TITLE
media: prioritise power efficiency sorting

### DIFF
--- a/.changeset/rare-actors-admire.md
+++ b/.changeset/rare-actors-admire.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": minor
+---
+
+Prioritise power efficiency when sorting codecs

--- a/packages/media/src/utils/mediaSettings.ts
+++ b/packages/media/src/utils/mediaSettings.ts
@@ -206,9 +206,10 @@ export async function sortCodecs(
     codecs: Codec[],
     features: { vp9On?: boolean; av1On?: boolean; preferHardwareDecodingOn?: boolean },
 ) {
+    codecs = sortCodecsByMimeType(codecs, features);
     if (features.preferHardwareDecodingOn) {
         codecs = await sortCodecsByPowerEfficiency(codecs);
     }
 
-    return sortCodecsByMimeType(codecs, features);
+    return codecs;
 }

--- a/packages/media/src/webrtc/P2pRtcManager.ts
+++ b/packages/media/src/webrtc/P2pRtcManager.ts
@@ -969,7 +969,7 @@ export default class P2pRtcManager implements RtcManager {
                         capabilities.codecs = await sortCodecs(capabilities.codecs, {
                             vp9On: p2pVp9On,
                             av1On: p2pAv1On,
-                            preferHardwareDecodingOn: preferP2pHardwareDecodingOn,
+                            preferHardwareDecodingOn: p2pVp9On || preferP2pHardwareDecodingOn,
                         });
                     }
 


### PR DESCRIPTION
previously we would use VP9 even if it was inefficient

-------

### Description
sorts codecs by power efficiency _after_ we force VP9, so we don't force VP9 onto clients that aren't power efficient decoding it
**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**
https://linear.app/whereby/issue/COB-1768/ensure-vp8-is-prioritized-if-vp9-flag-is-on-but-vp9-decoding-is-power
<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->
1. `yarn add @whereby.com/media@0.0.0-canary-20250424151513` to local PWA
2. enable `p2pVp9On` in your local unleash
3. join a P2P room with `?stats` in two browsers, see they use VP9
4. leave from one browser, paste this into the console of the other still in the room:
```
Object.assign(navigator.mediaCapabilities, {
    decodingInfo: async ({ video: { contentType } }) => {
        return { powerEfficient: !contentType.match(/vp9/i) };
    },
});
```
5. rejoin from the other browser that just left
6. see they use another codec, probably VP8
### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->