### PR TITLE
browser-sdk: Allow react19 to be used

### DIFF
--- a/.changeset/swift-pens-impress.md
+++ b/.changeset/swift-pens-impress.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": patch
+---
+
+Allow react19 to be used

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -87,8 +87,8 @@
     "runes": "^0.4.3"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": ">=18.2.0",
+    "react-dom": ">=18.2.0"
   },
   "resolutions": {
     "string-width": "^4",


### PR DESCRIPTION
### Description
Allow react19 to be used with browser-sdk, by updating peer dependencies to minimal version 18.2, not exact.

This currently works with yarn, but npm is more strict and throws an error when trying to install the browser-sdk in a react 19 project.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

1. Create a react 19 app (f.ex with vite)
2. Try to install the current published browser-sdk with npm `npm install @whereby.com/browser-sdk`
3. It should throw an error
4. Install this canary with npm `npm install @whereby.com/browser-sdk@0.0.0-canary-20250617101238`
5. It should work

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
