### PR TITLE
core: clarify stream unaccept in SFU breakout groups

### DIFF
--- a/.changeset/brave-tips-hang.md
+++ b/.changeset/brave-tips-hang.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": patch
+---
+
+Clarify stream unaccept in SFU breakout groups

--- a/packages/core/src/RoomParticipant.ts
+++ b/packages/core/src/RoomParticipant.ts
@@ -60,11 +60,9 @@ export interface RemoteParticipantData {
 export type StreamState =
     | "new_accept"
     | "to_accept"
-    | "old_accept"
     | "done_accept"
     | "to_unaccept"
     | "done_unaccept"
-    | "auto";
 
 interface Stream {
     id: string;

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -262,8 +262,11 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
         } else if (state === "new_accept" || state === "old_accept") {
             // do nothing - let this be marked as done_accept as the rtcManager
             // will trigger accept from other end
+        } else if (state === "to_unaccept" && streamId === CAMERA_STREAM_ID) {
+            // This is only used in SFU breakout groups.
+            rtcManager?.disconnect(streamId);
         } else if (state === "to_unaccept") {
-            rtcManager?.disconnect(streamId === CAMERA_STREAM_ID ? clientId : streamId);
+            // noop but needed to mark screenshare streams as done_unaccept when moving between SFU breakout groups.
         } else if (state !== "done_accept") {
             continue;
             // console.warn(`Stream state not handled: ${state} for ${clientId}-${streamId}`);

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -265,7 +265,7 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
         } else if (state === "to_unaccept") {
             if (streamId === CAMERA_STREAM_ID) {
                 // This is only used in SFU breakout groups.
-                rtcManager?.disconnect(streamId);
+                rtcManager?.disconnect(clientId);
             }
             // noop but needed to mark screenshare streams as done_unaccept when moving between SFU breakout groups.
         } else if (state !== "done_accept") {

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -252,14 +252,13 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
         if (!participant) continue;
         if (
             state === "to_accept" ||
-            (state === "new_accept" && shouldAcceptNewClients) ||
-            (state === "old_accept" && !shouldAcceptNewClients) // these are done to enable broadcast in legacy/p2p
+            (state === "new_accept" && shouldAcceptNewClients)
         ) {
             rtcManager.acceptNewStream({
                 streamId: streamId === CAMERA_STREAM_ID ? clientId : streamId,
                 clientId,
             });
-        } else if (state === "new_accept" || state === "old_accept") {
+        } else if (state === "new_accept") {
             // do nothing - let this be marked as done_accept as the rtcManager
             // will trigger accept from other end
         } else if (state === "to_unaccept") {
@@ -274,7 +273,7 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
         } else {
             // done_accept
         }
-        updates.push({ clientId, streamId, state: state.replace(/to_|new_|old_/, "done_") as StreamState });
+        updates.push({ clientId, streamId, state: state.replace(/to_|new_/, "done_") as StreamState });
     }
 
     dispatch(streamStatusUpdated(updates));

--- a/packages/core/src/redux/slices/rtcConnection/index.ts
+++ b/packages/core/src/redux/slices/rtcConnection/index.ts
@@ -262,10 +262,11 @@ export const doHandleAcceptStreams = createAppThunk((payload: StreamStatusUpdate
         } else if (state === "new_accept" || state === "old_accept") {
             // do nothing - let this be marked as done_accept as the rtcManager
             // will trigger accept from other end
-        } else if (state === "to_unaccept" && streamId === CAMERA_STREAM_ID) {
-            // This is only used in SFU breakout groups.
-            rtcManager?.disconnect(streamId);
         } else if (state === "to_unaccept") {
+            if (streamId === CAMERA_STREAM_ID) {
+                // This is only used in SFU breakout groups.
+                rtcManager?.disconnect(streamId);
+            }
             // noop but needed to mark screenshare streams as done_unaccept when moving between SFU breakout groups.
         } else if (state !== "done_accept") {
             continue;

--- a/packages/core/src/redux/tests/store/rtcConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/rtcConnection.spec.ts
@@ -9,7 +9,7 @@ import {
 } from "../../slices/rtcConnection";
 import { randomRemoteParticipant, randomString } from "../../../__mocks__/appMocks";
 import MockMediaStream from "../../../__mocks__/MediaStream";
-import { RtcManagerDispatcher } from "@whereby.com/media";
+import { CAMERA_STREAM_ID, RtcManagerDispatcher } from "@whereby.com/media";
 import { initialLocalMediaState } from "../../slices/localMedia";
 import { diff } from "deep-object-diff";
 import { coreVersion } from "../../../version";
@@ -167,6 +167,99 @@ describe("actions", () => {
         expect(mockRtcManager.addCameraStream).toHaveBeenCalledWith(store.getState().localMedia.stream, { audioPaused:true, videoPaused: true});
         expect(store.getState().rtcConnection.rtcManagerInitialized).toBe(true);
     });
+
+    describe("doAcceptStreams", () => {
+        it("should unaccept camera stream in SFU breakout groups", () => {
+            const remoteClientId = randomString()
+            const store = createStore({ withRtcManager: true, initialState: {
+            remoteParticipants: {
+                remoteParticipants: [{
+                    id: remoteClientId,
+                    streams: [{ id: CAMERA_STREAM_ID, state: "done_accept" }],
+                    breakoutGroup: "a",
+                    deviceId: "",
+                    displayName: "",
+                    externalId: null,
+                    isAudioEnabled: false,
+                    isAudioRecorder: false,
+                    isDialIn: false,
+                    isLocalParticipant: false,
+                    isVideoEnabled: false,
+                    newJoiner: false,
+                    presentationStream: null,
+                    roleName: "none",
+                    stream: null
+                }]
+            }
+        } });
+        const before = store.getState().remoteParticipants;
+
+        store.dispatch(doHandleAcceptStreams([{ clientId: remoteClientId, streamId: CAMERA_STREAM_ID, state: "to_unaccept" }]));
+
+        const after = store.getState().remoteParticipants;
+
+        expect(mockRtcManager.disconnect).toHaveBeenCalledTimes(1);
+        expect(mockRtcManager.disconnect).toHaveBeenCalledWith(remoteClientId);
+        expect(diff(before, after)).toEqual({
+            remoteParticipants: {
+                "0": {
+                    streams: {
+                        "0": {
+                            state: "done_unaccept"
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+        it("should unaccept screenshare stream in SFU breakout groups", () => {
+            const remoteClientId = randomString();  
+            const screenshareStreamId = randomString();
+            const store = createStore({
+                withRtcManager: true,
+                initialState: {
+                    remoteParticipants: {
+                        remoteParticipants: [{
+                            id: remoteClientId,
+                            streams: [{ id: screenshareStreamId, state: "done_accept" }],
+                            breakoutGroup: "a",
+                            deviceId: "",
+                            displayName: "",
+                            externalId: null,
+                            isAudioEnabled: false,
+                            isAudioRecorder: false,
+                            isDialIn: false,
+                            isLocalParticipant: false,
+                            isVideoEnabled: false,
+                            newJoiner: false,
+                            presentationStream: null,
+                            roleName: "none",
+                            stream: null
+                        }]
+                    }
+                }
+            });
+        const before = store.getState().remoteParticipants;
+
+        store.dispatch(doHandleAcceptStreams([{ clientId: remoteClientId, streamId: screenshareStreamId, state: "to_unaccept" }]));
+
+        const after = store.getState().remoteParticipants;
+
+        expect(mockRtcManager.disconnect).not.toHaveBeenCalled();
+        expect(diff(before, after)).toEqual({
+            remoteParticipants: {
+                "0": {
+                    streams: {
+                        "0": {
+                            state: "done_unaccept"
+                            }
+                        }
+                    }
+                }
+            });
+        });
+    })
 });
 
 describe("middleware", () => {


### PR DESCRIPTION
### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->
* make it more clear what is actually happening when unaccepting streams.
* remove deprecated `old_accept` etc. it's no longer used
* add tests that catches a regression that was initially introduced in this PR

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
