### PR TITLE
common: Add live transcription start/stop handling in media, core and browser sdk packages

### DIFF
--- a/.changeset/better-waves-lie.md
+++ b/.changeset/better-waves-lie.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Add live transcription typescript definitions

--- a/.changeset/every-doodles-cheat.md
+++ b/.changeset/every-doodles-cheat.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": minor
+---
+
+Expose core live transcription start/stop API

--- a/.changeset/lucky-wings-nail.md
+++ b/.changeset/lucky-wings-nail.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": minor
+---
+
+Add live transcription start/stop APIs

--- a/apps/sample-app/src/App.tsx
+++ b/apps/sample-app/src/App.tsx
@@ -74,6 +74,8 @@ function RoomControls({
     stopScreenshare,
     startCloudRecording,
     stopCloudRecording,
+    startLiveTranscription,
+    stopLiveTranscription,
     localParticipant,
     isCameraEnabled,
     isMicrophoneEnabled,
@@ -89,6 +91,8 @@ function RoomControls({
     stopScreenshare: () => void;
     startCloudRecording: () => void;
     stopCloudRecording: () => void;
+    startLiveTranscription: () => void;
+    stopLiveTranscription: () => void;
     localParticipant?: LocalParticipantState;
     isCameraEnabled: boolean;
     isMicrophoneEnabled: boolean;
@@ -137,6 +141,12 @@ function RoomControls({
             </button>
             <button data-testid="stopCloudRecordingBtn" onClick={() => stopCloudRecording()}>
                 Stop cloud recording
+            </button>
+            <button data-testid="startLiveTranscriptionBtn" onClick={() => startLiveTranscription()}>
+                Start live transcription
+            </button>
+            <button data-testid="stopLiveTranscriptionBtn" onClick={() => stopLiveTranscription()}>
+                Stop live transcription
             </button>
             {localParticipant && (
                 <>
@@ -198,6 +208,8 @@ const Room = ({ roomUrl, localMedia, displayName, isHost }: RoomProps) => {
         stopScreenshare,
         startCloudRecording,
         stopCloudRecording,
+        startLiveTranscription,
+        stopLiveTranscription,
         joinRoom,
         leaveRoom,
         toggleRaiseHand,
@@ -360,6 +372,8 @@ const Room = ({ roomUrl, localMedia, displayName, isHost }: RoomProps) => {
                 stopScreenshare={stopScreenshare}
                 startCloudRecording={startCloudRecording}
                 stopCloudRecording={stopCloudRecording}
+                startLiveTranscription={startLiveTranscription}
+                stopLiveTranscription={stopLiveTranscription}
                 localParticipant={localParticipant}
                 isCameraEnabled={isCameraEnabled}
                 isMicrophoneEnabled={isMicrophoneEnabled}

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -90,8 +90,10 @@ export function useRoomConnection(
         [client],
     );
     const startCloudRecording = React.useCallback(() => client.startCloudRecording(), [client]);
+    const startLiveTranscription = React.useCallback(() => client.startLiveTranscription(), [client]);
     const startScreenshare = React.useCallback(() => client.startScreenshare(), [client]);
     const stopCloudRecording = React.useCallback(() => client.stopCloudRecording(), [client]);
+    const stopLiveTranscription = React.useCallback(() => client.stopLiveTranscription(), [client]);
     const stopScreenshare = React.useCallback(() => client.stopScreenshare(), [client]);
     const leaveRoom = React.useCallback(() => client.leaveRoom(), [client]);
     const lockRoom = React.useCallback((locked: boolean) => client.lockRoom(locked), [client]);
@@ -158,8 +160,10 @@ export function useRoomConnection(
             sendChatMessage,
             setDisplayName,
             startCloudRecording,
+            startLiveTranscription,
             startScreenshare,
             stopCloudRecording,
+            stopLiveTranscription,
             stopScreenshare,
             toggleCamera,
             toggleMicrophone,

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -33,8 +33,10 @@ export interface RoomConnectionActions {
     sendChatMessage: (text: string) => void;
     setDisplayName: (displayName: string) => void;
     startCloudRecording: () => void;
+    startLiveTranscription: () => void;
     startScreenshare: () => void;
     stopCloudRecording: () => void;
+    stopLiveTranscription: () => void;
     stopScreenshare: () => void;
     toggleCamera: (enabled?: boolean) => void;
     toggleMicrophone: (enabled?: boolean) => void;

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -59,6 +59,8 @@ export default function VideoExperience({
         screenshares,
         spotlightedParticipants,
         breakout,
+        cloudRecording,
+        liveTranscription,
     } = state;
     const {
         knock,
@@ -78,7 +80,11 @@ export default function VideoExperience({
         askToSpeak,
         acceptWaitingParticipant,
         rejectWaitingParticipant,
+        startCloudRecording,
+        startLiveTranscription,
         startScreenshare,
+        stopCloudRecording,
+        stopLiveTranscription,
         stopScreenshare,
         spotlightParticipant,
         removeSpotlight,
@@ -299,6 +305,53 @@ export default function VideoExperience({
                             })}
                         </div>
                     )}
+                    <div className="roomStatus" style={{ display: "flex", columnGap: "10px" }}>
+                        <span>Room status:</span>
+                        {showHostControls ? (
+                            <>
+                                <button
+                                    onClick={() => {
+                                        if (cloudRecording) {
+                                            stopCloudRecording();
+                                        } else {
+                                            startCloudRecording();
+                                        }
+                                    }}
+                                >
+                                    {cloudRecording
+                                        ? `Cloud Recording: ${cloudRecording.status}`
+                                        : "Start Cloud Recording (if available)"}
+                                </button>
+                                <button
+                                    onClick={() => {
+                                        if (liveTranscription) {
+                                            stopLiveTranscription();
+                                        } else {
+                                            startLiveTranscription();
+                                        }
+                                    }}
+                                >
+                                    {liveTranscription
+                                        ? `Live Transcription: ${liveTranscription.status}`
+                                        : "Start Live Transcription (if available)"}
+                                </button>
+                            </>
+                        ) : (
+                            <>
+                                <span>
+                                    {cloudRecording
+                                        ? `Cloud Recording: ${cloudRecording.status}`
+                                        : "No Cloud Recording"}
+                                </span>
+                                <span>
+                                    {liveTranscription
+                                        ? `Live Transcription: ${liveTranscription.status}`
+                                        : "No Live Transcription"}
+                                </span>
+                            </>
+                        )}
+                    </div>
+
                     {showHostControls && (
                         <div className="hostControls">
                             Host controls:

--- a/packages/core/src/__mocks__/appMocks.ts
+++ b/packages/core/src/__mocks__/appMocks.ts
@@ -86,6 +86,7 @@ export const randomSignalClient = ({
     isVideoEnabled = true,
     role = { roleName: "visitor" },
     startedCloudRecordingAt = null,
+    startedLiveTranscriptionAt = null,
     streams = [],
 }: Partial<SignalClient> = {}): SignalClient => {
     return {
@@ -100,6 +101,7 @@ export const randomSignalClient = ({
         isVideoEnabled,
         role,
         startedCloudRecordingAt,
+        startedLiveTranscriptionAt,
         streams,
     };
 };

--- a/packages/core/src/client/RoomConnection/events.ts
+++ b/packages/core/src/client/RoomConnection/events.ts
@@ -5,6 +5,7 @@ import {
     BreakoutState,
     CloudRecordingState,
     LiveStreamState,
+    LiveTranscriptionState,
     LocalParticipantState,
     LocalScreenshareStatus,
     RemoteParticipantState,
@@ -18,6 +19,8 @@ export const CHAT_NEW_MESSAGE = "chat:new-message";
 export const CLOUD_RECORDING_STATUS_CHANGED = "cloud-recording:status-changed";
 /* Connection Status Events */
 export const CONNECTION_STATUS_CHANGED = "connection:status-changed";
+/* Live Transcription Events */
+export const LIVE_TRANSCRIPTION_STATUS_CHANGED = "live-transcription:status-changed";
 /* Local participant events */
 export const LOCAL_PARTICIPANT_CHANGED = "local-participant:changed";
 export const LOCAL_SCREENSHARE_STATUS_CHANGED = "local-screenshare:status-changed";
@@ -54,6 +57,7 @@ export type RoomConnectionEvents = {
     [CHAT_NEW_MESSAGE]: [message: ChatMessage];
     [CLOUD_RECORDING_STATUS_CHANGED]: [status: CloudRecordingState | undefined];
     [CONNECTION_STATUS_CHANGED]: [status: ConnectionStatus];
+    [LIVE_TRANSCRIPTION_STATUS_CHANGED]: [status: LiveTranscriptionState | undefined];
     [LOCAL_PARTICIPANT_CHANGED]: [participant?: LocalParticipantState];
     [LOCAL_SCREENSHARE_STATUS_CHANGED]: [status?: LocalScreenshareStatus];
     [REMOTE_PARTICIPANTS_CHANGED]: [participants: RemoteParticipantState[]];

--- a/packages/core/src/client/RoomConnection/index.ts
+++ b/packages/core/src/client/RoomConnection/index.ts
@@ -21,8 +21,10 @@ import {
     doSetLocalStickyReaction,
     doSpotlightParticipant,
     doStartCloudRecording,
+    doStartLiveTranscription,
     doStartScreenshare,
     doStopCloudRecording,
+    doStopLiveTranscription,
     doStopScreenshare,
     selectNotificationsEmitter,
     setDisplayName,
@@ -37,6 +39,8 @@ import type { Store as AppStore } from "../../redux/store";
 import type {
     BreakoutState,
     ChatMessage,
+    CloudRecordingState,
+    LiveTranscriptionState,
     LocalParticipantState,
     LocalScreenshareStatus,
     RemoteParticipantState,
@@ -51,6 +55,7 @@ import {
     CHAT_NEW_MESSAGE,
     CLOUD_RECORDING_STATUS_CHANGED,
     CONNECTION_STATUS_CHANGED,
+    LIVE_TRANSCRIPTION_STATUS_CHANGED,
     LOCAL_PARTICIPANT_CHANGED,
     LOCAL_SCREENSHARE_STATUS_CHANGED,
     REMOTE_PARTICIPANTS_CHANGED,
@@ -76,7 +81,8 @@ export class RoomConnectionClient extends BaseClient<RoomConnectionState, RoomCo
     private selfId: string | null = null;
 
     private chatMessageSubscribers = new Set<(messages: ChatMessage[]) => void>();
-    private cloudRecordingSubscribers = new Set<(status: { status: "recording" } | undefined) => void>();
+    private cloudRecordingSubscribers = new Set<(status: CloudRecordingState | undefined) => void>();
+    private liveTranscriptionSubscribers = new Set<(status: LiveTranscriptionState | undefined) => void>();
     private breakoutSubscribers = new Set<(config: BreakoutState) => void>();
     private connectionStatusSubscribers = new Set<(status: ConnectionStatus) => void>();
     private liveStreamSubscribers = new Set<(status: { status: "streaming" } | undefined) => void>();
@@ -99,10 +105,13 @@ export class RoomConnectionClient extends BaseClient<RoomConnectionState, RoomCo
         }
 
         if (state.cloudRecording !== previousState.cloudRecording) {
-            this.cloudRecordingSubscribers.forEach((cb) =>
-                cb(state.cloudRecording ? { status: "recording" } : undefined),
-            );
-            this.emit(CLOUD_RECORDING_STATUS_CHANGED, state.cloudRecording ? { status: "recording" } : undefined);
+            this.cloudRecordingSubscribers.forEach((cb) => cb(state.cloudRecording));
+            this.emit(CLOUD_RECORDING_STATUS_CHANGED, state.cloudRecording);
+        }
+
+        if (state.liveTranscription !== previousState.liveTranscription) {
+            this.liveTranscriptionSubscribers.forEach((cb) => cb(state.liveTranscription));
+            this.emit(LIVE_TRANSCRIPTION_STATUS_CHANGED, state.liveTranscription);
         }
 
         if (state.breakout !== previousState.breakout) {
@@ -222,9 +231,14 @@ export class RoomConnectionClient extends BaseClient<RoomConnectionState, RoomCo
         return () => this.chatMessageSubscribers.delete(callback);
     }
 
-    public subscribeToCloudRecording(callback: (status: { status: "recording" } | undefined) => void): () => void {
+    public subscribeToCloudRecording(callback: (status: CloudRecordingState | undefined) => void): () => void {
         this.cloudRecordingSubscribers.add(callback);
         return () => this.cloudRecordingSubscribers.delete(callback);
+    }
+
+    public subscribeToLiveTranscription(callback: (status: LiveTranscriptionState | undefined) => void): () => void {
+        this.liveTranscriptionSubscribers.add(callback);
+        return () => this.liveTranscriptionSubscribers.delete(callback);
     }
 
     public subscribeToBreakoutConfig(callback: (config: BreakoutState) => void): () => void {
@@ -467,6 +481,20 @@ export class RoomConnectionClient extends BaseClient<RoomConnectionState, RoomCo
      */
     public stopCloudRecording() {
         this.store.dispatch(doStopCloudRecording());
+    }
+
+    /**
+     * Start live transcription.
+     */
+    public startLiveTranscription() {
+        this.store.dispatch(doStartLiveTranscription());
+    }
+
+    /**
+     * Stop live transcription.
+     */
+    public stopLiveTranscription() {
+        this.store.dispatch(doStopLiveTranscription());
     }
 
     /**

--- a/packages/core/src/client/RoomConnection/selector.ts
+++ b/packages/core/src/client/RoomConnection/selector.ts
@@ -7,6 +7,7 @@ import {
     selectScreenshares,
     selectRoomConnectionStatus,
     selectWaitingParticipants,
+    selectLiveTranscriptionRaw,
     selectLocalMediaStream,
     selectStreamingRaw,
     selectNotificationsEmitter,
@@ -26,6 +27,7 @@ export const selectRoomConnectionState = createSelector(
     selectBreakoutActive,
     selectBreakoutGroupedParticipants,
     selectAllClientViewsInCurrentGroup,
+    selectLiveTranscriptionRaw,
     selectLocalParticipantRaw,
     selectLocalMediaStream,
     selectRemoteParticipants,
@@ -42,6 +44,7 @@ export const selectRoomConnectionState = createSelector(
         breakoutActive,
         breakoutGroupedParticipants,
         clientViewsInCurrentGroup,
+        liveTranscription,
         localParticipant,
         localMediaStream,
         remoteParticipants,
@@ -54,7 +57,13 @@ export const selectRoomConnectionState = createSelector(
     ) => {
         const state: RoomConnectionState = {
             chatMessages,
-            cloudRecording: cloudRecording.isRecording ? { status: "recording" } : undefined,
+            cloudRecording: cloudRecording.status
+                ? {
+                      error: cloudRecording.error,
+                      startedAt: cloudRecording.startedAt,
+                      status: cloudRecording.status,
+                  }
+                : undefined,
             breakout: {
                 isActive: breakoutActive,
                 currentGroup: breakoutCurrentGroup,
@@ -67,6 +76,13 @@ export const selectRoomConnectionState = createSelector(
                 ? {
                       status: "streaming",
                       startedAt: streaming.startedAt,
+                  }
+                : undefined,
+            liveTranscription: liveTranscription.status
+                ? {
+                      error: liveTranscription.error,
+                      startedAt: liveTranscription.startedAt,
+                      status: liveTranscription.status,
                   }
                 : undefined,
             localScreenshareStatus: localParticipant.isScreenSharing ? "active" : undefined,

--- a/packages/core/src/client/RoomConnection/types.ts
+++ b/packages/core/src/client/RoomConnection/types.ts
@@ -45,6 +45,12 @@ export type CloudRecordingState = {
     startedAt?: number;
 };
 
+export type LiveTranscriptionState = {
+    error?: string;
+    status: "transcribing" | "requested" | "error";
+    startedAt?: number;
+};
+
 export type LiveStreamState = {
     status: "streaming";
     startedAt?: number;
@@ -73,6 +79,7 @@ export interface RoomConnectionState {
     breakout: BreakoutState;
     events?: NotificationsEventEmitter;
     liveStream?: LiveStreamState;
+    liveTranscription?: LiveTranscriptionState;
     localScreenshareStatus?: LocalScreenshareStatus;
     localParticipant?: LocalParticipantState;
     remoteParticipants: RemoteParticipantState[];

--- a/packages/core/src/redux/constants.ts
+++ b/packages/core/src/redux/constants.ts
@@ -1,1 +1,1 @@
-export const NON_PERSON_ROLES = ["recorder", "streamer"];
+export const NON_PERSON_ROLES = ["recorder", "streamer", "captioner", "assistant"];

--- a/packages/core/src/redux/index.ts
+++ b/packages/core/src/redux/index.ts
@@ -10,6 +10,7 @@ export * from "./slices/breakout";
 export * from "./slices/cloudRecording";
 export * from "./slices/connectionMonitor";
 export * from "./slices/deviceCredentials";
+export * from "./slices/liveTranscription";
 export * from "./slices/localMedia";
 export * from "./slices/localParticipant";
 export * from "./slices/localParticipant/selectors";

--- a/packages/core/src/redux/slices/__tests__/authorization.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/authorization.unit.ts
@@ -67,6 +67,7 @@ describe("authorizationSlice", () => {
                                             roleName: "host",
                                         },
                                         startedCloudRecordingAt: null,
+                                        startedLiveTranscriptionAt: null,
                                         externalId: null,
                                         isDialIn: false,
                                         isAudioRecorder: false,

--- a/packages/core/src/redux/slices/__tests__/liveTranscription.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/liveTranscription.unit.ts
@@ -1,44 +1,54 @@
-import { cloudRecordingSlice, initialCloudRecordingState } from "../cloudRecording";
+import { randomString } from "../../../__mocks__/appMocks";
+import { liveTranscriptionSlice, initialLiveTranscriptionState } from "../liveTranscription";
 import { signalEvents } from "../signalConnection/actions";
 
-describe("cloudRecordingSlice", () => {
+describe("liveTranscriptionSlice", () => {
     describe("reducers", () => {
         // We only handle error in this event. We start cloud recording when a new recorder client joins.
-        it("signalEvents.cloudRecordingStarted", () => {
-            const result = cloudRecordingSlice.reducer(
+        it("signalEvents.liveTranscriptionStarted", () => {
+            const result = liveTranscriptionSlice.reducer(
                 undefined,
-                signalEvents.cloudRecordingStarted({ error: "some error" }),
+                signalEvents.liveTranscriptionStarted({ error: "some error" }),
             );
 
             expect(result).toEqual({
                 error: "some error",
                 isInitiator: false,
-                isRecording: false,
+                isTranscribing: false,
                 status: "error",
             });
         });
 
-        describe("signalEvents.cloudRecordingStopped", () => {
+        describe("signalEvents.liveTranscriptionStopped", () => {
             it("resets the recording state", () => {
-                const result = cloudRecordingSlice.reducer(undefined, signalEvents.cloudRecordingStopped());
+                const result = liveTranscriptionSlice.reducer(
+                    undefined,
+                    signalEvents.liveTranscriptionStopped({
+                        transcriptionId: randomString(),
+                        endedAt: "2021-01-01T00:00:00.000Z",
+                    }),
+                );
 
                 expect(result).toEqual({
                     isInitiator: false,
-                    isRecording: false,
+                    isTranscribing: false,
                     startedAt: undefined,
                     status: undefined,
                 });
             });
 
             it("resets the recording state as the initiator", () => {
-                const result = cloudRecordingSlice.reducer(
-                    { ...initialCloudRecordingState, isInitiator: true },
-                    signalEvents.cloudRecordingStopped(),
+                const result = liveTranscriptionSlice.reducer(
+                    { ...initialLiveTranscriptionState, isInitiator: true },
+                    signalEvents.liveTranscriptionStopped({
+                        transcriptionId: randomString(),
+                        endedAt: "2021-01-01T00:00:00.000Z",
+                    }),
                 );
 
                 expect(result).toEqual({
                     isInitiator: false,
-                    isRecording: false,
+                    isTranscribing: false,
                     startedAt: undefined,
                     status: undefined,
                 });
@@ -46,11 +56,11 @@ describe("cloudRecordingSlice", () => {
         });
 
         it("signalEvents.newClient", () => {
-            const result = cloudRecordingSlice.reducer(
+            const result = liveTranscriptionSlice.reducer(
                 undefined,
                 signalEvents.newClient({
                     client: {
-                        displayName: "recorder",
+                        displayName: "captioner",
                         deviceId: "deviceId",
                         streams: [],
                         isAudioEnabled: true,
@@ -58,10 +68,10 @@ describe("cloudRecordingSlice", () => {
                         breakoutGroup: null,
                         id: "id",
                         role: {
-                            roleName: "recorder",
+                            roleName: "captioner",
                         },
-                        startedCloudRecordingAt: "2021-01-01T00:00:00.000Z",
-                        startedLiveTranscriptionAt: null,
+                        startedCloudRecordingAt: null,
+                        startedLiveTranscriptionAt: "2021-01-01T00:00:00.000Z",
                         externalId: null,
                         isDialIn: false,
                         isAudioRecorder: false,
@@ -71,8 +81,8 @@ describe("cloudRecordingSlice", () => {
 
             expect(result).toEqual({
                 isInitiator: false,
-                isRecording: true,
-                status: "recording",
+                isTranscribing: true,
+                status: "transcribing",
                 startedAt: 1609459200000,
             });
         });

--- a/packages/core/src/redux/slices/cloudRecording.ts
+++ b/packages/core/src/redux/slices/cloudRecording.ts
@@ -10,7 +10,7 @@ import { selectSignalConnectionRaw } from "./signalConnection";
 export interface CloudRecordingState {
     isInitiator: boolean;
     isRecording: boolean;
-    error: unknown;
+    error?: string;
     status?: "recording" | "requested" | "error";
     startedAt?: number;
 }
@@ -18,7 +18,6 @@ export interface CloudRecordingState {
 export const initialCloudRecordingState: CloudRecordingState = {
     isInitiator: false,
     isRecording: false,
-    error: null,
     startedAt: undefined,
 };
 

--- a/packages/core/src/redux/slices/liveTranscription.ts
+++ b/packages/core/src/redux/slices/liveTranscription.ts
@@ -1,0 +1,112 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { RootState } from "../store";
+import { createRoomConnectedThunk } from "../thunk";
+import { signalEvents } from "./signalConnection/actions";
+import { selectSignalConnectionRaw } from "./signalConnection";
+
+/**
+ * Reducer
+ */
+export interface LiveTranscriptionState {
+    isInitiator: boolean;
+    isTranscribing: boolean;
+    error?: string;
+    status?: "transcribing" | "requested" | "error";
+    startedAt?: number;
+}
+
+export const initialLiveTranscriptionState: LiveTranscriptionState = {
+    isInitiator: false,
+    isTranscribing: false,
+    startedAt: undefined,
+};
+
+export const liveTranscriptionSlice = createSlice({
+    name: "liveTranscription",
+    initialState: initialLiveTranscriptionState,
+    reducers: {
+        transcribingRequestStarted: (state) => {
+            return {
+                ...state,
+                isInitiator: true,
+                status: "requested",
+            };
+        },
+    },
+    extraReducers: (builder) => {
+        builder.addCase(signalEvents.liveTranscriptionStopped, (state) => {
+            return {
+                ...state,
+                isInitiator: false,
+                isTranscribing: false,
+                status: undefined,
+            };
+        });
+        builder.addCase(signalEvents.liveTranscriptionStarted, (state, action) => {
+            const { payload } = action;
+
+            if (!payload.error) {
+                return state;
+            }
+
+            return {
+                ...state,
+                isInitiator: false,
+                isTranscribing: false,
+                status: "error",
+                error: payload.error,
+            };
+        });
+
+        builder.addCase(signalEvents.newClient, (state, { payload }) => {
+            const { client } = payload;
+            if (client.role?.roleName === "captioner") {
+                return {
+                    ...state,
+                    isTranscribing: true,
+                    status: "transcribing",
+                    startedAt: client.startedLiveTranscriptionAt
+                        ? new Date(client.startedLiveTranscriptionAt).getTime()
+                        : new Date().getTime(),
+                };
+            }
+            return state;
+        });
+    },
+});
+
+/**
+ * Action creators
+ */
+export const { transcribingRequestStarted } = liveTranscriptionSlice.actions;
+
+export const doStartLiveTranscription = createRoomConnectedThunk(() => (dispatch, getState) => {
+    const state = getState();
+    const socket = selectSignalConnectionRaw(state).socket;
+    const status = selectLiveTranscriptionStatus(state);
+
+    if (status && ["transcribing", "requested"].includes(status)) {
+        return;
+    }
+
+    socket?.emit("start_live_transcription");
+
+    dispatch(transcribingRequestStarted());
+});
+
+export const doStopLiveTranscription = createRoomConnectedThunk(() => (dispatch, getState) => {
+    const state = getState();
+    const socket = selectSignalConnectionRaw(state).socket;
+
+    socket?.emit("stop_live_transcription");
+});
+
+/**
+ * Selectors
+ */
+export const selectLiveTranscriptionRaw = (state: RootState) => state.liveTranscription;
+export const selectLiveTranscriptionStatus = (state: RootState) => state.liveTranscription.status;
+export const selectLiveTranscriptionStartedAt = (state: RootState) => state.liveTranscription.startedAt;
+export const selectLiveTranscriptionError = (state: RootState) => state.liveTranscription.error;
+export const selectIsLiveTranscription = (state: RootState) => state.liveTranscription.isTranscribing;
+export const selectLiveTranscriptionIsInitiator = (state: RootState) => state.liveTranscription.isInitiator;

--- a/packages/core/src/redux/slices/rtcAnalytics.ts
+++ b/packages/core/src/redux/slices/rtcAnalytics.ts
@@ -15,6 +15,7 @@ import { doStartScreenshare, selectLocalScreenshareStream, stopScreenshare } fro
 import { selectRoomConnectionSessionId } from "./roomConnection/selectors";
 import { signalEvents } from "./signalConnection/actions";
 import { selectCloudRecordingIsInitiator, selectIsCloudRecording } from "./cloudRecording";
+import { selectLiveTranscriptionIsInitiator, selectIsLiveTranscription } from "./liveTranscription";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RtcAnalyticsCustomEvent<T = any> = {
@@ -113,6 +114,15 @@ export const rtcAnalyticsCustomEvents: { [key: string]: RtcAnalyticsCustomEvent 
         getValue: (state: RootState) => ({
             local: false,
             cloud: !!(selectIsCloudRecording(state) && selectCloudRecordingIsInitiator(state)),
+        }),
+        getOutput: (value) => value,
+    }),
+    transcribing: createRtcAnalyticsCustomEvent({
+        actions: [signalEvents.newClient],
+        rtcEventName: "transcribing",
+        getValue: (state: RootState) => ({
+            local: false,
+            cloud: !!(selectIsLiveTranscription(state) && selectLiveTranscriptionIsInitiator(state)),
         }),
         getOutput: (value) => value,
     }),

--- a/packages/core/src/redux/store.ts
+++ b/packages/core/src/redux/store.ts
@@ -9,6 +9,7 @@ import { chatSlice } from "./slices/chat";
 import { cloudRecordingSlice } from "./slices/cloudRecording";
 import { connectionMonitorSlice } from "./slices/connectionMonitor";
 import { deviceCredentialsSlice } from "./slices/deviceCredentials";
+import { liveTranscriptionSlice } from "./slices/liveTranscription";
 import { localMediaSlice } from "./slices/localMedia";
 import { localParticipantSlice } from "./slices/localParticipant";
 import { localScreenshareSlice } from "./slices/localScreenshare";
@@ -36,6 +37,7 @@ const appReducer = combineReducers({
     cloudRecording: cloudRecordingSlice.reducer,
     connectionMonitor: connectionMonitorSlice.reducer,
     deviceCredentials: deviceCredentialsSlice.reducer,
+    liveTranscription: liveTranscriptionSlice.reducer,
     localMedia: localMediaSlice.reducer,
     localParticipant: localParticipantSlice.reducer,
     localScreenshare: localScreenshareSlice.reducer,

--- a/packages/core/src/redux/tests/store/liveTranscription.spec.ts
+++ b/packages/core/src/redux/tests/store/liveTranscription.spec.ts
@@ -1,0 +1,63 @@
+import { createStore, mockSignalEmit } from "../store.setup";
+import {
+    doStartLiveTranscription,
+    doStopLiveTranscription,
+    initialLiveTranscriptionState,
+} from "../../slices/liveTranscription";
+import { diff } from "deep-object-diff";
+
+describe("actions", () => {
+    describe("doStartLiveTranscription", () => {
+        it("should start transcribing", () => {
+            const store = createStore({ withSignalConnection: true, connectToRoom: true });
+
+            const before = store.getState().liveTranscription;
+
+            store.dispatch(doStartLiveTranscription());
+
+            const after = store.getState().liveTranscription;
+
+            expect(mockSignalEmit).toHaveBeenCalledWith("start_live_transcription");
+            expect(diff(before, after)).toEqual({
+                status: "requested",
+                isInitiator: true,
+            });
+        });
+
+        it("should not start transcribing if already transcribing", () => {
+            const store = createStore({
+                withSignalConnection: true,
+                connectToRoom: true,
+                initialState: {
+                    liveTranscription: {
+                        ...initialLiveTranscriptionState,
+                        isTranscribing: true,
+                        status: "transcribing",
+                    },
+                },
+            });
+
+            store.dispatch(doStartLiveTranscription());
+
+            expect(mockSignalEmit).not.toHaveBeenCalled();
+        });
+    });
+
+    it("doStopLiveTranscription", () => {
+        const store = createStore({
+            withSignalConnection: true,
+            connectToRoom: true,
+            initialState: {
+                liveTranscription: {
+                    ...initialLiveTranscriptionState,
+                    isTranscribing: true,
+                    status: "transcribing",
+                },
+            },
+        });
+
+        store.dispatch(doStopLiveTranscription());
+
+        expect(mockSignalEmit).toHaveBeenCalledWith("stop_live_transcription");
+    });
+});

--- a/packages/media/src/utils/types.ts
+++ b/packages/media/src/utils/types.ts
@@ -59,6 +59,7 @@ export interface SignalClient {
     isVideoEnabled: boolean;
     role: ClientRole;
     startedCloudRecordingAt: string | null;
+    startedLiveTranscriptionAt: string | null;
     breakoutGroup: string | null;
     externalId: string | null;
     isDialIn: boolean;
@@ -354,8 +355,9 @@ export interface SpotlightRemovedEvent {
 }
 
 export interface LiveTranscriptionStartedEvent {
-    transcriptionId: string;
-    startedAt: string;
+    transcriptionId?: string;
+    error?: string;
+    startedAt?: string;
 }
 
 export interface LiveTranscriptionStoppedEvent {
@@ -454,6 +456,7 @@ export interface SignalRequests {
     enable_video: { enabled: boolean };
     handle_knock: { action: "accept" | "reject"; clientId: string; response: unknown };
     identify_device: IdentifyDeviceRequest;
+    join_breakout_group: { group: string };
     join_room: JoinRoomRequest;
     knock_room: KnockRoomRequest;
     leave_room: void;
@@ -462,7 +465,9 @@ export interface SignalRequests {
     request_video_enable: VideoEnableRequest;
     send_client_metadata: { type: string; payload: { displayName?: string; stickyReaction?: unknown } };
     set_lock: { locked: boolean };
+    start_live_transcription: void;
     start_recording: { recording: string };
+    stop_live_transcription: void;
     stop_recording: void;
 }
 


### PR DESCRIPTION
### Description

This PR adds support for live transcription start/stop handling in both the Core and Browser SDKs.

**Summary:**

Core SDK usage:

```JavaScript
import { WherebyClient } from "@whereby.com/core";

const client = new WherebyClient();
const roomConnection = client.getRoomConnection();

// start live transcriptions with...
roomConnection.startLiveTranscription();
// later, stop live transcriptions with...
roomConnection.stopLiveTranscription();
// check the state of live transcriptions at any time...
roomConnection.subscribeToLiveTranscription(({ status }) => {
    console.log(status); // one of undefined (not started), "requesting", "transcribing", "error",
});
```

Browser SDK usage:

```JavaScript
...
const { actions, state } = useRoomConnection("whereby_room_url");
// start live transcriptions with...
actions.startLiveTranscription();
// later, stop live transcriptions with...
actions.stopLiveTranscription();
// check the state of live transcriptions at any time...
console.log(state.liveTranscription?.status) // one of undefined (not started), "requesting", "transcribing", "error",
```

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
