### PR TITLE
media: aborts further host connection attempts when network is seemingly

### DIFF
--- a/.changeset/old-shoes-burn.md
+++ b/.changeset/old-shoes-burn.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+media: aborts further host connection attempts when network is seemingly down'

--- a/packages/media/src/webrtc/VegaConnectionManager.ts
+++ b/packages/media/src/webrtc/VegaConnectionManager.ts
@@ -108,15 +108,32 @@ export function createVegaConnectionManager(config: {
             if (typeof dcIndexByDC[dc] === "undefined") dcIndexByDC[dc] = currentDCIndex++;
         });
 
-        // setup connection attempts for all hosts, with delays according to priority and DC
-        // a new host might be tested before the previous is resolved, so multiple connections might exist in parallell
-        // the first host that is connected will be used
         let timeBeforeConnect = 0;
         const prevTimeBeforeConnectByDC = {} as Record<string, number>;
         let nominatedConnection: VegaConnection | undefined;
         let connectionsToResolve = targetHostList.length;
         let hasNotifiedDisconnect = false;
         let wasConnected = false;
+        const beforeNetworkPossiblyDownTime = lastNetworkPossiblyDownTime;
+
+        const handleFailedOrAbortedConnection = () => {
+            connectionsToResolve--;
+            if (connectionsToResolve === 0 && !hasNotifiedDisconnect) {
+                connectionAttemptInProgress = false;
+                if (hasPendingConnectionAttempt) {
+                    // if we have a pending connect attempt we don't notify about this fail, we instead trigger a new attempt
+                    setTimeout(connect, 0);
+                } else {
+                    config.onFailed?.();
+                }
+            }
+        };
+
+        const timers = [] as ReturnType<typeof setTimeout>[];
+
+        // setup connection attempts for all hosts, with delays according to priority and DC
+        // a new host might be tested before the previous is resolved, so multiple connections might exist in parallell
+        // the first host that is connected will be used
         targetHostList.forEach(({ host, dc }, index) => {
             if (index > 0) {
                 timeBeforeConnect += timeNextServer;
@@ -125,110 +142,122 @@ export function createVegaConnectionManager(config: {
             }
             prevTimeBeforeConnectByDC[dc] = timeBeforeConnect;
 
-            setTimeout(() => {
-                if (wasConnected) return;
-                const vegaConnection = new VegaConnection(config.getUrlForHost?.(host) || host);
-                let wasClosed = false;
-                vegaConnection.on("open", () => {
-                    // we are connected, but proxies or full/busy servers may close, so we wait a bit
-                    setTimeout(() => {
-                        if (wasClosed) return;
-                        if (!nominatedConnection && !wasConnected) {
-                            nominatedConnection = vegaConnection;
-                            wasConnected = true;
+            timers.push(
+                setTimeout(() => {
+                    timers.shift();
 
-                            const thisRoundFailedHosts = [
-                                ...new Set(
-                                    targetHostList
-                                        .slice(0, index)
-                                        .filter((o) => o.host !== host)
-                                        .map((o) => o.host),
-                                ),
-                            ];
-                            const thisRoundFailedDCs = [
-                                ...new Set(
-                                    targetHostList
-                                        .slice(0, index)
-                                        .filter((o) => o.dc !== dc)
-                                        .map((o) => o.dc),
-                                ),
-                            ];
-                            if (!connectionInfo) {
-                                connectionInfo = {
-                                    host,
-                                    dc,
-                                    initialHost: host,
-                                    initialDC: dc,
-                                    initialHostIndex: index,
-                                    initialDCIndex: dcIndexByDC[dc],
-                                    failedHosts: thisRoundFailedHosts,
-                                    failedDCs: thisRoundFailedDCs,
-                                    usedHosts: [host],
-                                    usedDCs: [dc],
-                                    numConnections: 1,
-                                    numUsedDCs: 1,
-                                    numUsedHosts: 1,
-                                    numFailedDCs: 0, // calculate this later
-                                    numFailedHosts: 0, // calculate this later
-                                };
+                    if (wasConnected) return;
+
+                    if (beforeNetworkPossiblyDownTime !== lastNetworkPossiblyDownTime) {
+                        // if network seemingly dropped after connect() started, drop any remaining scheduled host
+                        // connection attempts so we can start trying the first/primary host again
+                        handleFailedOrAbortedConnection();
+
+                        // cancel pending connection attempts
+                        timers.forEach((timeoutId) => {
+                            clearTimeout(timeoutId);
+                            // we might have one connection attempt in progress, that might actually connect
+                            // so we only mark the pending attempts as aborted
+                            handleFailedOrAbortedConnection();
+                        });
+                        return;
+                    }
+
+                    const vegaConnection = new VegaConnection(config.getUrlForHost?.(host) || host);
+                    let wasClosed = false;
+
+                    vegaConnection.on("open", () => {
+                        // we are connected, but proxies or full/busy servers may close, so we wait a bit
+                        setTimeout(() => {
+                            if (wasClosed) return;
+                            if (!nominatedConnection && !wasConnected) {
+                                nominatedConnection = vegaConnection;
+                                wasConnected = true;
+
+                                const thisRoundFailedHosts = [
+                                    ...new Set(
+                                        targetHostList
+                                            .slice(0, index)
+                                            .filter((o) => o.host !== host)
+                                            .map((o) => o.host),
+                                    ),
+                                ];
+                                const thisRoundFailedDCs = [
+                                    ...new Set(
+                                        targetHostList
+                                            .slice(0, index)
+                                            .filter((o) => o.dc !== dc)
+                                            .map((o) => o.dc),
+                                    ),
+                                ];
+                                if (!connectionInfo) {
+                                    connectionInfo = {
+                                        host,
+                                        dc,
+                                        initialHost: host,
+                                        initialDC: dc,
+                                        initialHostIndex: index,
+                                        initialDCIndex: dcIndexByDC[dc],
+                                        failedHosts: thisRoundFailedHosts,
+                                        failedDCs: thisRoundFailedDCs,
+                                        usedHosts: [host],
+                                        usedDCs: [dc],
+                                        numConnections: 1,
+                                        numUsedDCs: 1,
+                                        numUsedHosts: 1,
+                                        numFailedDCs: 0, // calculate this later
+                                        numFailedHosts: 0, // calculate this later
+                                    };
+                                } else {
+                                    connectionInfo = {
+                                        ...connectionInfo,
+                                        host,
+                                        dc,
+                                        failedHosts: [
+                                            ...new Set([...thisRoundFailedHosts, ...connectionInfo.failedHosts]),
+                                        ].filter(
+                                            (failedHost) =>
+                                                failedHost !== host && !connectionInfo.usedHosts.includes(failedHost),
+                                        ),
+                                        failedDCs: [
+                                            ...new Set([...thisRoundFailedDCs, ...connectionInfo.failedDCs]),
+                                        ].filter(
+                                            (failedDC) => failedDC !== dc && !connectionInfo.usedDCs.includes(failedDC),
+                                        ),
+                                        usedHosts: [...new Set([...connectionInfo.usedHosts, host])],
+                                        usedDCs: [...new Set([...connectionInfo.usedDCs, dc])],
+                                        numConnections: connectionInfo.numConnections + 1,
+                                    };
+                                }
+                                // update convenient props (posthog cannot query on length of set)
+                                connectionInfo.numUsedDCs = connectionInfo.usedDCs.length;
+                                connectionInfo.numUsedHosts = connectionInfo.usedHosts.length;
+                                connectionInfo.numFailedDCs = connectionInfo.failedDCs.length;
+                                connectionInfo.numFailedHosts = connectionInfo.failedHosts.length;
+
+                                // if we have a pending connect() abort it as we're already connected
+                                hasPendingConnectionAttempt = false;
+                                connectionAttemptInProgress = false;
+
+                                config.onConnected?.(vegaConnection, connectionInfo);
                             } else {
-                                connectionInfo = {
-                                    ...connectionInfo,
-                                    host,
-                                    dc,
-                                    failedHosts: [
-                                        ...new Set([...thisRoundFailedHosts, ...connectionInfo.failedHosts]),
-                                    ].filter(
-                                        (failedHost) =>
-                                            failedHost !== host && !connectionInfo.usedHosts.includes(failedHost),
-                                    ),
-                                    failedDCs: [
-                                        ...new Set([...thisRoundFailedDCs, ...connectionInfo.failedDCs]),
-                                    ].filter(
-                                        (failedDC) => failedDC !== dc && !connectionInfo.usedDCs.includes(failedDC),
-                                    ),
-                                    usedHosts: [...new Set([...connectionInfo.usedHosts, host])],
-                                    usedDCs: [...new Set([...connectionInfo.usedDCs, dc])],
-                                    numConnections: connectionInfo.numConnections + 1,
-                                };
+                                vegaConnection.close();
                             }
-                            // update convenient props (posthog cannot query on length of set)
-                            connectionInfo.numUsedDCs = connectionInfo.usedDCs.length;
-                            connectionInfo.numUsedHosts = connectionInfo.usedHosts.length;
-                            connectionInfo.numFailedDCs = connectionInfo.failedDCs.length;
-                            connectionInfo.numFailedHosts = connectionInfo.failedHosts.length;
-
-                            // if we have a pending connect() abort it as we're already connected
-                            hasPendingConnectionAttempt = false;
-                            connectionAttemptInProgress = false;
-
-                            config.onConnected?.(vegaConnection, connectionInfo);
-                        } else {
-                            vegaConnection.close();
+                        }, timeToWaitForEarlyServerClose);
+                    });
+                    vegaConnection.on("close", () => {
+                        wasClosed = true;
+                        if (vegaConnection === nominatedConnection) {
+                            // the nominated connection was closed
+                            nominatedConnection = undefined;
+                            lastDisconnectTime = Date.now();
+                            hasNotifiedDisconnect = true;
+                            config.onDisconnected?.();
                         }
-                    }, timeToWaitForEarlyServerClose);
-                });
-                vegaConnection.on("close", () => {
-                    wasClosed = true;
-                    if (vegaConnection === nominatedConnection) {
-                        // the nominated connection was closed
-                        nominatedConnection = undefined;
-                        lastDisconnectTime = Date.now();
-                        hasNotifiedDisconnect = true;
-                        config.onDisconnected?.();
-                    }
-                    connectionsToResolve--;
-                    if (connectionsToResolve === 0 && !hasNotifiedDisconnect) {
-                        connectionAttemptInProgress = false;
-                        if (hasPendingConnectionAttempt) {
-                            // if we have a pending connect attempt we don't notify about this fail, we instead trigger a new attempt
-                            setTimeout(connect, 0);
-                        } else {
-                            config.onFailed?.();
-                        }
-                    }
-                });
-            }, timeBeforeConnect);
+                        handleFailedOrAbortedConnection();
+                    });
+                }, timeBeforeConnect),
+            );
         });
     };
 


### PR DESCRIPTION
### Description

When network is unstable, you could be losing and recovering network before the list of hosts to attempt was completed, making it sometimes using a less ideal host / datacenter than needed. With this change, the reaming attempts/host in the list is cancelled when it is signalled about network being possibly down. This is signalled when the signal server network connection is down - and will only affect SFU connection process in progress (not yet connected)

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

