### PR TITLE
core: export createServices from /redux

### DIFF
--- a/.changeset/wide-breads-slide.md
+++ b/.changeset/wide-breads-slide.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": patch
+---
+
+Fix createStore/createServices type mismatch

--- a/packages/core/src/redux/index.ts
+++ b/packages/core/src/redux/index.ts
@@ -25,3 +25,4 @@ export * from "./slices/spotlights";
 export * from "./slices/streaming";
 export * from "./slices/waitingParticipants";
 export * from "./types";
+export { createServices } from "../services";


### PR DESCRIPTION


### Description

**Summary:**
if we try to use createStore from /redux and createServices form /core there is a type mismatch because they both declare everything twice
<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
