### PR TITLE
core: hideInsightsDisplayNames

### DIFF
--- a/.changeset/modern-geese-teach.md
+++ b/.changeset/modern-geese-teach.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": minor
+---
+
+Respect hideInsightsDisplayNames when sending rtc-stats

--- a/packages/core/src/redux/slices/organization.ts
+++ b/packages/core/src/redux/slices/organization.ts
@@ -80,6 +80,7 @@ export const doOrganizationFetch = createAppAsyncThunk(
 
 export const selectOrganizationRaw = (state: RootState) => state.organization;
 export const selectOrganizationId = (state: RootState) => state.organization.data?.organizationId;
+export const selectOrganizationPreferences = (state: RootState) => state.organization.data?.preferences;
 
 /**
  * Reducers

--- a/packages/core/src/redux/slices/rtcAnalytics.ts
+++ b/packages/core/src/redux/slices/rtcAnalytics.ts
@@ -4,10 +4,10 @@ import { RootState } from "../store";
 import { ThunkConfig, createAppThunk } from "../thunk";
 import { createReactor, startAppListening } from "../listenerMiddleware";
 import { selectRtcConnectionRaw, selectRtcManagerInitialized, selectRtcStatus } from "./rtcConnection";
-import { selectAppDisplayName, selectAppExternalId } from "./app";
-import { selectOrganizationId } from "./organization";
+import { selectAppExternalId } from "./app";
+import { selectOrganizationId, selectOrganizationPreferences } from "./organization";
 import { doEnableAudio, doEnableVideo, setDisplayName } from "./localParticipant";
-import { selectSelfId } from "./localParticipant/selectors";
+import { selectLocalParticipantDisplayName, selectSelfId } from "./localParticipant/selectors";
 import { selectAuthorizationRoleName } from "./authorization";
 import { selectSignalStatus } from "./signalConnection";
 import { selectDeviceId } from "./deviceCredentials";
@@ -64,7 +64,12 @@ export const rtcAnalyticsCustomEvents: { [key: string]: RtcAnalyticsCustomEvent 
     displayName: {
         actions: [setDisplayName],
         rtcEventName: "displayName",
-        getValue: (state: RootState) => selectAppDisplayName(state),
+        getValue: (state: RootState) => {
+            const displayName = selectLocalParticipantDisplayName(state);
+            const prefs = selectOrganizationPreferences(state);
+
+            return prefs?.hideInsightsDisplayNames ? "[[redacted]]" : displayName;
+        },
         getOutput: (value) => ({ displayName: value }),
     },
     clientId: {

--- a/packages/core/src/redux/tests/store/rtcAnalytics.spec.ts
+++ b/packages/core/src/redux/tests/store/rtcAnalytics.spec.ts
@@ -1,6 +1,8 @@
 import { createStore, mockRtcManager } from "../store.setup";
 import { doRtcAnalyticsCustomEventsInitialize, rtcAnalyticsState } from "../../slices/rtcAnalytics";
 import { diff } from "deep-object-diff";
+import { randomOrganization } from "../../../__mocks__/appMocks";
+import { setDisplayName } from "../../slices/localParticipant";
 
 describe("actions", () => {
     it("doRtcAnalyticsCustomEventsInitialize", async () => {
@@ -28,5 +30,60 @@ describe("actions", () => {
             ]),
         );
         expect(mockRtcManager.sendStatsCustomEvent).toHaveBeenCalledWith("insightsStats", expect.any(Object));
+    });
+    it("redacts the displayName when hideInsightsDisplayName is true", () => {
+        const organization = randomOrganization({ preferences: { hideInsightsDisplayNames: true } });
+        const store = createStore({
+            withRtcManager: true,
+            initialState: {
+                organization: { data: organization, isFetching: false, error: null },
+            },
+        });
+
+        store.dispatch(doRtcAnalyticsCustomEventsInitialize());
+
+        expect(mockRtcManager.sendStatsCustomEvent).toHaveBeenCalledWith(
+            "displayName",
+            expect.objectContaining({ displayName: "[[redacted]]" }),
+        );
+    });
+});
+
+describe("middleware", () => {
+    describe("displayName", () => {
+        it("tracks display name changes", () => {
+            const organization = randomOrganization({ preferences: { hideInsightsDisplayNames: false } });
+            const store = createStore({
+                withRtcManager: true,
+                initialState: {
+                    organization: { data: organization, isFetching: false, error: null },
+                },
+            });
+
+            store.dispatch(doRtcAnalyticsCustomEventsInitialize());
+            store.dispatch(setDisplayName({ displayName: "Trogdor" }));
+
+            expect(mockRtcManager.sendStatsCustomEvent).toHaveBeenCalledWith(
+                "displayName",
+                expect.objectContaining({ displayName: "Trogdor" }),
+            );
+        });
+        it("redacts the displayName when applicable", () => {
+            const organization = randomOrganization({ preferences: { hideInsightsDisplayNames: true } });
+            const store = createStore({
+                withRtcManager: true,
+                initialState: {
+                    organization: { data: organization, isFetching: false, error: null },
+                },
+            });
+
+            store.dispatch(doRtcAnalyticsCustomEventsInitialize());
+            store.dispatch(setDisplayName({ displayName: "Trogdor" }));
+
+            expect(mockRtcManager.sendStatsCustomEvent).toHaveBeenCalledWith(
+                "displayName",
+                expect.objectContaining({ displayName: "[[redacted]]" }),
+            );
+        });
     });
 });


### PR DESCRIPTION
### Description

### Tested like
1. Enable hiding display names in your test org prefs
![image](https://github.com/user-attachments/assets/0a358e63-18ee-4b81-a650-c2097e35a352)
1. `yarn dev:sample-app` and go to http://localhost:5420, enter a room url for your test org
1. open brower dev tools network tab to capture websockets
1. set the room url to one from your test org
1. see the displayName rtc-stats message is redacted 
![image](https://github.com/user-attachments/assets/8c71c8ba-c62c-4c42-9feb-7852df9fe878)

*The person approving this PR is REQUIRED to run the included test steps*

### Related tasks
https://linear.app/whereby/issue/COB-1809/redact-dispaly-name-from-rtc-stats-payloads-in-sdk