### PR TITLE
common: Fix changeset command

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -47,7 +47,7 @@ jobs:
               id: changesets
               uses: changesets/action@v1
               with:
-                  version: pnpm changeset version && pnpm install --lockfile-only
+                  version: pnpm run version
                   publish: pnpm release
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "build": "turbo build",
         "changeset": "changeset",
+        "version": "changeset version && pnpm install --lockfile-only",
         "dev": "turbo dev --filter=@whereby.com/browser-sdk",
         "dev:embed-element-app": "turbo dev --filter=embed-element-app",
         "dev:telehealth-app": "turbo dev --filter=telehealth-tutorial-app",


### PR DESCRIPTION
### Description

The previous merge workflow failed with this error:
```
changeset version \&\& pnpm install --lockfile-only

🦋  error Too many arguments passed to changesets - we only accept the command name as an argument
Existing pull requests: []
```

It's adding `\` for some reason to the command. It should look like this: `pnpm changeset version && pnpm install --lockfile-only`.

Moving this to the package json should fix it. 
**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
