### PR TITLE
media: add flag to switch SVC encoding mode in VP9

### DIFF
--- a/.changeset/silly-carrots-explain.md
+++ b/.changeset/silly-carrots-explain.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": minor
+---
+
+Update preferred codec logic in Group mode rooms

--- a/packages/media/src/utils/__tests__/mediaSettings.spec.ts
+++ b/packages/media/src/utils/__tests__/mediaSettings.spec.ts
@@ -1,6 +1,19 @@
-import { sortCodecs } from "../mediaSettings";
+import {
+    ADDITIONAL_SCREEN_SHARE_SETTINGS,
+    ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9,
+    AUDIO_SETTINGS,
+    SCREEN_SHARE_SETTINGS,
+    SCREEN_SHARE_SETTINGS_LOW_BANDWIDTH,
+    SCREEN_SHARE_SIMULCAST_SETTINGS,
+    SCREEN_SHARE_SETTINGS_VP9,
+    VIDEO_SETTINGS_HD,
+    VIDEO_SETTINGS_SD,
+    VIDEO_SETTINGS_VP9,
+    VIDEO_SETTINGS_VP9_LOW_BANDWIDTH,
+    getMediaSettings,
+    sortCodecs,
+} from "../mediaSettings";
 import { type Codec } from "../mediaSettings";
-
 describe("sortCodecs", () => {
     const codecs: Codec[] = [
         {
@@ -246,4 +259,68 @@ describe("sortCodecs", () => {
             });
         });
     });
+});
+
+describe("getMediaSettings", () => {
+    const x = () => Math.random() > 0.5;
+
+    it.each`
+        kind       | isScreenshare | lowDataModeEnabled | isSomeoneAlreadyPresenting | simulcastScreenshareOn | lowBandwidth | vp9On    | expected
+        ${"audio"} | ${x()}        | ${x()}             | ${x()}                     | ${x()}                 | ${x()}       | ${x()}   | ${AUDIO_SETTINGS}
+        ${"video"} | ${false}      | ${false}           | ${true}                    | ${true}                | ${false}     | ${false} | ${VIDEO_SETTINGS_HD}
+        ${"video"} | ${false}      | ${false}           | ${true}                    | ${false}               | ${false}     | ${false} | ${VIDEO_SETTINGS_HD}
+        ${"video"} | ${false}      | ${false}           | ${false}                   | ${true}                | ${false}     | ${false} | ${VIDEO_SETTINGS_HD}
+        ${"video"} | ${false}      | ${false}           | ${false}                   | ${false}               | ${false}     | ${false} | ${VIDEO_SETTINGS_HD}
+        ${"video"} | ${false}      | ${true}            | ${true}                    | ${true}                | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${false}      | ${true}            | ${true}                    | ${true}                | ${false}     | ${false} | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${false}      | ${true}            | ${true}                    | ${false}               | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${false}      | ${true}            | ${true}                    | ${false}               | ${false}     | ${false} | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${false}      | ${true}            | ${false}                   | ${true}                | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${false}      | ${true}            | ${false}                   | ${true}                | ${false}     | ${false} | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${false}      | ${true}            | ${false}                   | ${false}               | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${false}      | ${true}            | ${false}                   | ${false}               | ${false}     | ${false} | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${false}      | ${false}           | ${true}                    | ${true}                | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${false}      | ${false}           | ${true}                    | ${false}               | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${false}      | ${false}           | ${false}                   | ${true}                | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${false}      | ${false}           | ${false}                   | ${false}               | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${true}       | ${false}           | ${false}                   | ${false}               | ${false}     | ${false} | ${SCREEN_SHARE_SETTINGS}
+        ${"video"} | ${true}       | ${true}            | ${false}                   | ${false}               | ${false}     | ${false} | ${SCREEN_SHARE_SETTINGS}
+        ${"video"} | ${true}       | ${false}           | ${false}                   | ${false}               | ${false}     | ${true}  | ${SCREEN_SHARE_SETTINGS_VP9}
+        ${"video"} | ${true}       | ${true}            | ${false}                   | ${false}               | ${false}     | ${true}  | ${SCREEN_SHARE_SETTINGS_VP9}
+        ${"video"} | ${true}       | ${true}            | ${false}                   | ${true}                | ${false}     | ${false} | ${SCREEN_SHARE_SIMULCAST_SETTINGS}
+        ${"video"} | ${true}       | ${true}            | ${false}                   | ${false}               | ${true}      | ${false} | ${SCREEN_SHARE_SETTINGS_LOW_BANDWIDTH}
+        ${"video"} | ${true}       | ${false}           | ${false}                   | ${false}               | ${true}      | ${false} | ${SCREEN_SHARE_SETTINGS_LOW_BANDWIDTH}
+        ${"video"} | ${true}       | ${true}            | ${true}                    | ${false}               | ${true}      | ${false} | ${ADDITIONAL_SCREEN_SHARE_SETTINGS}
+        ${"video"} | ${true}       | ${false}           | ${true}                    | ${false}               | ${true}      | ${false} | ${ADDITIONAL_SCREEN_SHARE_SETTINGS}
+        ${"video"} | ${true}       | ${true}            | ${true}                    | ${false}               | ${true}      | ${true}  | ${ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9}
+        ${"video"} | ${true}       | ${false}           | ${true}                    | ${false}               | ${true}      | ${true}  | ${ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9}
+        ${"video"} | ${false}      | ${false}           | ${true}                    | ${true}                | ${false}     | ${true}  | ${VIDEO_SETTINGS_VP9}
+        ${"video"} | ${false}      | ${false}           | ${true}                    | ${false}               | ${false}     | ${true}  | ${VIDEO_SETTINGS_VP9}
+        ${"video"} | ${false}      | ${false}           | ${false}                   | ${true}                | ${false}     | ${true}  | ${VIDEO_SETTINGS_VP9}
+        ${"video"} | ${false}      | ${false}           | ${false}                   | ${false}               | ${false}     | ${true}  | ${VIDEO_SETTINGS_VP9}
+        ${"video"} | ${false}      | ${true}            | ${true}                    | ${true}                | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
+        ${"video"} | ${false}      | ${true}            | ${true}                    | ${false}               | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
+        ${"video"} | ${false}      | ${true}            | ${false}                   | ${true}                | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
+        ${"video"} | ${false}      | ${true}            | ${false}                   | ${false}               | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
+        ${"video"} | ${false}      | ${false}           | ${true}                    | ${true}                | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
+        ${"video"} | ${false}      | ${false}           | ${true}                    | ${false}               | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
+        ${"video"} | ${false}      | ${false}           | ${false}                   | ${true}                | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
+        ${"video"} | ${false}      | ${false}           | ${false}                   | ${false}               | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
+    `(
+        "should return $expected when isScreenshare:$isScreenshare, isSomeoneAlreadyPresenting:$isSomeoneAlreadyPresenting, lowDataModeEnabled:$lowDataModeEnabled, simulcastScreenshareOn:$simulcastScreenshareOn, lowBandwidth:$lowBandwidth, vp9On:$vp9On",
+        ({
+            kind,
+            isScreenshare,
+            isSomeoneAlreadyPresenting,
+            lowDataModeEnabled,
+            simulcastScreenshareOn,
+            lowBandwidth,
+            vp9On,
+            expected,
+        }) => {
+            const features = { lowDataModeEnabled, simulcastScreenshareOn, lowBandwidth, vp9On };
+
+            expect(getMediaSettings(kind, isScreenshare, features, isSomeoneAlreadyPresenting)).toEqual(expected);
+        },
+    );
 });

