### PR TITLE
browser-sdk: set room configuration before both knocking or joining a room

### DIFF
--- a/.changeset/red-kangaroos-confess.md
+++ b/.changeset/red-kangaroos-confess.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": minor
+---
+
+Apply useRoomConnection config before both knocking or joining a room

--- a/.changeset/unlucky-berries-call.md
+++ b/.changeset/unlucky-berries-call.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": patch
+---
+
+Call app setup before calling either knock or join room in useRoomConnection hook

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -15,6 +15,7 @@ import {
     toggleLowDataModeEnabled,
     doStartScreenshare,
     doStopScreenshare,
+    doAppSetup,
     doAppStart,
     doAppStop,
     doKnockRoom,
@@ -74,7 +75,7 @@ export function useRoomConnection(
     }, []);
 
     const sendChatMessage = React.useCallback((text: string) => dispatch(doSendChatMessage({ text })), [dispatch]);
-    const knock = React.useCallback(() => dispatch(doKnockRoom()), [dispatch]);
+    const knock = React.useCallback(() => dispatch(doAppSetup(roomConfig)) && dispatch(doKnockRoom()), [dispatch]);
     const setDisplayName = React.useCallback(
         (displayName: string) => dispatch(doSetDisplayName({ displayName })),
         [dispatch],
@@ -116,7 +117,7 @@ export function useRoomConnection(
     const startScreenshare = React.useCallback(() => dispatch(doStartScreenshare()), [dispatch]);
     const stopCloudRecording = React.useCallback(() => dispatch(doStopCloudRecording()), [dispatch]);
     const stopScreenshare = React.useCallback(() => dispatch(doStopScreenshare()), [dispatch]);
-    const joinRoom = React.useCallback(() => dispatch(doAppStart(roomConfig)), [dispatch]);
+    const joinRoom = React.useCallback(() => dispatch(doAppSetup(roomConfig)) && dispatch(doAppStart()), [dispatch]);
     const leaveRoom = React.useCallback(() => dispatch(doAppStop()), [dispatch]);
     const lockRoom = React.useCallback((locked: boolean) => dispatch(doLockRoom({ locked })), [dispatch]);
     const muteParticipants = React.useCallback(

--- a/packages/browser-sdk/src/stories/custom-ui.stories.tsx
+++ b/packages/browser-sdk/src/stories/custom-ui.stories.tsx
@@ -271,8 +271,13 @@ RoomConnectionStrictMode.parameters = {
     },
 };
 
-
-export const RoomConnectionWithBreakoutGroups = ({ roomUrl, displayName }: { roomUrl: string; displayName?: string }) => {
+export const RoomConnectionWithBreakoutGroups = ({
+    roomUrl,
+    displayName,
+}: {
+    roomUrl: string;
+    displayName?: string;
+}) => {
     if (!roomUrl || !roomUrl.match(roomRegEx)) {
         return <p>Set room url on the Controls panel</p>;
     }

--- a/packages/core/src/redux/slices/__tests__/app.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/app.unit.ts
@@ -2,7 +2,7 @@ import { appSlice } from "../app";
 
 describe("appSlice", () => {
     describe("reducers", () => {
-        describe("doAppStart", () => {
+        describe("doAppSetup", () => {
             it("should change the state", () => {
                 const initialConfig = {
                     isNodeSdk: true,
@@ -15,10 +15,10 @@ describe("appSlice", () => {
                     externalId: "externalId",
                 };
 
-                const result = appSlice.reducer(undefined, appSlice.actions.doAppStart(initialConfig));
+                const result = appSlice.reducer(undefined, appSlice.actions.doAppSetup(initialConfig));
 
                 expect(result).toEqual({
-                    isActive: true,
+                    isActive: false,
                     isDialIn: true,
                     ignoreBreakoutGroups: true,
                     roomName: "/roomName",
@@ -41,10 +41,10 @@ describe("appSlice", () => {
                     externalId: "externalId",
                 };
 
-                const result = appSlice.reducer(undefined, appSlice.actions.doAppStart(initialConfig));
+                const result = appSlice.reducer(undefined, appSlice.actions.doAppSetup(initialConfig));
 
                 expect(result).toEqual({
-                    isActive: true,
+                    isActive: false,
                     isDialIn: false,
                     ignoreBreakoutGroups: false,
                     roomName: "/roomName",
@@ -56,6 +56,26 @@ describe("appSlice", () => {
                     isNodeSdk: true,
                     initialConfig,
                 });
+            });
+        });
+
+        describe("doAppStart", () => {
+            it("should set sdk app to an active state", () => {
+                const result = appSlice.reducer(undefined, appSlice.actions.doAppStart());
+
+                expect(result.isActive).toEqual(true);
+            });
+        });
+
+        describe("doAppStop", () => {
+            beforeEach(() => {
+                appSlice.reducer(undefined, appSlice.actions.doAppStart());
+            });
+
+            it("should set sdk app to an inactive state", () => {
+                const result = appSlice.reducer(undefined, appSlice.actions.doAppStop());
+
+                expect(result.isActive).toEqual(false);
             });
         });
     });

--- a/packages/core/src/redux/slices/__tests__/authorization.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/authorization.unit.ts
@@ -7,7 +7,7 @@ import {
     selectIsAuthorizedToRequestAudioEnable,
 } from "../authorization";
 import { signalEvents } from "../signalConnection/actions";
-import { doAppStart } from "../app";
+import { doAppSetup } from "../app";
 
 describe("authorizationSlice", () => {
     describe("reducers", () => {
@@ -17,10 +17,10 @@ describe("authorizationSlice", () => {
             expect(result.roomKey).toEqual("roomKey");
         });
 
-        it("doAppStart", () => {
+        it("doAppSetup", () => {
             const result = authorizationSlice.reducer(
                 undefined,
-                doAppStart({
+                doAppSetup({
                     roomUrl: "https://some.url/roomName",
                     roomKey: "roomKey",
                     displayName: "displayName",

--- a/packages/core/src/redux/slices/app.ts
+++ b/packages/core/src/redux/slices/app.ts
@@ -48,7 +48,7 @@ export const appSlice = createSlice({
     name: "app",
     initialState,
     reducers: {
-        doAppStart: (state, action: PayloadAction<AppConfig>) => {
+        doAppSetup: (state, action: PayloadAction<AppConfig>) => {
             const url = new URL(action.payload.roomUrl);
 
             return {
@@ -56,8 +56,11 @@ export const appSlice = createSlice({
                 ...action.payload,
                 roomName: url.pathname,
                 initialConfig: { ...action.payload },
-                isActive: true,
+                isActive: false,
             };
+        },
+        doAppStart: (state) => {
+            return { ...state, isActive: true };
         },
         doAppStop: (state) => {
             return { ...state, isActive: false };
@@ -69,7 +72,7 @@ export const appSlice = createSlice({
  * Action creators
  */
 
-export const { doAppStop, doAppStart } = appSlice.actions;
+export const { doAppStop, doAppStart, doAppSetup } = appSlice.actions;
 
 /**
  * Selectors

--- a/packages/core/src/redux/slices/authorization.ts
+++ b/packages/core/src/redux/slices/authorization.ts
@@ -2,7 +2,7 @@ import { PayloadAction, createSelector, createSlice } from "@reduxjs/toolkit";
 import { RoleName } from "@whereby.com/media";
 import { RootState } from "../store";
 import { signalEvents } from "./signalConnection/actions";
-import { doAppStart } from "./app";
+import { doAppSetup } from "./app";
 
 const ROOM_ACTION_PERMISSIONS_BY_ROLE: { [permissionKey: string]: Array<RoleName> } = {
     canLockRoom: ["host"],
@@ -40,7 +40,7 @@ export const authorizationSlice = createSlice({
         },
     },
     extraReducers: (builder) => {
-        builder.addCase(doAppStart, (state, action) => {
+        builder.addCase(doAppSetup, (state, action) => {
             return {
                 ...state,
                 roomKey: action.payload.roomKey,

--- a/packages/core/src/redux/slices/localMedia.ts
+++ b/packages/core/src/redux/slices/localMedia.ts
@@ -3,7 +3,7 @@ import { getStream, getUpdatedDevices, getDeviceData } from "@whereby.com/media"
 import { createAppAsyncThunk, createAppThunk } from "../thunk";
 import { RootState } from "../store";
 import { createReactor, startAppListening } from "../listenerMiddleware";
-import { doAppStart, selectAppIsActive } from "./app";
+import { doAppSetup, selectAppIsActive } from "./app";
 import { debounce } from "../../utils";
 import { signalEvents } from "./signalConnection/actions";
 
@@ -141,7 +141,7 @@ export const localMediaSlice = createSlice({
         },
     },
     extraReducers: (builder) => {
-        builder.addCase(doAppStart, (state, action) => {
+        builder.addCase(doAppSetup, (state, action) => {
             return {
                 ...state,
                 options: action.payload.localMediaOptions,

--- a/packages/core/src/redux/slices/localParticipant/index.ts
+++ b/packages/core/src/redux/slices/localParticipant/index.ts
@@ -3,7 +3,7 @@ import { RoleName } from "@whereby.com/media";
 import { createAsyncRoomConnectedThunk, createRoomConnectedThunk } from "../../thunk";
 import { LocalParticipant } from "../../../RoomParticipant";
 import { selectSignalConnectionRaw } from "../signalConnection";
-import { doAppStart } from "../app";
+import { doAppSetup } from "../app";
 import { toggleCameraEnabled, toggleMicrophoneEnabled } from "../localMedia";
 import { createReactor, startAppListening } from "../../listenerMiddleware";
 import { signalEvents } from "../signalConnection/actions";
@@ -61,7 +61,7 @@ export const localParticipantSlice = createSlice({
         },
     },
     extraReducers: (builder) => {
-        builder.addCase(doAppStart, (state, action) => {
+        builder.addCase(doAppSetup, (state, action) => {
             return {
                 ...state,
                 displayName: action.payload.displayName,

--- a/packages/core/src/redux/store.ts
+++ b/packages/core/src/redux/store.ts
@@ -2,7 +2,7 @@ import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import { listenerMiddleware } from "./listenerMiddleware";
 import { createServices } from "../services";
 
-import { appSlice, doAppStart } from "./slices/app";
+import { appSlice, doAppSetup } from "./slices/app";
 import { authorizationSlice } from "./slices/authorization";
 import { breakoutSlice } from "./slices/breakout";
 import { chatSlice } from "./slices/chat";
@@ -52,7 +52,7 @@ const appReducer = combineReducers({
 
 export const rootReducer: AppReducer = (state, action) => {
     // Reset store state on app join action
-    if (doAppStart.match(action)) {
+    if (doAppSetup.match(action)) {
         const resetState: Partial<RootState> = {
             app: {
                 ...appSlice.getInitialState(),


### PR DESCRIPTION
### Description

We have a scenario where the app configuration passed in to the `useRoomConnection` call is only being applied  when `joinRoom` is being called. 

We have always intended for `joinRoom` to be called initially to first ascertain the locked state of any room. Then, if the `joinRoom` call triggers a `room_locked` connection status then, at that point, a developer can call `knock`. When implementing a `joinRoom` -> `room_locked` -> `knock` flow, the app configuration passed in to the `useRoomConnection` call will then successfully also be passed with the knock request to the room. However, when implementing a `knock` directly, the SDK is not passing in the app configuration passed in to the `useRoomConnection` call.

In summary, the following code **does not** pass the `displayName` provided in the `useRoomConnection` call:

```javascript
// blind-knock.js

const roomConnection = useRoomConnection(roomUrl, {
  displayName: "Test Name",
});

useEffect(() => {
  roomConnection.actions.knock();
}, []);
```

However, the following code **will** pass the `displayName` value provided in the `useRoomConnection` call:
What does currently work:

```javascript
// joinRoom-knock.js 

const roomConnection = useRoomConnection(roomUrl, {
  displayName: "Test Name",
});

useEffect(() => {
  roomConnection.actions.joinRoom();
}, []);

useEffect(() => {
  if(roomConnection.state.connectionStatus === "room_locked") {
    roomConnection.actions.knock(); 
  }
}, [roomConnection.state.connectionStatus]);
```

---

This PR enables the first code snippet above work, provideing configuration parameters from the `useRoomConnection` call directly in to the `knock` without having to initially also call `joinRoom` first to ascertain the locked status of the room (assuming a developer know thats all rooms they are generating will be configured to be locked by default).

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
