### PR TITLE
media: limit SFU VP9 bandwidth usage

### DIFF
--- a/.changeset/purple-jobs-punch.md
+++ b/.changeset/purple-jobs-punch.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": minor
+---
+
+Limit bandwidth for large rooms sending VP9

--- a/packages/media/src/utils/mediaSettings.ts
+++ b/packages/media/src/utils/mediaSettings.ts
@@ -31,7 +31,7 @@ const VIDEO_SETTINGS_VP9 = {
     codecOptions: {
         videoGoogleStartBitrate: 500,
     },
-    encodings: [{ scalabilityMode: "L3T2_KEY" }],
+    encodings: [{ scalabilityMode: "L3T2_KEY", maxBitrate: 1650000 }],
 };
 
 const VIDEO_SETTINGS_VP9_LOW_BANDWIDTH = {


### PR DESCRIPTION
# media: limit SFU VP9 bandwidth usage

-------

### Description

**Summary:**
Apply bandwidth limits to VP9 SFU connections
<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**
https://linear.app/whereby/issue/COB-1688/limit-sfu-vp9-bandwidth-to-16mbps
<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. In your local stack, join an SFU room in 2 browser clients with ?sfuVp9On
2. send !stats to the chat, see the bandwidth stats show outbound transfers around 2mbps or more 
![image](https://github.com/user-attachments/assets/c055bda9-5949-4e9c-96a4-bdf6468fde4b)

4. add this media ~canary~ package to your local PWA and rejoin the rooms (with yalc, you can `cd packages/media && yalc publish` then `yalc add @whereby.com/media@1.26.0` in your pwa)
5. see bandwidth is now limited
![image](https://github.com/user-attachments/assets/d484fd4f-3e26-4576-98eb-48368913ca86)

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