--- a/packages/media/src/utils/__tests__/mediaSettings.spec.ts
+++ b/packages/media/src/utils/__tests__/mediaSettings.spec.ts
@@ -9,11 +9,17 @@ import {
     VIDEO_SETTINGS_HD,
     VIDEO_SETTINGS_SD,
     VIDEO_SETTINGS_VP9,
+    VIDEO_SETTINGS_VP9_KEY,
     VIDEO_SETTINGS_VP9_LOW_BANDWIDTH,
-    getMediaSettings,
+    VIDEO_SETTINGS_VP9_LOW_BANDWIDTH_KEY,
     sortCodecs,
+    getMediaSettings,
 } from "../mediaSettings";
+
 import { type Codec } from "../mediaSettings";
+
+jest.mock("webrtc-adapter", () => ({ browserDetails: { browser: "firefox" } }));
+
 describe("sortCodecs", () => {
     const codecs: Codec[] = [
         {
@@ -262,52 +268,35 @@ describe("sortCodecs", () => {
 });
 
 describe("getMediaSettings", () => {
-    const x = () => Math.random() > 0.5;
+    const randomBoolean = () => Math.random() > 0.5;
+    const randomBrowser = () => (randomBoolean() ? "chrome" : "not chrome");
 
     it.each`
-        kind       | isScreenshare | lowDataModeEnabled | isSomeoneAlreadyPresenting | simulcastScreenshareOn | lowBandwidth | vp9On    | expected
-        ${"audio"} | ${x()}        | ${x()}             | ${x()}                     | ${x()}                 | ${x()}       | ${x()}   | ${AUDIO_SETTINGS}
-        ${"video"} | ${false}      | ${false}           | ${true}                    | ${true}                | ${false}     | ${false} | ${VIDEO_SETTINGS_HD}
-        ${"video"} | ${false}      | ${false}           | ${true}                    | ${false}               | ${false}     | ${false} | ${VIDEO_SETTINGS_HD}
-        ${"video"} | ${false}      | ${false}           | ${false}                   | ${true}                | ${false}     | ${false} | ${VIDEO_SETTINGS_HD}
-        ${"video"} | ${false}      | ${false}           | ${false}                   | ${false}               | ${false}     | ${false} | ${VIDEO_SETTINGS_HD}
-        ${"video"} | ${false}      | ${true}            | ${true}                    | ${true}                | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
-        ${"video"} | ${false}      | ${true}            | ${true}                    | ${true}                | ${false}     | ${false} | ${VIDEO_SETTINGS_SD}
-        ${"video"} | ${false}      | ${true}            | ${true}                    | ${false}               | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
-        ${"video"} | ${false}      | ${true}            | ${true}                    | ${false}               | ${false}     | ${false} | ${VIDEO_SETTINGS_SD}
-        ${"video"} | ${false}      | ${true}            | ${false}                   | ${true}                | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
-        ${"video"} | ${false}      | ${true}            | ${false}                   | ${true}                | ${false}     | ${false} | ${VIDEO_SETTINGS_SD}
-        ${"video"} | ${false}      | ${true}            | ${false}                   | ${false}               | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
-        ${"video"} | ${false}      | ${true}            | ${false}                   | ${false}               | ${false}     | ${false} | ${VIDEO_SETTINGS_SD}
-        ${"video"} | ${false}      | ${false}           | ${true}                    | ${true}                | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
-        ${"video"} | ${false}      | ${false}           | ${true}                    | ${false}               | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
-        ${"video"} | ${false}      | ${false}           | ${false}                   | ${true}                | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
-        ${"video"} | ${false}      | ${false}           | ${false}                   | ${false}               | ${true}      | ${false} | ${VIDEO_SETTINGS_SD}
-        ${"video"} | ${true}       | ${false}           | ${false}                   | ${false}               | ${false}     | ${false} | ${SCREEN_SHARE_SETTINGS}
-        ${"video"} | ${true}       | ${true}            | ${false}                   | ${false}               | ${false}     | ${false} | ${SCREEN_SHARE_SETTINGS}
-        ${"video"} | ${true}       | ${false}           | ${false}                   | ${false}               | ${false}     | ${true}  | ${SCREEN_SHARE_SETTINGS_VP9}
-        ${"video"} | ${true}       | ${true}            | ${false}                   | ${false}               | ${false}     | ${true}  | ${SCREEN_SHARE_SETTINGS_VP9}
-        ${"video"} | ${true}       | ${true}            | ${false}                   | ${true}                | ${false}     | ${false} | ${SCREEN_SHARE_SIMULCAST_SETTINGS}
-        ${"video"} | ${true}       | ${true}            | ${false}                   | ${false}               | ${true}      | ${false} | ${SCREEN_SHARE_SETTINGS_LOW_BANDWIDTH}
-        ${"video"} | ${true}       | ${false}           | ${false}                   | ${false}               | ${true}      | ${false} | ${SCREEN_SHARE_SETTINGS_LOW_BANDWIDTH}
-        ${"video"} | ${true}       | ${true}            | ${true}                    | ${false}               | ${true}      | ${false} | ${ADDITIONAL_SCREEN_SHARE_SETTINGS}
-        ${"video"} | ${true}       | ${false}           | ${true}                    | ${false}               | ${true}      | ${false} | ${ADDITIONAL_SCREEN_SHARE_SETTINGS}
-        ${"video"} | ${true}       | ${true}            | ${true}                    | ${false}               | ${true}      | ${true}  | ${ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9}
-        ${"video"} | ${true}       | ${false}           | ${true}                    | ${false}               | ${true}      | ${true}  | ${ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9}
-        ${"video"} | ${false}      | ${false}           | ${true}                    | ${true}                | ${false}     | ${true}  | ${VIDEO_SETTINGS_VP9}
-        ${"video"} | ${false}      | ${false}           | ${true}                    | ${false}               | ${false}     | ${true}  | ${VIDEO_SETTINGS_VP9}
-        ${"video"} | ${false}      | ${false}           | ${false}                   | ${true}                | ${false}     | ${true}  | ${VIDEO_SETTINGS_VP9}
-        ${"video"} | ${false}      | ${false}           | ${false}                   | ${false}               | ${false}     | ${true}  | ${VIDEO_SETTINGS_VP9}
-        ${"video"} | ${false}      | ${true}            | ${true}                    | ${true}                | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
-        ${"video"} | ${false}      | ${true}            | ${true}                    | ${false}               | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
-        ${"video"} | ${false}      | ${true}            | ${false}                   | ${true}                | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
-        ${"video"} | ${false}      | ${true}            | ${false}                   | ${false}               | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
-        ${"video"} | ${false}      | ${false}           | ${true}                    | ${true}                | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
-        ${"video"} | ${false}      | ${false}           | ${true}                    | ${false}               | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
-        ${"video"} | ${false}      | ${false}           | ${false}                   | ${true}                | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
-        ${"video"} | ${false}      | ${false}           | ${false}                   | ${false}               | ${true}      | ${true}  | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
+        kind       | isScreenshare      | lowDataModeEnabled | isSomeoneAlreadyPresenting | simulcastScreenshareOn | lowBandwidth       | vp9On              | svcKeyScalabilityModeOn | browser            | expected
+        ${"audio"} | ${randomBoolean()} | ${randomBoolean()} | ${randomBoolean()}         | ${randomBoolean()}     | ${randomBoolean()} | ${randomBoolean()} | ${randomBoolean()}      | ${randomBrowser()} | ${AUDIO_SETTINGS}
+        ${"video"} | ${false}           | ${false}           | ${randomBoolean()}         | ${randomBoolean()}     | ${false}           | ${false}           | ${randomBoolean()}      | ${randomBrowser()} | ${VIDEO_SETTINGS_HD}
+        ${"video"} | ${false}           | ${false}           | ${randomBoolean()}         | ${randomBoolean()}     | ${false}           | ${true}            | ${randomBoolean()}      | ${"not_chrome"}    | ${VIDEO_SETTINGS_HD}
+        ${"video"} | ${false}           | ${true}            | ${randomBoolean()}         | ${randomBoolean()}     | ${randomBoolean()} | ${false}           | ${randomBoolean()}      | ${randomBrowser()} | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${false}           | ${false}           | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${false}           | ${randomBoolean()}      | ${randomBrowser()} | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${false}           | ${true}            | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${true}            | ${randomBoolean()}      | ${"not_chrome"}    | ${VIDEO_SETTINGS_SD}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${false}                   | ${false}               | ${false}           | ${false}           | ${randomBoolean()}      | ${randomBrowser()} | ${SCREEN_SHARE_SETTINGS}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${false}                   | ${false}               | ${false}           | ${true}            | ${randomBoolean()}      | ${"not chrome"}    | ${SCREEN_SHARE_SETTINGS}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${false}                   | ${false}               | ${false}           | ${true}            | ${randomBoolean()}      | ${"chrome"}        | ${SCREEN_SHARE_SETTINGS_VP9}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${false}                   | ${true}                | ${false}           | ${false}           | ${randomBoolean()}      | ${randomBrowser()} | ${SCREEN_SHARE_SIMULCAST_SETTINGS}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${false}                   | ${false}               | ${true}            | ${false}           | ${randomBoolean()}      | ${randomBrowser()} | ${SCREEN_SHARE_SETTINGS_LOW_BANDWIDTH}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${true}                    | ${false}               | ${true}            | ${false}           | ${randomBoolean()}      | ${randomBrowser()} | ${ADDITIONAL_SCREEN_SHARE_SETTINGS}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${true}                    | ${false}               | ${true}            | ${true}            | ${randomBoolean()}      | ${"not chrome"}    | ${ADDITIONAL_SCREEN_SHARE_SETTINGS}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${true}                    | ${false}               | ${true}            | ${true}            | ${randomBoolean()}      | ${"chrome"}        | ${ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9}
+        ${"video"} | ${false}           | ${false}           | ${randomBoolean()}         | ${randomBoolean()}     | ${false}           | ${true}            | ${false}                | ${"chrome"}        | ${VIDEO_SETTINGS_VP9}
+        ${"video"} | ${false}           | ${false}           | ${randomBoolean()}         | ${randomBoolean()}     | ${false}           | ${true}            | ${true}                 | ${"chrome"}        | ${VIDEO_SETTINGS_VP9_KEY}
+        ${"video"} | ${false}           | ${true}            | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${true}            | ${false}                | ${"chrome"}        | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
+        ${"video"} | ${false}           | ${false}           | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${true}            | ${false}                | ${"chrome"}        | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
+        ${"video"} | ${false}           | ${true}            | ${randomBoolean()}         | ${randomBoolean()}     | ${false}           | ${true}            | ${false}                | ${"chrome"}        | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}
+        ${"video"} | ${false}           | ${true}            | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${true}            | ${true}                 | ${"chrome"}        | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH_KEY}
+        ${"video"} | ${false}           | ${false}           | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${true}            | ${true}                 | ${"chrome"}        | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH_KEY}
+        ${"video"} | ${false}           | ${true}            | ${randomBoolean()}         | ${randomBoolean()}     | ${false}           | ${true}            | ${true}                 | ${"chrome"}        | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH_KEY}
     `(
-        "should return $expected when isScreenshare:$isScreenshare, isSomeoneAlreadyPresenting:$isSomeoneAlreadyPresenting, lowDataModeEnabled:$lowDataModeEnabled, simulcastScreenshareOn:$simulcastScreenshareOn, lowBandwidth:$lowBandwidth, vp9On:$vp9On",
+        "should return $expected when isScreenshare:$isScreenshare, isSomeoneAlreadyPresenting:$isSomeoneAlreadyPresenting, lowDataModeEnabled:$lowDataModeEnabled, simulcastScreenshareOn:$simulcastScreenshareOn, lowBandwidth:$lowBandwidth, vp9On:$vp9On, svcKeyScalabilityModeOn:$svcKeyScalabilityModeOn, browser:$browser",
         ({
             kind,
             isScreenshare,
@@ -316,9 +305,20 @@ describe("getMediaSettings", () => {
             simulcastScreenshareOn,
             lowBandwidth,
             vp9On,
+            svcKeyScalabilityModeOn,
+            browser,
             expected,
         }) => {
-            const features = { lowDataModeEnabled, simulcastScreenshareOn, lowBandwidth, vp9On };
+            const webrtcAdapterMock = jest.requireMock("webrtc-adapter");
+            webrtcAdapterMock.browserDetails.browser = browser;
+
+            const features = {
+                lowDataModeEnabled,
+                simulcastScreenshareOn,
+                lowBandwidth,
+                vp9On,
+                svcKeyScalabilityModeOn,
+            };
 
             expect(getMediaSettings(kind, isScreenshare, features, isSomeoneAlreadyPresenting)).toEqual(expected);
         },

--- a/packages/media/src/utils/__tests__/mockRouterRtpCapabilities.json
+++ b/packages/media/src/utils/__tests__/mockRouterRtpCapabilities.json
@@ -1,0 +1,263 @@
+{
+    "codecs": [
+        {
+            "kind": "audio",
+            "mimeType": "audio/opus",
+            "clockRate": 48000,
+            "channels": 2,
+            "rtcpFeedback": [
+                {
+                    "type": "nack",
+                    "parameter": ""
+                },
+                {
+                    "type": "transport-cc",
+                    "parameter": ""
+                }
+            ],
+            "parameters": {},
+            "preferredPayloadType": 100
+        },
+        {
+            "kind": "video",
+            "mimeType": "video/VP8",
+            "clockRate": 90000,
+            "rtcpFeedback": [
+                {
+                    "type": "nack",
+                    "parameter": ""
+                },
+                {
+                    "type": "nack",
+                    "parameter": "pli"
+                },
+                {
+                    "type": "ccm",
+                    "parameter": "fir"
+                },
+                {
+                    "type": "goog-remb",
+                    "parameter": ""
+                },
+                {
+                    "type": "transport-cc",
+                    "parameter": ""
+                }
+            ],
+            "parameters": {
+                "x-google-start-bitrate": 500
+            },
+            "preferredPayloadType": 101
+        },
+        {
+            "kind": "video",
+            "mimeType": "video/rtx",
+            "preferredPayloadType": 102,
+            "clockRate": 90000,
+            "parameters": {
+                "apt": 101
+            },
+            "rtcpFeedback": []
+        },
+        {
+            "kind": "video",
+            "mimeType": "video/H264",
+            "clockRate": 90000,
+            "parameters": {
+                "level-asymmetry-allowed": 1,
+                "packetization-mode": 1,
+                "profile-level-id": "42e01f",
+                "x-google-start-bitrate": 500
+            },
+            "rtcpFeedback": [
+                {
+                    "type": "nack",
+                    "parameter": ""
+                },
+                {
+                    "type": "nack",
+                    "parameter": "pli"
+                },
+                {
+                    "type": "ccm",
+                    "parameter": "fir"
+                },
+                {
+                    "type": "goog-remb",
+                    "parameter": ""
+                },
+                {
+                    "type": "transport-cc",
+                    "parameter": ""
+                }
+            ],
+            "preferredPayloadType": 103
+        },
+        {
+            "kind": "video",
+            "mimeType": "video/rtx",
+            "preferredPayloadType": 104,
+            "clockRate": 90000,
+            "parameters": {
+                "apt": 103
+            },
+            "rtcpFeedback": []
+        },
+        {
+            "kind": "video",
+            "mimeType": "video/VP9",
+            "clockRate": 90000,
+            "rtcpFeedback": [
+                {
+                    "type": "nack",
+                    "parameter": ""
+                },
+                {
+                    "type": "nack",
+                    "parameter": "pli"
+                },
+                {
+                    "type": "ccm",
+                    "parameter": "fir"
+                },
+                {
+                    "type": "goog-remb",
+                    "parameter": ""
+                },
+                {
+                    "type": "transport-cc",
+                    "parameter": ""
+                }
+            ],
+            "parameters": {
+                "profile-id": 0,
+                "x-google-start-bitrate": 500
+            },
+            "preferredPayloadType": 105
+        },
+        {
+            "kind": "video",
+            "mimeType": "video/rtx",
+            "preferredPayloadType": 106,
+            "clockRate": 90000,
+            "parameters": {
+                "apt": 105
+            },
+            "rtcpFeedback": []
+        }
+    ],
+    "headerExtensions": [
+        {
+            "kind": "audio",
+            "uri": "urn:ietf:params:rtp-hdrext:sdes:mid",
+            "preferredId": 1,
+            "preferredEncrypt": false,
+            "direction": "sendrecv"
+        },
+        {
+            "kind": "video",
+            "uri": "urn:ietf:params:rtp-hdrext:sdes:mid",
+            "preferredId": 1,
+            "preferredEncrypt": false,
+            "direction": "sendrecv"
+        },
+        {
+            "kind": "video",
+            "uri": "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id",
+            "preferredId": 2,
+            "preferredEncrypt": false,
+            "direction": "recvonly"
+        },
+        {
+            "kind": "video",
+            "uri": "urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id",
+            "preferredId": 3,
+            "preferredEncrypt": false,
+            "direction": "recvonly"
+        },
+        {
+            "kind": "audio",
+            "uri": "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time",
+            "preferredId": 4,
+            "preferredEncrypt": false,
+            "direction": "sendrecv"
+        },
+        {
+            "kind": "video",
+            "uri": "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time",
+            "preferredId": 4,
+            "preferredEncrypt": false,
+            "direction": "sendrecv"
+        },
+        {
+            "kind": "audio",
+            "uri": "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01",
+            "preferredId": 5,
+            "preferredEncrypt": false,
+            "direction": "recvonly"
+        },
+        {
+            "kind": "video",
+            "uri": "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01",
+            "preferredId": 5,
+            "preferredEncrypt": false,
+            "direction": "sendrecv"
+        },
+        {
+            "kind": "video",
+            "uri": "http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07",
+            "preferredId": 6,
+            "preferredEncrypt": false,
+            "direction": "sendrecv"
+        },
+        {
+            "kind": "video",
+            "uri": "urn:ietf:params:rtp-hdrext:framemarking",
+            "preferredId": 7,
+            "preferredEncrypt": false,
+            "direction": "sendrecv"
+        },
+        {
+            "kind": "audio",
+            "uri": "urn:ietf:params:rtp-hdrext:ssrc-audio-level",
+            "preferredId": 10,
+            "preferredEncrypt": false,
+            "direction": "sendrecv"
+        },
+        {
+            "kind": "video",
+            "uri": "urn:ietf:params:rtp-hdrext:toffset",
+            "preferredId": 12,
+            "preferredEncrypt": false,
+            "direction": "sendrecv"
+        },
+        {
+            "kind": "audio",
+            "uri": "http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time",
+            "preferredId": 13,
+            "preferredEncrypt": false,
+            "direction": "sendrecv"
+        },
+        {
+            "kind": "video",
+            "uri": "http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time",
+            "preferredId": 13,
+            "preferredEncrypt": false,
+            "direction": "sendrecv"
+        },
+        {
+            "kind": "audio",
+            "uri": "http://www.webrtc.org/experiments/rtp-hdrext/playout-delay",
+            "preferredId": 14,
+            "preferredEncrypt": false,
+            "direction": "sendrecv"
+        },
+        {
+            "kind": "video",
+            "uri": "http://www.webrtc.org/experiments/rtp-hdrext/playout-delay",
+            "preferredId": 14,
+            "preferredEncrypt": false,
+            "direction": "sendrecv"
+        }
+    ]
+}

--- a/packages/media/src/utils/mediaSettings.ts
+++ b/packages/media/src/utils/mediaSettings.ts
@@ -1,4 +1,4 @@
-const AUDIO_SETTINGS = {
+export const AUDIO_SETTINGS = {
     codecOptions: {
         opusDtx: true,
         opusFec: true,
@@ -6,7 +6,7 @@ const AUDIO_SETTINGS = {
     encodings: [{ dtx: true }],
 };
 
-const VIDEO_SETTINGS_HD = {
+export const VIDEO_SETTINGS_HD = {
     codecOptions: {
         videoGoogleStartBitrate: 500,
     },
@@ -17,7 +17,7 @@ const VIDEO_SETTINGS_HD = {
     ],
 };
 
-const VIDEO_SETTINGS_SD = {
+export const VIDEO_SETTINGS_SD = {
     codecOptions: {
         videoGoogleStartBitrate: 500,
     },
@@ -27,25 +27,25 @@ const VIDEO_SETTINGS_SD = {
     ],
 };
 
-const VIDEO_SETTINGS_VP9 = {
+export const VIDEO_SETTINGS_VP9 = {
     codecOptions: {
         videoGoogleStartBitrate: 500,
     },
     encodings: [{ scalabilityMode: "L3T2_KEY", maxBitrate: 1650000 }],
 };
 
-const VIDEO_SETTINGS_VP9_LOW_BANDWIDTH = {
+export const VIDEO_SETTINGS_VP9_LOW_BANDWIDTH = {
     codecOptions: {
         videoGoogleStartBitrate: 500,
     },
     encodings: [{ scalabilityMode: "L2T2_KEY", maxBitrate: 800000 }],
 };
 
-const SCREEN_SHARE_SETTINGS = {
+export const SCREEN_SHARE_SETTINGS = {
     encodings: [{}],
 };
 
-const SCREEN_SHARE_SETTINGS_LOW_BANDWIDTH = {
+export const SCREEN_SHARE_SETTINGS_LOW_BANDWIDTH = {
     encodings: [
         {
             maxBitrate: 600000,
@@ -54,14 +54,14 @@ const SCREEN_SHARE_SETTINGS_LOW_BANDWIDTH = {
     ],
 };
 
-const SCREEN_SHARE_SIMULCAST_SETTINGS = {
+export const SCREEN_SHARE_SIMULCAST_SETTINGS = {
     encodings: [
         { scaleResolutionDownBy: 2, dtx: true, maxBitrate: 500000 },
         { scaleResolutionDownBy: 1, dtx: true, maxBitrate: 1500000 },
     ],
 };
 
-const ADDITIONAL_SCREEN_SHARE_SETTINGS = {
+export const ADDITIONAL_SCREEN_SHARE_SETTINGS = {
     encodings: [
         { scaleResolutionDownBy: 4, dtx: true, maxBitrate: 150000 },
         { scaleResolutionDownBy: 2, dtx: true, maxBitrate: 500000 },
@@ -69,11 +69,11 @@ const ADDITIONAL_SCREEN_SHARE_SETTINGS = {
     ],
 };
 
-const ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9 = {
+export const ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9 = {
     encodings: [{ scalabilityMode: "L2T2_KEY", dtx: true, maxBitrate: 1500000 }],
 };
 
-const SCREEN_SHARE_SETTINGS_VP9 = {
+export const SCREEN_SHARE_SETTINGS_VP9 = {
     encodings: [{ dtx: true }],
 };
 

--- a/packages/media/src/utils/mediaSettings.ts
+++ b/packages/media/src/utils/mediaSettings.ts
@@ -95,25 +95,61 @@ export const getMediaSettings = (
     }
 
     if (isScreenShare) {
-        if (isSomeoneAlreadyPresenting) {
-            if (vp9On) return ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9;
-            return ADDITIONAL_SCREEN_SHARE_SETTINGS;
-        }
-        if (lowBandwidth && !vp9On) return SCREEN_SHARE_SETTINGS_LOW_BANDWIDTH;
-        if (vp9On) return SCREEN_SHARE_SETTINGS_VP9;
-        if (simulcastScreenshareOn) return SCREEN_SHARE_SIMULCAST_SETTINGS;
-
-        return SCREEN_SHARE_SETTINGS;
+        return getScreenShareMediaSettings({
+            lowBandwidth: lowBandwidth,
+            vp9On,
+            isSomeoneAlreadyPresenting,
+            simulcastScreenshareOn,
+        });
     } else {
-        if (lowBandwidth) {
-            if (vp9On) return VIDEO_SETTINGS_VP9_LOW_BANDWIDTH;
-            return VIDEO_SETTINGS_SD;
-        }
-        if (vp9On) return VIDEO_SETTINGS_VP9;
-        if (lowDataModeEnabled) return VIDEO_SETTINGS_SD;
-
-        return VIDEO_SETTINGS_HD;
+        return getCameraMediaSettings({
+            lowBandwidth: lowBandwidth || lowDataModeEnabled,
+            vp9On,
+        });
     }
+};
+
+const getCameraMediaSettings = ({
+    lowBandwidth,
+    vp9On,
+}: {
+    lowBandwidth?: boolean;
+    vp9On?: boolean;
+    svcKeyScalabilityModeOn?: boolean;
+}) => {
+    if (lowBandwidth) {
+        if (vp9On) {
+            return VIDEO_SETTINGS_VP9_LOW_BANDWIDTH;
+        }
+        return VIDEO_SETTINGS_SD;
+    }
+    if (vp9On) {
+        return VIDEO_SETTINGS_VP9;
+    }
+
+    return VIDEO_SETTINGS_HD;
+};
+
+const getScreenShareMediaSettings = ({
+    lowBandwidth,
+    vp9On,
+    isSomeoneAlreadyPresenting,
+    simulcastScreenshareOn,
+}: {
+    lowBandwidth?: boolean;
+    vp9On?: boolean;
+    isSomeoneAlreadyPresenting?: boolean;
+    simulcastScreenshareOn?: boolean;
+}) => {
+    if (isSomeoneAlreadyPresenting) {
+        if (vp9On) return ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9;
+        return ADDITIONAL_SCREEN_SHARE_SETTINGS;
+    }
+    if (lowBandwidth && !vp9On) return SCREEN_SHARE_SETTINGS_LOW_BANDWIDTH;
+    if (vp9On) return SCREEN_SHARE_SETTINGS_VP9;
+    if (simulcastScreenshareOn) return SCREEN_SHARE_SIMULCAST_SETTINGS;
+
+    return SCREEN_SHARE_SETTINGS;
 };
 
 export const modifyMediaCapabilities = (

--- a/packages/media/src/webrtc/BandwidthTester.ts
+++ b/packages/media/src/webrtc/BandwidthTester.ts
@@ -158,10 +158,13 @@ export default class BandwidthTester extends EventEmitter {
             const { routerRtpCapabilities } = await this._vegaConnection.request("getCapabilities");
 
             if (!this._routerRtpCapabilities) {
-                modifyMediaCapabilities(routerRtpCapabilities, this._features);
+                const modifiedCapabilities = modifyMediaCapabilities(routerRtpCapabilities, {
+                    ...this._features,
+                    vp9On: this._features.sfuVp9On,
+                });
 
-                this._routerRtpCapabilities = routerRtpCapabilities;
-                await this._mediasoupDevice?.load({ routerRtpCapabilities });
+                this._routerRtpCapabilities = modifiedCapabilities;
+                await this._mediasoupDevice?.load({ routerRtpCapabilities: modifiedCapabilities });
             }
 
             this._vegaConnection.message("setCapabilities", {

--- a/packages/media/src/webrtc/VegaRtcManager/index.ts
+++ b/packages/media/src/webrtc/VegaRtcManager/index.ts
@@ -433,10 +433,13 @@ export default class VegaRtcManager implements RtcManager {
             const { routerRtpCapabilities } = await this._vegaConnection.request("getCapabilities");
 
             if (!this._routerRtpCapabilities) {
-                modifyMediaCapabilities(routerRtpCapabilities, { ...this._features, vp9On: this._features.sfuVp9On });
+                const modifiedCapabilities = modifyMediaCapabilities(routerRtpCapabilities, {
+                    ...this._features,
+                    vp9On: this._features.sfuVp9On,
+                });
 
-                this._routerRtpCapabilities = routerRtpCapabilities;
-                await this._mediasoupDevice?.load({ routerRtpCapabilities });
+                this._routerRtpCapabilities = modifiedCapabilities;
+                await this._mediasoupDevice?.load({ routerRtpCapabilities: modifiedCapabilities });
             }
 
             this._vegaConnection.message("setCapabilities", {


### PR DESCRIPTION
# media: limit SFU VP9 bandwidth usage

-------

### Description

**Summary:**
This changes a bit of behaviour with certain flags activated:
- *sfuVp9On & h264On*: previously, these flags made _only_ these codecs work. It turns out Safari and Firefox can't encode VP9 SVC (instead of simulcast) properly, so now VP9 also includes an `isChrome` check. Secondly, the preferred codec is moved to the top of the list of router capabilities, where previously all other codecs were removed.
This change means we can have Chrome clients with VP9 & SVC in the same room as clients using VP8/H264 and simulcast - yay!
- *VP9 bandwidth limits*: Where previously with VP8 we were sending multiple streams at different qualities (simulcast), VP9 uses [SVC](https://w3c.github.io/webrtc-svc/), which allows us to encode all 3 quality levels in one stream. This means that we can save ~600kbps upload that used to be allocated to the lower quality streams. Hurray!
I had previously set this to 1600kbps thinking we could use the extra bandwidth for more quality, but it occurred to me  that this would result in 600kbps per participant extra _download_ bandwidth usage, so that's a no go.
- *svcKeyScalabilityModeOn*: this is an alternative SVC encoding that does some special stuff with key frames. It might result in better quality in the case of dropped packets, so we're gonna run some tests and use it if it appears to improve things. It comes with a ~20% bandwidth overhead, so that's reflected in the bandwidth limits for these encodings
<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**
https://linear.app/whereby/issue/COB-1886/add-flag-to-switch-between-l3t2-and-l3t2-key
<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
0. checkout this PWA branch locally: https://github.com/whereby/pwa/pull/4370
1. In your local stack, join an SFU room in 2 chrome clients with ?sfuVp9On
2. send !stats to the chat, see the bandwidth stats show outbound bitrate around 2000kbps (or more), and inbound is about 1600kbps (or ~20% below outbound)
3. add this media canary to your local PWA `yarn add @whereby.com/media@0.0.0-canary-20250613075108`
 and rejoin the rooms with `&svcKeyScalabilityModeOn` url param
4. see bandwidth both directions is now more like 1000kbps
5. add `&svcKeyScalabilityModeOn` to both clients and see outbound bandwidth goes up to about 1200kbps, but inbound remains the same.
6. join from a safari and firefox browser, see these two clients use VP8
7. add `h264On` to one of the clients, see it switches to H264
<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
