### PR TITLE
common: remove p2pVp9On flag

### DIFF
--- a/.changeset/sour-buses-dance.md
+++ b/.changeset/sour-buses-dance.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/media": minor
+"@whereby.com/core": minor
+---
+
+Remove p2pVp9On flag

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -233,7 +233,6 @@ export const doConnectRtc = createAppThunk(() => (dispatch, getState) => {
             sfuServerOverrideHost: undefined,
             turnServerOverrideHost: undefined,
             useOnlyTURN: undefined,
-            p2pVp9On: true,
             sfuVp9On: false,
             h264On: false,
             simulcastScreenshareOn: false,

--- a/packages/media/src/utils/__tests__/mediaSettings.spec.ts
+++ b/packages/media/src/utils/__tests__/mediaSettings.spec.ts
@@ -30,124 +30,54 @@ describe("sortCodecs", () => {
         },
         {
             clockRate: 90000,
-            mimeType: "video/rtx",
-        },
-        {
-            clockRate: 90000,
             mimeType: "video/VP9",
-            sdpFmtpLine: "profile-id=0",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/VP9",
-            sdpFmtpLine: "profile-id=2",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/VP9",
-            sdpFmtpLine: "profile-id=1",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/VP9",
-            sdpFmtpLine: "profile-id=3",
         },
         {
             clockRate: 90000,
             mimeType: "video/H264",
-            sdpFmtpLine: "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/H264",
-            sdpFmtpLine: "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/H264",
-            sdpFmtpLine: "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/H264",
-            sdpFmtpLine: "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/H264",
-            sdpFmtpLine: "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/H264",
-            sdpFmtpLine: "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=4d001f",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/H264",
-            sdpFmtpLine: "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=f4001f",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/H264",
-            sdpFmtpLine: "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=f4001f",
         },
         {
             clockRate: 90000,
             mimeType: "video/AV1",
-            sdpFmtpLine: "level-idx=5;profile=0;tier=0",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/AV1",
-            sdpFmtpLine: "level-idx=5;profile=1;tier=0",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/H264",
-            sdpFmtpLine: "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=64001f",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/H264",
-            sdpFmtpLine: "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=64001f",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/red",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/ulpfec",
-        },
-        {
-            clockRate: 90000,
-            mimeType: "video/flexfec-03",
-            sdpFmtpLine: "repair-window=10000000",
         },
     ];
-    describe("with no flags enabled", () => {
-        it("returns the array unchanged", async () => {
-            const sorted = await sortCodecs(codecs, {});
-
-            expect(sorted).toEqual(codecs);
-        });
+    const decodingInfo = jest.fn();
+    decodingInfo.mockImplementation((config: { video: { contentType: string } }) => {
+        return {
+            powerEfficient: config.video.contentType !== "video/VP8" && config.video.contentType !== "video/VP9",
+        };
     });
+    Object.assign(globalThis.navigator, { mediaCapabilities: { decodingInfo } });
 
-    describe("with vp9On enabled", () => {
-        it("returns the sorted array", async () => {
-            const sorted = await sortCodecs(codecs, { vp9On: true });
-
-            expect(sorted.findIndex((codec: Codec) => !!codec.mimeType.match(/vp9/i))).toEqual(0);
+    it("puts hardware decodable codecs first, prioritising VP9 otherwise", async () => {
+        const decodingInfo = jest.fn();
+        decodingInfo.mockImplementation((config: { video: { contentType: string } }) => {
+            return {
+                powerEfficient: config.video.contentType !== "video/VP8" && config.video.contentType !== "video/VP9",
+            };
         });
+        Object.assign(globalThis.navigator, { mediaCapabilities: { decodingInfo } });
 
-        it("leaves the rest of the array in order", async () => {
-            const removeVp9 = (codec: Codec) => !codec.mimeType.match(/vp9/i);
-            const sortedFiltered = (await sortCodecs(codecs, { av1On: true, vp9On: true })).filter(removeVp9);
-            const unsortedFiltered = codecs.filter(removeVp9);
+        const sorted = await sortCodecs(codecs, {});
 
-            expect(sortedFiltered).toEqual(unsortedFiltered);
-        });
+        expect(sorted).toEqual([
+            {
+                clockRate: 90000,
+                mimeType: "video/H264",
+            },
+            {
+                clockRate: 90000,
+                mimeType: "video/AV1",
+            },
+            {
+                clockRate: 90000,
+                mimeType: "video/VP9",
+            },
+            {
+                clockRate: 90000,
+                mimeType: "video/VP8",
+            },
+        ]);
     });
 
     describe("with av1On enabled", () => {
@@ -159,112 +89,10 @@ describe("sortCodecs", () => {
 
         it("leaves the rest of the array in order", async () => {
             const removeAv1 = (codec: Codec) => !codec.mimeType.match(/av1/i);
-            const sortedFiltered = (await sortCodecs(codecs, { av1On: true, vp9On: false })).filter(removeAv1);
+            const sortedFiltered = (await sortCodecs(codecs, { av1On: true })).filter(removeAv1);
             const unsortedFiltered = codecs.filter(removeAv1);
 
             expect(sortedFiltered).toEqual(unsortedFiltered);
-        });
-    });
-
-    describe("with av1On and vp9On enabled", () => {
-        it("prioritizes AV1", async () => {
-            const sorted = await sortCodecs(codecs, { av1On: true, vp9On: true });
-
-            expect(sorted.findIndex((codec: Codec) => !!codec.mimeType.match(/av1/i))).toEqual(0);
-            expect(sorted.findIndex((codec: Codec) => !!codec.mimeType.match(/vp9/i))).toEqual(2);
-        });
-
-        it("leaves the rest of the array in order", async () => {
-            const removeVp9AndAv1 = (codec: Codec) => !codec.mimeType.match(/vp9|av1/i);
-            const sortedFiltered = (await sortCodecs(codecs, { av1On: true, vp9On: true })).filter(removeVp9AndAv1);
-            const unsortedFiltered = codecs.filter(removeVp9AndAv1);
-
-            expect(sortedFiltered).toEqual(unsortedFiltered);
-        });
-    });
-
-    describe("with preferHardwareDecodingOn enabled", () => {
-        const codecs = [
-            {
-                clockRate: 90000,
-                mimeType: "video/VP8",
-            },
-            {
-                clockRate: 90000,
-                mimeType: "video/VP9",
-            },
-            {
-                clockRate: 90000,
-                mimeType: "video/AV1",
-            },
-            {
-                clockRate: 90000,
-                mimeType: "video/H264",
-            },
-        ];
-        it("puts hardware decodable codecs first", async () => {
-            const decodingInfo = jest.fn();
-            decodingInfo.mockImplementation((config: { video: { contentType: string } }) => {
-                return {
-                    powerEfficient: config.video.contentType !== "video/VP8",
-                };
-            });
-            Object.assign(globalThis.navigator, { mediaCapabilities: { decodingInfo } });
-
-            const sorted = await sortCodecs(codecs, { preferHardwareDecodingOn: true });
-
-            expect(sorted).toEqual([
-                {
-                    clockRate: 90000,
-                    mimeType: "video/VP9",
-                },
-                {
-                    clockRate: 90000,
-                    mimeType: "video/AV1",
-                },
-                {
-                    clockRate: 90000,
-                    mimeType: "video/H264",
-                },
-                {
-                    clockRate: 90000,
-                    mimeType: "video/VP8",
-                },
-            ]);
-        });
-
-        describe("with vp9On", () => {
-            it("puts hardware decodable codecs first, prioritising VP9 otherwise", async () => {
-                const decodingInfo = jest.fn();
-                decodingInfo.mockImplementation((config: { video: { contentType: string } }) => {
-                    return {
-                        powerEfficient:
-                            config.video.contentType !== "video/VP8" && config.video.contentType !== "video/VP9",
-                    };
-                });
-                Object.assign(globalThis.navigator, { mediaCapabilities: { decodingInfo } });
-
-                const sorted = await sortCodecs(codecs, { preferHardwareDecodingOn: true, vp9On: true });
-
-                expect(sorted).toEqual([
-                    {
-                        clockRate: 90000,
-                        mimeType: "video/AV1",
-                    },
-                    {
-                        clockRate: 90000,
-                        mimeType: "video/H264",
-                    },
-                    {
-                        clockRate: 90000,
-                        mimeType: "video/VP9",
-                    },
-                    {
-                        clockRate: 90000,
-                        mimeType: "video/VP8",
-                    },
-                ]);
-            });
         });
     });
 });

--- a/packages/media/src/utils/mediaSettings.ts
+++ b/packages/media/src/utils/mediaSettings.ts
@@ -209,10 +209,8 @@ function prioritizeRouterRtpCapabilitiesCodecs(codecs: RtpCodecCapability[], pre
     });
 }
 
-function getPreferredOrder(availableCodecs: string[], { vp9On, av1On }: { vp9On?: boolean; av1On?: boolean }) {
-    if (vp9On) {
-        availableCodecs.unshift("video/vp9");
-    }
+function getPreferredOrder(availableCodecs: string[], { av1On }: { av1On?: boolean }) {
+    availableCodecs.unshift("video/vp9");
 
     if (av1On) {
         availableCodecs.unshift("video/av1");
@@ -226,7 +224,7 @@ export interface Codec {
     sdpFmtpLine?: string;
 }
 
-function sortCodecsByMimeType(codecs: Codec[], features: { vp9On?: boolean; av1On?: boolean }) {
+function sortCodecsByMimeType(codecs: Codec[], features: { av1On?: boolean }) {
     const availableCodecs = codecs
         .map(({ mimeType }) => mimeType)
         .filter((value, index, array) => array.indexOf(value) === index);
@@ -271,14 +269,9 @@ async function sortCodecsByPowerEfficiency(codecs: Codec[]) {
     return sorted;
 }
 
-export async function sortCodecs(
-    codecs: Codec[],
-    features: { vp9On?: boolean; av1On?: boolean; preferHardwareDecodingOn?: boolean },
-) {
-    codecs = sortCodecsByMimeType(codecs, features);
-    if (features.preferHardwareDecodingOn) {
-        codecs = await sortCodecsByPowerEfficiency(codecs);
-    }
+export async function sortCodecs(codecs: Codec[], features: { av1On?: boolean }) {
+    let sortedCodecs = sortCodecsByMimeType(codecs, features);
+    sortedCodecs = await sortCodecsByPowerEfficiency(codecs);
 
-    return codecs;
+    return sortedCodecs;
 }


### PR DESCRIPTION
### Description

**Summary:**
this is default now

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**
https://linear.app/whereby/issue/COB-1679/remove-flags-and-make-vp9-default-for-p2p
<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. add canary media to your local PWA - `yarn add @whereby.com/media@0.0.0-canary-20250711131634`
2. disable p2pVp9On in local unleash
3. join a P2P room from two clients in various browsers with `?stats`
4. ensure the video codec is VP9
5. do the same from an embedded client
<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
