### PR TITLE
media: Fixes stats collection on firefox

### DIFF
--- a/.changeset/stale-onions-hide.md
+++ b/.changeset/stale-onions-hide.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": minor
+---
+
+media: Fixes stats collection issues on firefox

--- a/packages/media/src/webrtc/stats/StatsMonitor/peerConnection.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/peerConnection.ts
@@ -8,7 +8,7 @@ export let numFailedTrackSsrcLookups = 0;
 
 export const getPeerConnectionsWithStatsReports = (pcDataByPc = PC_DATA_BY_PC) =>
     Promise.all(
-        getCurrentPeerConnections().map(async (pc: any) => {
+        getCurrentPeerConnections().map(async (pc: RTCPeerConnection) => {
             let pcData = pcDataByPc.get(pc);
             if (!pcData) {
                 pcData = { ssrcToTrackId: {} };
@@ -62,7 +62,7 @@ export const getPeerConnectionsWithStatsReports = (pcDataByPc = PC_DATA_BY_PC) =
                     reports.forEach((tReport, index) => {
                         tReport.forEach((stats: any) => {
                             if (stats.type === "inbound-rtp" || stats.type === "outbound-rtp") {
-                                pcData.ssrcToTrackId[stats.ssrc] = sendersAndReceivers[index].track.id;
+                                pcData.ssrcToTrackId[stats.ssrc] = sendersAndReceivers[index].track!.id;
                             }
                         });
                     });

--- a/packages/media/src/webrtc/stats/StatsMonitor/peerConnection.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/peerConnection.ts
@@ -69,8 +69,8 @@ export const getPeerConnectionsWithStatsReports = (pcDataByPc = PC_DATA_BY_PC) =
 
                     // create fake track ids for anything not found
                     missingSsrcs.forEach((ssrc: any) => {
-                        numMissingTrackSsrcLookups++;
                         if (!pcData.ssrcToTrackId[ssrc]) {
+                            numMissingTrackSsrcLookups++;
                             pcData.ssrcToTrackId[ssrc] = "?" + ssrc;
                         }
                     });

--- a/packages/media/src/webrtc/stats/StatsMonitor/peerConnection.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/peerConnection.ts
@@ -53,7 +53,11 @@ export const getPeerConnectionsWithStatsReports = (pcDataByPc = PC_DATA_BY_PC) =
 
                 if (missingSsrcs) {
                     // call getStats() on all senders and receivers to map missing ssrcs
-                    const sendersAndReceivers = [...pc.getSenders(), ...pc.getReceivers()];
+
+                    // on firefox there might be senders/receivers returned without a track.
+                    // doesn't seem to be cleaned up like with other browsers. we ignore these.
+                    const sendersAndReceivers = [...pc.getSenders(), ...pc.getReceivers()].filter((o) => o.track);
+
                     const reports = await Promise.all(sendersAndReceivers.map((o) => o.getStats()));
                     reports.forEach((tReport, index) => {
                         tReport.forEach((stats: any) => {

--- a/packages/media/src/webrtc/stats/StatsMonitor/peerConnectionTracker.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/peerConnectionTracker.ts
@@ -25,7 +25,7 @@ if (window.RTCPeerConnection) {
     (window.RTCPeerConnection as any) = PatchedRTCPeerConnection;
 }
 
-export const getCurrentPeerConnections = () => peerConnections;
+export const getCurrentPeerConnections = () => peerConnections.filter((p) => p.connectionState !== "closed");
 
 export const getPeerConnectionIndex = (pc: RTCPeerConnection) => peerConnectionData.get(pc)?.index;
 


### PR DESCRIPTION
### Description

Firefox seems to be returning senders and receivers without tracks, probably for unidirection media sections, and inactive sections. This made parts of the stats collection (issues/posthog/insights but not rest of rtcstats) stop because of exception accessing track property, and wasting cycles trying again and again. Easily reproducible by starting/stopping a screenshare.

So now we just ignore senders/receivers without a track.
