### PR TITLE
media: Replace rtcstats with published version

### DIFF
--- a/.changeset/clean-dolls-attend.md
+++ b/.changeset/clean-dolls-attend.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Replace rtcstats with published version

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -54,7 +54,7 @@
         "events": "^3.3.0",
         "ip-address": "^9.0.5",
         "mediasoup-client": "3.19.0",
-        "rtcstats": "github:whereby/rtcstats#5.4.1",
+        "@whereby.com/rtcstats": "5.4.2",
         "sdp": "^3.2.0",
         "sdp-transform": "^2.14.2",
         "socket.io-client": "4.7.2",

--- a/packages/media/src/webrtc/rtcStatsService.ts
+++ b/packages/media/src/webrtc/rtcStatsService.ts
@@ -1,6 +1,6 @@
 // ensure adapter is loaded first.
 import adapterRaw from "webrtc-adapter";
-import rtcstats from "rtcstats";
+import rtcstats from "@whereby.com/rtcstats";
 import { v4 as uuidv4 } from "uuid";
 
 // @ts-ignore

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -705,6 +705,9 @@ importers:
 
   packages/media:
     dependencies:
+      '@whereby.com/rtcstats':
+        specifier: 5.4.2
+        version: 5.4.2
       check-ip:
         specifier: ^1.1.1
         version: 1.1.1
@@ -717,9 +720,6 @@ importers:
       mediasoup-client:
         specifier: 3.19.0
         version: 3.19.0
-      rtcstats:
-        specifier: github:whereby/rtcstats#5.4.1
-        version: https://codeload.github.com/whereby/rtcstats/tar.gz/63bcb6420d76d34161b39e494524ae73aa6dd70d
       sdp:
         specifier: ^3.2.0
         version: 3.2.1
@@ -4200,6 +4200,9 @@ packages:
 
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
+  '@whereby.com/rtcstats@5.4.2':
+    resolution: {integrity: sha512-NEhoaeNPtq0cSD/di7gh5w7mQXse20LYg2mhFFsb2b4obp+H7tJD6M/NsoejHGo71Vuzm03nIMW6hSW8v3fEpQ==}
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -8331,10 +8334,6 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
-
-  rtcstats@https://codeload.github.com/whereby/rtcstats/tar.gz/63bcb6420d76d34161b39e494524ae73aa6dd70d:
-    resolution: {tarball: https://codeload.github.com/whereby/rtcstats/tar.gz/63bcb6420d76d34161b39e494524ae73aa6dd70d}
-    version: 5.4.1
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -13515,6 +13514,8 @@ snapshots:
     dependencies:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
+
+  '@whereby.com/rtcstats@5.4.2': {}
 
   '@xmldom/xmldom@0.8.10': {}
 
@@ -18860,8 +18861,6 @@ snapshots:
       path-to-regexp: 8.2.0
     transitivePeerDependencies:
       - supports-color
-
-  rtcstats@https://codeload.github.com/whereby/rtcstats/tar.gz/63bcb6420d76d34161b39e494524ae73aa6dd70d: {}
 
   run-parallel@1.2.0:
     dependencies:


### PR DESCRIPTION
### Description

Fixes #952 

Replacing `rtcstats` with the now published version: https://www.npmjs.com/package/@whereby.com/rtcstats

No functional changes.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

Regression testing
<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
