### PR TITLE
core: fix duplicate RemoteParticipantState export

### DIFF
--- a/.changeset/old-years-play.md
+++ b/.changeset/old-years-play.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": patch
+---
+
+Fix duplicate RemoteParticipantState export

--- a/packages/core/src/redux/slices/remoteParticipants.ts
+++ b/packages/core/src/redux/slices/remoteParticipants.ts
@@ -38,12 +38,16 @@ export function createRemoteParticipant(client: SignalClient, newJoiner = false)
 //     return client.roleName === "captioner" || client.role?.roleName === "captioner";
 // }
 
-function findParticipant(state: RemoteParticipantState, participantId: string) {
+function findParticipant(state: RemoteParticipantSliceState, participantId: string) {
     const index = state.remoteParticipants.findIndex((c) => c.id === participantId);
     return { index, participant: state.remoteParticipants[index] };
 }
 
-function updateParticipant(state: RemoteParticipantState, participantId: string, updates: Partial<RemoteParticipant>) {
+function updateParticipant(
+    state: RemoteParticipantSliceState,
+    participantId: string,
+    updates: Partial<RemoteParticipant>,
+) {
     const { participant, index } = findParticipant(state, participantId);
 
     if (!participant) {
@@ -61,7 +65,7 @@ function updateParticipant(state: RemoteParticipantState, participantId: string,
     };
 }
 
-function addParticipant(state: RemoteParticipantState, participant: RemoteParticipant) {
+function addParticipant(state: RemoteParticipantSliceState, participant: RemoteParticipant) {
     const { participant: foundParticipant } = findParticipant(state, participant.id);
 
     if (foundParticipant) {
@@ -76,7 +80,7 @@ function addParticipant(state: RemoteParticipantState, participant: RemotePartic
 }
 
 function updateStreamState(
-    state: RemoteParticipantState,
+    state: RemoteParticipantSliceState,
     participantId: string,
     streamId: string,
     state_: StreamState,
@@ -94,14 +98,14 @@ function updateStreamState(
     return updateParticipant(state, participantId, { streams });
 }
 
-function removeClient(state: RemoteParticipantState, participantId: string) {
+function removeClient(state: RemoteParticipantSliceState, participantId: string) {
     return {
         ...state,
         remoteParticipants: state.remoteParticipants.filter((c) => c.id !== participantId),
     };
 }
 
-function addStreamId(state: RemoteParticipantState, participantId: string, streamId: string) {
+function addStreamId(state: RemoteParticipantSliceState, participantId: string, streamId: string) {
     const { participant } = findParticipant(state, participantId);
 
     if (!participant || participant.streams.find((s) => s.id === streamId)) {
@@ -114,7 +118,7 @@ function addStreamId(state: RemoteParticipantState, participantId: string, strea
     });
 }
 
-function removeStreamId(state: RemoteParticipantState, participantId: string, streamId: string) {
+function removeStreamId(state: RemoteParticipantSliceState, participantId: string, streamId: string) {
     const { participant } = findParticipant(state, participantId);
     if (!participant) {
         console.error(`No participant ${participantId} found to remove stream ${streamId}`);
@@ -131,7 +135,7 @@ function removeStreamId(state: RemoteParticipantState, participantId: string, st
     });
 }
 
-function addStream(state: RemoteParticipantState, payload: RtcStreamAddedPayload) {
+function addStream(state: RemoteParticipantSliceState, payload: RtcStreamAddedPayload) {
     const { clientId, stream, streamType } = payload;
     let { streamId } = payload;
 
@@ -174,11 +178,11 @@ function addStream(state: RemoteParticipantState, payload: RtcStreamAddedPayload
  * Reducer
  */
 
-export interface RemoteParticipantState {
+export interface RemoteParticipantSliceState {
     remoteParticipants: RemoteParticipant[];
 }
 
-export const remoteParticipantsSliceInitialState: RemoteParticipantState = {
+export const remoteParticipantsSliceInitialState: RemoteParticipantSliceState = {
     remoteParticipants: [],
 };
 


### PR DESCRIPTION
### Description
**Summary:**
My editor was getting the wrong state from /core, this renames the export from the remoteParticipants slice to fix it
<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
if it builds it works

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
