### PR TITLE
media: Add high and extreme RTT delay capture in Issue Monitor

### DIFF
--- a/.changeset/tangy-symbols-join.md
+++ b/.changeset/tangy-symbols-join.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Add high and extreme RTT delay capture in Issue Monitor

--- a/packages/media/src/webrtc/stats/IssueMonitor/issueDetectors.ts
+++ b/packages/media/src/webrtc/stats/IssueMonitor/issueDetectors.ts
@@ -312,13 +312,36 @@ export const issueDetectors: IssueDetector[] = [
             (ssrc0.audioLevel || 0) >= 0.001 &&
             (ssrc0.audioAcceleration || 0) >= 0.1,
     },
+    {
+        id: "high-rtt-delay",
+        global: true,
+        enabled: ({ stats }) => !!Object.values(stats?.candidatePairs || {}).length,
+        check: ({ stats }) =>
+            Object.values(stats?.candidatePairs || {}).some((cp) => cp.roundTripTime && cp.roundTripTime > 0.5),
+    },
+    {
+        id: "extreme-rtt-delay",
+        global: true,
+        enabled: ({ stats }) => !!Object.values(stats?.candidatePairs || {}).length,
+        check: ({ stats }) =>
+            Object.values(stats?.candidatePairs || {}).some((cp) => cp.roundTripTime && cp.roundTripTime > 1),
+    },
+    {
+        id: "high-rtt-delay",
+        enabled: ({ hasLiveTrack, ssrc0 }) => hasLiveTrack && !!ssrc0,
+        check: ({ ssrc0 }) => (ssrc0?.roundTripTime || 0) > 0.5,
+    },
+    {
+        id: "extreme-rtt-delay",
+        enabled: ({ hasLiveTrack, ssrc0 }) => hasLiveTrack && !!ssrc0,
+        check: ({ ssrc0 }) => (ssrc0?.roundTripTime || 0) > 1,
+    },
     // todo:
     // jitter/congestion - increasing jitter for several "ticks"
     // encodeTime?
     // low audio (energy)?
     // keyframe rate?
     // canidate-pair switches
-    // RTT?
     // stun req/res
     // available bitrates
     // probes? low media bitrate?

--- a/packages/media/src/webrtc/stats/types.ts
+++ b/packages/media/src/webrtc/stats/types.ts
@@ -43,9 +43,18 @@ export interface ViewStats {
 
 export interface CandidatePairStats {
     active?: boolean;
+    availableIncomingBitrate?: number;
+    availableOutgoingBitrate?: number;
+    bitrateIn?: number;
+    bitrateOut?: number;
     id: string;
     inactiveFromTime?: number;
     lastRtcStatsTime?: number;
+    requestsSent?: number;
+    requestsReceived?: number;
+    responsesReceived?: number;
+    responsesSent?: number;
+    roundTripTime?: number;
     startTime: number;
     state?: string;
     turnProtocol?: string;


### PR DESCRIPTION
### Description

Add high (> 0.5 seconds) and extreme (> 1 second) Round Trip Time (RTT) delay issue detectors.

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.