### PR TITLE
media: fix vp9 bandwidth tester

### DIFF
--- a/.changeset/vast-rocks-push.md
+++ b/.changeset/vast-rocks-push.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Fix BandwidthTester when using VP9

--- a/packages/media/src/webrtc/BandwidthTester.ts
+++ b/packages/media/src/webrtc/BandwidthTester.ts
@@ -350,7 +350,10 @@ export default class BandwidthTester extends EventEmitter {
 
         const producer = await this._sendTransport.produce({
             track,
-            ...getMediaSettings("video", false, this._features),
+            ...getMediaSettings("video", false, {
+                ...this._features,
+                vp9On: this._features.sfuVp9On,
+            }),
             appData: {
                 paused: false,
             },


### PR DESCRIPTION
### Description

**Summary:**
Fixes the bandwidth test when using VP9
<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. add the media canary to PWA
2. in a VP9 enabled room precall using chrome, try to run a bandwidth test - it should succeed

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
