### PR TITLE
media: Add checks to not collect issues and metrics for disabled tracks

### DIFF
--- a/.changeset/nine-suits-chew.md
+++ b/.changeset/nine-suits-chew.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Re-add check to prevent issues and metrics being collected for disabled tracks

--- a/packages/media/src/webrtc/stats/IssueMonitor/__tests__/issueDetectors.spec.ts
+++ b/packages/media/src/webrtc/stats/IssueMonitor/__tests__/issueDetectors.spec.ts
@@ -2,40 +2,9 @@ import {
     badNetworkIssueDetector,
     dryTrackIssueDetector,
     noTrackIssueDetector,
-    IssueCheckData,
     noTrackStatsIssueDetector,
 } from "../issueDetectors";
-import { SsrcStats, StatsClient, TrackStats, ViewStats } from "../../types";
-
-function makeStatsClient(args?: Partial<StatsClient>): StatsClient {
-    return {
-        isLocalClient: true,
-        isAudioOnlyModeEnabled: false,
-        audio: { enabled: true },
-        video: { enabled: true },
-        clientId: "local",
-        id: "local",
-        isPresentation: false,
-        ...args,
-    };
-}
-
-function makeCheckData(args?: Partial<IssueCheckData>): IssueCheckData {
-    return {
-        client: makeStatsClient(),
-        clients: [makeStatsClient(), makeStatsClient()],
-        kind: "audio",
-        track: undefined,
-        trackStats: {} as TrackStats,
-        stats: {} as ViewStats,
-        hasLiveTrack: true,
-        ssrc0: {} as SsrcStats,
-        ssrcs: {} as SsrcStats[],
-        issues: {},
-        metrics: {},
-        ...args,
-    };
-}
+import { mockCheckData, mockStatsClient } from "../../../../../tests/webrtc/webRtcHelpers";
 
 describe("badNetworkIssueDetector", () => {
     describe("enabled", () => {
@@ -46,7 +15,7 @@ describe("badNetworkIssueDetector", () => {
             ${false}     | ${[{}]} | ${false}
             ${true}      | ${[{}]} | ${true}
         `("expected $expected when hasLiveTrack:$hasLiveTrack, ssrcs:$ssrcs", ({ hasLiveTrack, ssrcs, expected }) => {
-            const checkData = makeCheckData({
+            const checkData = mockCheckData({
                 hasLiveTrack,
                 ssrcs,
             });
@@ -56,7 +25,7 @@ describe("badNetworkIssueDetector", () => {
     });
 
     describe("check", () => {
-        const client = makeStatsClient({ isLocalClient: true });
+        const client = mockStatsClient({ isLocalClient: true });
 
         it.each`
             client    | clients                                                              | kind       | ssrcs                                     | expected
@@ -69,7 +38,7 @@ describe("badNetworkIssueDetector", () => {
         `(
             "expected $expected when client:$client, clients:$clients, kind:$kind, ssrcs:$ssrcs",
             ({ client, clients, kind, ssrcs, expected }) => {
-                const checkData = makeCheckData({
+                const checkData = mockCheckData({
                     client,
                     clients,
                     kind,
@@ -91,7 +60,7 @@ describe("dryTrackIssueDetector", () => {
             ${false}     | ${{}}   | ${false}
             ${true}      | ${{}}   | ${true}
         `("expected $expected when hasLiveTrack:$hasLiveTrack, ssrcs:$ssrcs", ({ hasLiveTrack, ssrcs, expected }) => {
-            const checkData = makeCheckData({
+            const checkData = mockCheckData({
                 hasLiveTrack,
                 ssrcs,
             });
@@ -102,7 +71,7 @@ describe("dryTrackIssueDetector", () => {
 
     describe("check", () => {
         describe("local client", () => {
-            const client = makeStatsClient({ isLocalClient: true });
+            const client = mockStatsClient({ isLocalClient: true });
 
             it.each`
                 client    | clients                                                              | ssrcs                                 | expected
@@ -114,7 +83,7 @@ describe("dryTrackIssueDetector", () => {
             `(
                 "expected $expected when client:$client, clients:$clients, ssrcs:$ssrcs",
                 ({ client, clients, ssrcs, expected }) => {
-                    const checkData = makeCheckData({
+                    const checkData = mockCheckData({
                         client,
                         clients,
                         ssrcs,
@@ -130,7 +99,7 @@ describe("dryTrackIssueDetector", () => {
 describe("noTrackIssueDetector", () => {
     describe("check", () => {
         describe("local client", () => {
-            const client = makeStatsClient({ isLocalClient: true });
+            const client = mockStatsClient({ isLocalClient: true });
             it.each`
                 client    | clients                                                              | kind       | track        | expected
                 ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"audio"} | ${{}}        | ${false}
@@ -139,7 +108,7 @@ describe("noTrackIssueDetector", () => {
             `(
                 "expected $expected when client:$client, clients:$clients, kind:$kind, track:$track",
                 ({ client, clients, kind, track, expected }) => {
-                    const checkData = makeCheckData({
+                    const checkData = mockCheckData({
                         client,
                         clients,
                         kind,
@@ -152,7 +121,7 @@ describe("noTrackIssueDetector", () => {
         });
 
         describe("remote client", () => {
-            const client = makeStatsClient({ isLocalClient: false });
+            const client = mockStatsClient({ isLocalClient: false });
             it.each`
                 client    | clients                                                              | kind       | track        | expected
                 ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"audio"} | ${{}}        | ${false}
@@ -161,7 +130,7 @@ describe("noTrackIssueDetector", () => {
             `(
                 "expected $expected when client:$client, clients:$clients, kind:$kind, track:$track",
                 ({ client, clients, kind, track, expected }) => {
-                    const checkData = makeCheckData({
+                    const checkData = mockCheckData({
                         client,
                         clients,
                         kind,
@@ -182,7 +151,7 @@ describe("noTrackStatsIssueDetector", () => {
             ${false}     | ${false}
             ${true}      | ${true}
         `("expected $expected when hasLiveTrack:$hasLiveTrack", ({ hasLiveTrack, expected }) => {
-            const checkData = makeCheckData({
+            const checkData = mockCheckData({
                 hasLiveTrack,
             });
 
@@ -192,7 +161,7 @@ describe("noTrackStatsIssueDetector", () => {
 
     describe("check", () => {
         describe("local client", () => {
-            const client = makeStatsClient({ isLocalClient: true });
+            const client = mockStatsClient({ isLocalClient: true });
             it.each`
                 client    | clients                                                              | kind       | ssrcs   | expected
                 ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"audio"} | ${[{}]} | ${false}
@@ -201,7 +170,7 @@ describe("noTrackStatsIssueDetector", () => {
             `(
                 "expected $expected when client:$client, clients:$clients, kind:$kind, ssrcs:$ssrcs",
                 ({ client, clients, kind, ssrcs, expected }) => {
-                    const checkData = makeCheckData({
+                    const checkData = mockCheckData({
                         client,
                         clients,
                         kind,
@@ -214,7 +183,7 @@ describe("noTrackStatsIssueDetector", () => {
         });
 
         describe("remote client", () => {
-            const client = makeStatsClient({ isLocalClient: false });
+            const client = mockStatsClient({ isLocalClient: false });
             it.each`
                 client    | clients                                                              | kind       | ssrcs   | expected
                 ${client} | ${[client, { isLocalClient: false, isAudioOnlyModeEnabled: false }]} | ${"audio"} | ${[{}]} | ${false}
@@ -223,7 +192,7 @@ describe("noTrackStatsIssueDetector", () => {
             `(
                 "expected $expected when client:$client, clients:$clients, kind:$kind, ssrcs:$ssrcs",
                 ({ client, clients, kind, ssrcs, expected }) => {
-                    const checkData = makeCheckData({
+                    const checkData = mockCheckData({
                         client,
                         clients,
                         kind,

--- a/packages/media/src/webrtc/stats/IssueMonitor/issueDetectors.ts
+++ b/packages/media/src/webrtc/stats/IssueMonitor/issueDetectors.ts
@@ -2,7 +2,7 @@ import { PacketLossAnalyser } from "./packetLossAnalyser";
 import { MediaStreamTrackWithDenoiserContext, SsrcStats, StatsClient, TrackStats, ViewStats } from "../types";
 import { getRoomMode } from "../../RtcManagerDispatcher";
 
-interface IssueDetector {
+export interface IssueDetector {
     id: string;
     global?: boolean;
     enabled: (args: IssueCheckData) => boolean;

--- a/packages/media/tests/webrtc/webRtcHelpers.ts
+++ b/packages/media/tests/webrtc/webRtcHelpers.ts
@@ -1,6 +1,8 @@
 import WS from "jest-websocket-mock";
 
 import { ServerSocket } from "../../src/utils/ServerSocket";
+import { SsrcStats, StatsClient, TrackStats, ViewStats } from "../../src/webrtc/stats/types";
+import { IssueCheckData } from "../../src/webrtc/stats/IssueMonitor/issueDetectors";
 jest.mock("../../src/utils/ServerSocket");
 
 export function createServerSocketStub() {
@@ -280,3 +282,33 @@ export const createSfuWebsocketServer = (): {
 
     return { wss, url };
 };
+
+export function mockStatsClient(args?: Partial<StatsClient>): StatsClient {
+    return {
+        isLocalClient: true,
+        isAudioOnlyModeEnabled: false,
+        audio: { enabled: true },
+        video: { enabled: true },
+        clientId: "local",
+        id: "local",
+        isPresentation: false,
+        ...args,
+    };
+}
+
+export function mockCheckData(args?: Partial<IssueCheckData>): IssueCheckData {
+    return {
+        client: mockStatsClient(),
+        clients: [mockStatsClient(), mockStatsClient()],
+        kind: "audio",
+        track: undefined,
+        trackStats: {} as TrackStats,
+        stats: {} as ViewStats,
+        hasLiveTrack: true,
+        ssrc0: {} as SsrcStats,
+        ssrcs: {} as SsrcStats[],
+        issues: {},
+        metrics: {},
+        ...args,
+    };
+}


### PR DESCRIPTION
### Description

This re-adds some checks on the top level to prevent individual issue detectors and metrics from collecting values whenever the media kind in question is disabled.

### Testing

Added unit tests, more complete test will be added to PWA PR.

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

Follow-up of https://github.com/whereby/sdk/pull/725