### PR TITLE
media: remove option for *_KEY SVC encoding

### DIFF
--- a/.changeset/tame-items-say.md
+++ b/.changeset/tame-items-say.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": minor
+---
+
+Remove SVC \_KEY encoding flag

--- a/packages/media/src/utils/__tests__/mediaSettings.spec.ts
+++ b/packages/media/src/utils/__tests__/mediaSettings.spec.ts
@@ -9,9 +9,7 @@ import {
     VIDEO_SETTINGS_HD,
     VIDEO_SETTINGS_SD,
     VIDEO_SETTINGS_VP9,
-    VIDEO_SETTINGS_VP9_KEY,
     VIDEO_SETTINGS_VP9_LOW_BANDWIDTH,
-    VIDEO_SETTINGS_VP9_LOW_BANDWIDTH_KEY,
     sortCodecs,
     getMediaSettings,
     modifyMediaCapabilities,
@@ -274,25 +272,23 @@ describe("getMediaSettings", () => {
     const randomBrowser = () => (randomBoolean() ? "chrome" : "not chrome");
 
     it.each`
-        kind       | isScreenshare      | lowDataModeEnabled | isSomeoneAlreadyPresenting | simulcastScreenshareOn | vp9On              | svcKeyScalabilityModeOn | browser            | expected                                | expectedName
-        ${"audio"} | ${randomBoolean()} | ${randomBoolean()} | ${randomBoolean()}         | ${randomBoolean()}     | ${randomBoolean()} | ${randomBoolean()}      | ${randomBrowser()} | ${AUDIO_SETTINGS}                       | ${"AUDIO_SETTINGS"}
-        ${"video"} | ${false}           | ${false}           | ${randomBoolean()}         | ${randomBoolean()}     | ${false}           | ${randomBoolean()}      | ${randomBrowser()} | ${VIDEO_SETTINGS_HD}                    | ${"VIDEO_SETTINGS_HD"}
-        ${"video"} | ${false}           | ${false}           | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${randomBoolean()}      | ${"not_chrome"}    | ${VIDEO_SETTINGS_HD}                    | ${"VIDEO_SETTINGS_HD"}
-        ${"video"} | ${false}           | ${true}            | ${randomBoolean()}         | ${randomBoolean()}     | ${false}           | ${randomBoolean()}      | ${randomBrowser()} | ${VIDEO_SETTINGS_SD}                    | ${"VIDEO_SETTINGS_SD"}
-        ${"video"} | ${false}           | ${true}            | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${randomBoolean()}      | ${"not_chrome"}    | ${VIDEO_SETTINGS_SD}                    | ${"VIDEO_SETTINGS_SD"}
-        ${"video"} | ${true}            | ${randomBoolean()} | ${false}                   | ${false}               | ${false}           | ${randomBoolean()}      | ${randomBrowser()} | ${SCREEN_SHARE_SETTINGS}                | ${"SCREEN_SHARE_SETTINGS"}
-        ${"video"} | ${true}            | ${randomBoolean()} | ${false}                   | ${false}               | ${true}            | ${randomBoolean()}      | ${"not chrome"}    | ${SCREEN_SHARE_SETTINGS}                | ${"SCREEN_SHARE_SETTINGS"}
-        ${"video"} | ${true}            | ${randomBoolean()} | ${false}                   | ${false}               | ${true}            | ${randomBoolean()}      | ${"chrome"}        | ${SCREEN_SHARE_SETTINGS_VP9}            | ${"SCREEN_SHARE_SETTINGS_VP9"}
-        ${"video"} | ${true}            | ${randomBoolean()} | ${false}                   | ${true}                | ${false}           | ${randomBoolean()}      | ${randomBrowser()} | ${SCREEN_SHARE_SIMULCAST_SETTINGS}      | ${"SCREEN_SHARE_SIMULCAST_SETTINGS"}
-        ${"video"} | ${true}            | ${randomBoolean()} | ${true}                    | ${false}               | ${false}           | ${randomBoolean()}      | ${randomBrowser()} | ${ADDITIONAL_SCREEN_SHARE_SETTINGS}     | ${"ADDITIONAL_SCREEN_SHARE_SETTINGS"}
-        ${"video"} | ${true}            | ${randomBoolean()} | ${true}                    | ${false}               | ${true}            | ${randomBoolean()}      | ${"not chrome"}    | ${ADDITIONAL_SCREEN_SHARE_SETTINGS}     | ${"ADDITIONAL_SCREEN_SHARE_SETTINGS"}
-        ${"video"} | ${true}            | ${randomBoolean()} | ${true}                    | ${false}               | ${true}            | ${randomBoolean()}      | ${"chrome"}        | ${ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9} | ${"ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9"}
-        ${"video"} | ${false}           | ${false}           | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${false}                | ${"chrome"}        | ${VIDEO_SETTINGS_VP9}                   | ${"VIDEO_SETTINGS_VP9"}
-        ${"video"} | ${false}           | ${false}           | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${true}                 | ${"chrome"}        | ${VIDEO_SETTINGS_VP9_KEY}               | ${"VIDEO_SETTINGS_VP9_KEY"}
-        ${"video"} | ${false}           | ${true}            | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${false}                | ${"chrome"}        | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}     | ${"VIDEO_SETTINGS_VP9_LOW_BANDWIDTH"}
-        ${"video"} | ${false}           | ${true}            | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${true}                 | ${"chrome"}        | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH_KEY} | ${"VIDEO_SETTINGS_VP9_LOW_BANDWIDTH_KEY"}
+        kind       | isScreenshare      | lowDataModeEnabled | isSomeoneAlreadyPresenting | simulcastScreenshareOn | vp9On              | browser            | expected                                | expectedName
+        ${"audio"} | ${randomBoolean()} | ${randomBoolean()} | ${randomBoolean()}         | ${randomBoolean()}     | ${randomBoolean()} | ${randomBrowser()} | ${AUDIO_SETTINGS}                       | ${"AUDIO_SETTINGS"}
+        ${"video"} | ${false}           | ${false}           | ${randomBoolean()}         | ${randomBoolean()}     | ${false}           | ${randomBrowser()} | ${VIDEO_SETTINGS_HD}                    | ${"VIDEO_SETTINGS_HD"}
+        ${"video"} | ${false}           | ${false}           | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${"not_chrome"}    | ${VIDEO_SETTINGS_HD}                    | ${"VIDEO_SETTINGS_HD"}
+        ${"video"} | ${false}           | ${true}            | ${randomBoolean()}         | ${randomBoolean()}     | ${false}           | ${randomBrowser()} | ${VIDEO_SETTINGS_SD}                    | ${"VIDEO_SETTINGS_SD"}
+        ${"video"} | ${false}           | ${true}            | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${"not_chrome"}    | ${VIDEO_SETTINGS_SD}                    | ${"VIDEO_SETTINGS_SD"}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${false}                   | ${false}               | ${false}           | ${randomBrowser()} | ${SCREEN_SHARE_SETTINGS}                | ${"SCREEN_SHARE_SETTINGS"}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${false}                   | ${false}               | ${true}            | ${"not chrome"}    | ${SCREEN_SHARE_SETTINGS}                | ${"SCREEN_SHARE_SETTINGS"}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${false}                   | ${false}               | ${true}            | ${"chrome"}        | ${SCREEN_SHARE_SETTINGS_VP9}            | ${"SCREEN_SHARE_SETTINGS_VP9"}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${false}                   | ${true}                | ${false}           | ${randomBrowser()} | ${SCREEN_SHARE_SIMULCAST_SETTINGS}      | ${"SCREEN_SHARE_SIMULCAST_SETTINGS"}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${true}                    | ${false}               | ${false}           | ${randomBrowser()} | ${ADDITIONAL_SCREEN_SHARE_SETTINGS}     | ${"ADDITIONAL_SCREEN_SHARE_SETTINGS"}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${true}                    | ${false}               | ${true}            | ${"not chrome"}    | ${ADDITIONAL_SCREEN_SHARE_SETTINGS}     | ${"ADDITIONAL_SCREEN_SHARE_SETTINGS"}
+        ${"video"} | ${true}            | ${randomBoolean()} | ${true}                    | ${false}               | ${true}            | ${"chrome"}        | ${ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9} | ${"ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9"}
+        ${"video"} | ${false}           | ${false}           | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${"chrome"}        | ${VIDEO_SETTINGS_VP9}                   | ${"VIDEO_SETTINGS_VP9"}
+        ${"video"} | ${false}           | ${true}            | ${randomBoolean()}         | ${randomBoolean()}     | ${true}            | ${"chrome"}        | ${VIDEO_SETTINGS_VP9_LOW_BANDWIDTH}     | ${"VIDEO_SETTINGS_VP9_LOW_BANDWIDTH"}
     `(
-        "should return $expectedName when isScreenshare:$isScreenshare, isSomeoneAlreadyPresenting:$isSomeoneAlreadyPresenting, lowDataModeEnabled:$lowDataModeEnabled, simulcastScreenshareOn:$simulcastScreenshareOn, vp9On:$vp9On, svcKeyScalabilityModeOn:$svcKeyScalabilityModeOn, browser:$browser",
+        "should return $expectedName when isScreenshare:$isScreenshare, isSomeoneAlreadyPresenting:$isSomeoneAlreadyPresenting, lowDataModeEnabled:$lowDataModeEnabled, simulcastScreenshareOn:$simulcastScreenshareOn, vp9On:$vp9On, browser:$browser",
         ({
             kind,
             isScreenshare,
@@ -300,7 +296,6 @@ describe("getMediaSettings", () => {
             lowDataModeEnabled,
             simulcastScreenshareOn,
             vp9On,
-            svcKeyScalabilityModeOn,
             browser,
             expected,
         }) => {
@@ -311,7 +306,6 @@ describe("getMediaSettings", () => {
                 lowDataModeEnabled,
                 simulcastScreenshareOn,
                 vp9On,
-                svcKeyScalabilityModeOn,
             };
 
             expect(getMediaSettings(kind, isScreenshare, features, isSomeoneAlreadyPresenting)).toEqual(expected);

--- a/packages/media/src/utils/mediaSettings.ts
+++ b/packages/media/src/utils/mediaSettings.ts
@@ -37,25 +37,11 @@ export const VIDEO_SETTINGS_VP9 = {
     encodings: [{ scalabilityMode: "L3T2", maxBitrate: 1000000 }],
 };
 
-export const VIDEO_SETTINGS_VP9_KEY = {
-    codecOptions: {
-        videoGoogleStartBitrate: 500,
-    },
-    encodings: [{ scalabilityMode: "L3T2_KEY", maxBitrate: 1250000 }],
-};
-
 export const VIDEO_SETTINGS_VP9_LOW_BANDWIDTH = {
     codecOptions: {
         videoGoogleStartBitrate: 500,
     },
     encodings: [{ scalabilityMode: "L2T2", maxBitrate: 500000 }],
-};
-
-export const VIDEO_SETTINGS_VP9_LOW_BANDWIDTH_KEY = {
-    codecOptions: {
-        videoGoogleStartBitrate: 500,
-    },
-    encodings: [{ scalabilityMode: "L2T2_KEY", maxBitrate: 650000 }],
 };
 
 export const SCREEN_SHARE_SETTINGS = {
@@ -78,7 +64,7 @@ export const ADDITIONAL_SCREEN_SHARE_SETTINGS = {
 };
 
 export const ADDITIONAL_SCREEN_SHARE_SETTINGS_VP9 = {
-    encodings: [{ scalabilityMode: "L2T2_KEY", dtx: true, maxBitrate: 1500000 }],
+    encodings: [{ scalabilityMode: "L2T2", dtx: true, maxBitrate: 1500000 }],
 };
 
 export const SCREEN_SHARE_SETTINGS_VP9 = {
@@ -92,11 +78,10 @@ export const getMediaSettings = (
         lowDataModeEnabled?: boolean;
         simulcastScreenshareOn?: boolean;
         vp9On?: boolean;
-        svcKeyScalabilityModeOn?: boolean;
     },
     isSomeoneAlreadyPresenting = false,
 ) => {
-    const { lowDataModeEnabled, simulcastScreenshareOn, vp9On, svcKeyScalabilityModeOn } = features;
+    const { lowDataModeEnabled, simulcastScreenshareOn, vp9On } = features;
 
     if (kind === "audio") {
         return AUDIO_SETTINGS;
@@ -114,7 +99,6 @@ export const getMediaSettings = (
         return getCameraMediaSettings({
             lowBandwidth: lowDataModeEnabled,
             isVp9Available,
-            svcKeyScalabilityModeOn,
         });
     }
 };
@@ -122,21 +106,17 @@ export const getMediaSettings = (
 const getCameraMediaSettings = ({
     lowBandwidth,
     isVp9Available,
-    svcKeyScalabilityModeOn,
 }: {
     lowBandwidth?: boolean;
     isVp9Available?: boolean;
-    svcKeyScalabilityModeOn?: boolean;
 }) => {
     if (lowBandwidth) {
         if (isVp9Available) {
-            if (svcKeyScalabilityModeOn) return VIDEO_SETTINGS_VP9_LOW_BANDWIDTH_KEY;
             return VIDEO_SETTINGS_VP9_LOW_BANDWIDTH;
         }
         return VIDEO_SETTINGS_SD;
     }
     if (isVp9Available) {
-        if (svcKeyScalabilityModeOn) return VIDEO_SETTINGS_VP9_KEY;
         return VIDEO_SETTINGS_VP9;
     }
 


### PR DESCRIPTION
### Description
it uses ~15% more bandwidth and didn't show measurable improvements when tested

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**
[COB-1921: remove svcKeyScalabilityModeOn flag](https://linear.app/whereby/issue/COB-1921/remove-svckeyscalabilitymodeon-flag)
<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. add canary to your PWA
2. join an SFU room with two chromium clients with `?sfuVp9On&stats`
3. see the stream uses VP9 @ 720p, it should max out around 1mbps
4. resize the screen until the video tiles are about 2 inches wide, see it drops down to 640x360
5. resize again so they are really small, see the resolution falls again to 320X180

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
