### PR TITLE
core: Stop camera effect stream on room leave

### DIFF
--- a/.changeset/clear-swans-change.md
+++ b/.changeset/clear-swans-change.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": patch
+---
+
+Stop camera effect stream on leave room

--- a/packages/browser-sdk/src/stories/custom-ui.stories.tsx
+++ b/packages/browser-sdk/src/stories/custom-ui.stories.tsx
@@ -36,6 +36,68 @@ export const StartStop = () => {
     return <div>Go to this story to eg verify all resources (camera, microphone, connections) are released.</div>;
 };
 
+function RoomConnectionWithLocalMediaInner({
+    roomUrl,
+    displayName,
+    externalId,
+}: {
+    roomUrl: string;
+    displayName?: string;
+    externalId?: string;
+}) {
+    const localMedia = useLocalMedia({ audio: true, video: true });
+    const [shouldJoin, setShouldJoin] = useState(false);
+    const {
+        actions: { switchCameraEffect, clearCameraEffect, joinRoom, leaveRoom },
+    } = useRoomConnection(roomUrl, { localMedia, displayName, externalId });
+    const [effectPresets, setEffectPresets] = useState<Array<string>>([]);
+
+    useEffect(() => {
+        (async () => {
+            const { getUsablePresets } = await import("@whereby.com/camera-effects");
+            setEffectPresets(getUsablePresets());
+        })();
+    }, []);
+
+    const handleToggleJoin = () => {
+        if (shouldJoin) {
+            leaveRoom();
+        } else {
+            joinRoom();
+        }
+        setShouldJoin(!shouldJoin);
+    };
+
+    return (
+        <div>
+            <PrecallExperience {...localMedia} hideVideoPreview={shouldJoin} />
+            <div className="controls">
+                <button onClick={() => clearCameraEffect()}>Remove background effect</button>
+                <select value="" onChange={(e) => switchCameraEffect(e.target.value)}>
+                    <option value="" disabled>
+                        Select background effect
+                    </option>
+                    {effectPresets.map((preset) => (
+                        <option key={preset} value={preset}>
+                            {preset}
+                        </option>
+                    ))}
+                </select>
+            </div>
+            <button onClick={handleToggleJoin}>{shouldJoin ? "Leave room" : "Join room"}</button>
+
+            {shouldJoin && (
+                <VideoExperience
+                    displayName={displayName}
+                    roomName={roomUrl}
+                    localMedia={localMedia}
+                    externalId={externalId}
+                />
+            )}
+        </div>
+    );
+}
+
 export const RoomConnectionWithLocalMedia = ({
     roomUrl,
     displayName,
@@ -45,29 +107,11 @@ export const RoomConnectionWithLocalMedia = ({
     displayName?: string;
     externalId?: string;
 }) => {
-    const localMedia = useLocalMedia({ audio: true, video: true });
-    const [shouldJoin, setShouldJoin] = useState(false);
-
     if (!roomUrl || !roomUrl.match(roomRegEx)) {
         return <p>Set room url on the Controls panel</p>;
     }
 
-    return (
-        <div>
-            <PrecallExperience {...localMedia} hideVideoPreview={shouldJoin} />
-            <button onClick={() => setShouldJoin(!shouldJoin)}>{shouldJoin ? "Leave room" : "Join room"}</button>
-
-            {shouldJoin && (
-                <VideoExperience
-                    displayName={displayName}
-                    roomName={roomUrl}
-                    localMedia={localMedia}
-                    externalId={externalId}
-                    joinRoomOnLoad
-                />
-            )}
-        </div>
-    );
+    return <RoomConnectionWithLocalMediaInner roomUrl={roomUrl} displayName={displayName} externalId={externalId} />;
 };
 
 export const LocalMediaOnly = () => {

--- a/packages/core/src/redux/slices/cameraEffects.ts
+++ b/packages/core/src/redux/slices/cameraEffects.ts
@@ -1,8 +1,8 @@
-import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { createAppAsyncThunk } from "../thunk";
 import { RootState } from "../store";
-import { createReactor } from "../listenerMiddleware";
-import { selectAppIsActive } from "./app";
+import { startAppListening } from "../listenerMiddleware";
+import { doAppStop } from "./app";
 import { doLocalStreamEffect, selectLocalMediaIsSwitchingStream, selectLocalMediaStream } from "./localMedia";
 import { Setup, Params } from "@whereby.com/camera-effects";
 
@@ -164,12 +164,11 @@ export const doCameraEffectsClear = createAppAsyncThunk("cameraEffects/clear", a
     await dispatch(doCameraEffectsSwitchPreset({ effectId: null }));
 });
 
-const selectCameraEffectsShouldStop = createSelector(selectAppIsActive, selectCameraEffectsRaw, (appIsActive, raw) => {
-    return !appIsActive && !!raw.stop;
-});
-
-createReactor([selectCameraEffectsShouldStop], ({ dispatch }, shouldStop) => {
-    if (shouldStop) {
-        dispatch(doCameraEffectsClear());
-    }
+startAppListening({
+    actionCreator: doAppStop,
+    effect: (_, { dispatch, getState }) => {
+        if (selectCameraEffectsRaw(getState()).stop) {
+            dispatch(doCameraEffectsClear());
+        }
+    },
 });

--- a/packages/core/src/redux/store.ts
+++ b/packages/core/src/redux/store.ts
@@ -66,6 +66,10 @@ export const rootReducer: AppReducer = (state, action) => {
                 ...localMediaSlice.getInitialState(),
                 ...state?.localMedia,
             },
+            cameraEffects: {
+                ...cameraEffectsSlice.getInitialState(),
+                ...state?.cameraEffects,
+            },
         };
 
         return appReducer(resetState, action);

--- a/packages/core/src/redux/tests/store/cameraEffects.spec.ts
+++ b/packages/core/src/redux/tests/store/cameraEffects.spec.ts
@@ -1,0 +1,58 @@
+import * as cameraEffectsSlice from "../../slices/cameraEffects";
+import { doAppStart, doAppStop } from "../../slices/app";
+import { createStore } from "../store.setup";
+
+jest.mock("@whereby.com/media", () => ({
+    __esModule: true,
+    getStream: jest.fn(() => Promise.resolve()),
+    getUpdatedDevices: jest.fn(() => Promise.resolve({ addedDevices: {}, changedDevices: {} })),
+}));
+
+describe("cameraEffectsSlice", () => {
+    describe("reactors", () => {
+        it("does not clear the effect when it is applied before the app becomes active (pre-call)", () => {
+            const store = createStore();
+            const stop = jest.fn();
+
+            store.dispatch(
+                cameraEffectsSlice.cameraEffectsUpdated({
+                    effectId: "image-blur",
+                    raw: { stop },
+                }),
+            );
+
+            const state = store.getState().cameraEffects;
+            expect(state.currentEffectId).toBe("image-blur");
+            expect(state.raw.stop).toBe(stop);
+            expect(stop).not.toHaveBeenCalled();
+        });
+
+        it("clears the effect when the app stops", () => {
+            const store = createStore();
+            const stop = jest.fn();
+
+            store.dispatch(
+                doAppStart({
+                    displayName: "Test",
+                    externalId: null,
+                    roomKey: null,
+                    roomUrl: "https://example.whereby.com/test",
+                }),
+            );
+            store.dispatch(
+                cameraEffectsSlice.cameraEffectsUpdated({
+                    effectId: "image-blur",
+                    raw: { stop },
+                }),
+            );
+
+            expect(store.getState().cameraEffects.currentEffectId).toBe("image-blur");
+
+            store.dispatch(doAppStop());
+
+            const state = store.getState().cameraEffects;
+            expect(state.currentEffectId).toBeNull();
+            expect(state.raw).toEqual({});
+        });
+    });
+});


### PR DESCRIPTION
### Description

Fixes a bug where the camera effect stream stops automatically when not connected to a room (in pre-call f.ex). This was due to us using the isAppActive selector to decide when to stop the camera effect stream (to fix an issue where the effect stream wasn't stopped after leaving room). That was the wrong fix. This changes it to instead stop the effect stream when the leave room action is triggered.

I've added camera effects to the `Room connection with Local media` story, so we can test this.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
There's two scenarios that should be tested:
1. Test the `Room connection with Local media` story, verify that setting a camera effect in the pre-call works and it keeps the effect when joining the room
2. Test the `Room connection with Camera effects` story, verify that when setting a camera effect in the room and then clicking the leave room button, the camera light is turned off on your device. 

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
