### PR TITLE
media: fix wrong type of old stats report

### DIFF
--- a/.changeset/odd-actors-build.md
+++ b/.changeset/odd-actors-build.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Return map-like object when getStats fails during stats collection

--- a/packages/media/src/webrtc/stats/StatsMonitor/__tests__/peerConnection.spec.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/__tests__/peerConnection.spec.ts
@@ -3,6 +3,7 @@ import {
     createRTCPeerConnectionStub,
     createRTCTrancieverStub,
 } from "../../../../../tests/webrtc/webRtcHelpers";
+import { PCData } from "../../types";
 import { getPeerConnectionsWithStatsReports } from "../peerConnection";
 import { setPeerConnectionsForTests } from "../peerConnectionTracker";
 
@@ -19,7 +20,7 @@ describe("peerConnection", () => {
 
             const result = await getPeerConnectionsWithStatsReports();
 
-            result.forEach(([pc, report], index) => {
+            result.forEach(({ pc, report }, index) => {
                 expect(pc).toEqual(existingPeerConnections[index]);
                 expect(report).toEqual(pcStats[index]);
             });
@@ -34,7 +35,7 @@ describe("peerConnection", () => {
             const result = await getPeerConnectionsWithStatsReports();
 
             existingPeerConnections.forEach((_, index) => {
-                expect(result[index][1]).toEqual([]);
+                expect(result[index].report).toEqual(new Map());
             });
         });
         describe("ssrc to track mapping", () => {
@@ -43,13 +44,13 @@ describe("peerConnection", () => {
                     _scenario: "Creates empty mapping if stats are missing",
                     pcStats: [],
                     pcData: undefined,
-                    expectedPcData: { ssrcToTrackId: {} },
+                    expectedPcData: { ssrcToTrackId: {}, currentSSRCs: {} },
                 },
                 {
                     _scenario: "Creates fake track id if no track can be found",
                     pcStats: [{ id: "inbound", type: "inbound-rtp", ssrc: 12 }],
                     pcData: undefined,
-                    expectedPcData: { ssrcToTrackId: { "12": "?12" } },
+                    expectedPcData: { ssrcToTrackId: { "12": "?12" }, currentSSRCs: {} },
                 },
                 {
                     _scenario: "Uses media source track identifier for outbound stats",
@@ -58,7 +59,7 @@ describe("peerConnection", () => {
                         { id: "mediaSource", type: "media-source", trackIdentifier: "track" },
                     ],
                     pcData: undefined,
-                    expectedPcData: { ssrcToTrackId: { "12": "track" } },
+                    expectedPcData: { ssrcToTrackId: { "12": "track" }, currentSSRCs: {} },
                 },
                 {
                     _scenario: "Uses existing mapping",
@@ -66,8 +67,8 @@ describe("peerConnection", () => {
                         { id: "outbound", type: "outbound-rtp", ssrc: 12, mediaSourceId: "mediaSource" },
                         { id: "mediaSource", type: "media-source", trackIdentifier: "track" },
                     ],
-                    pcData: { ssrcToTrackId: { 12: "existingTrack" } },
-                    expectedPcData: { ssrcToTrackId: { "12": "existingTrack" } },
+                    pcData: { ssrcToTrackId: { "12": "existingTrack" }, currentSSRCs: {} } as PCData,
+                    expectedPcData: { ssrcToTrackId: { "12": "existingTrack" }, currentSSRCs: {} },
                 },
                 {
                     _scenario: "Uses deprecated trackId as fallback",
@@ -80,7 +81,7 @@ describe("peerConnection", () => {
                         },
                     ],
                     pcData: undefined,
-                    expectedPcData: { ssrcToTrackId: { "12": "trackIdentifier" } },
+                    expectedPcData: { ssrcToTrackId: { "12": "trackIdentifier" }, currentSSRCs: {} },
                 },
                 {
                     _scenario: "Uses tranceivers as fallback",
@@ -98,7 +99,7 @@ describe("peerConnection", () => {
                             stats: [{ id: "outbound", type: "outbound-rtp", ssrc: 13 }],
                         },
                     ],
-                    expectedPcData: { ssrcToTrackId: { "12": "receiverTrack", 13: "senderTrack" } },
+                    expectedPcData: { ssrcToTrackId: { "12": "receiverTrack", 13: "senderTrack" }, currentSSRCs: {} },
                 },
                 {
                     _scenario: "Dont map when trackIdentifier is present on inbound",
@@ -116,7 +117,7 @@ describe("peerConnection", () => {
                             stats: [{ id: "outbound", type: "outbound-rtp", ssrc: 13 }],
                         },
                     ],
-                    expectedPcData: { ssrcToTrackId: {} },
+                    expectedPcData: { ssrcToTrackId: {}, currentSSRCs: {} },
                 },
             ])("$_scenario", async ({ pcStats, pcData, senders = [], receivers = [], expectedPcData }) => {
                 const pc = createRTCPeerConnectionStub({
@@ -138,7 +139,8 @@ describe("peerConnection", () => {
                 const pcDataByPc = new Map([[pc, pcData]]);
                 setPeerConnectionsForTests([pc]);
 
-                const [[_resultPc, _resultReport, resultPcData]] = await getPeerConnectionsWithStatsReports(pcDataByPc);
+                const [{ pc: _resultPc, report: _resultReport, pcData: resultPcData }] =
+                    await getPeerConnectionsWithStatsReports(pcDataByPc);
 
                 expect(resultPcData).toEqual(expectedPcData);
             });

--- a/packages/media/src/webrtc/stats/StatsMonitor/__tests__/peerConnection.spec.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/__tests__/peerConnection.spec.ts
@@ -141,8 +141,6 @@ describe("peerConnection", () => {
 
                 const [
                     {
-                        pc: _resultPc,
-                        report: _resultReport,
                         pcData: { ssrcToTrackId },
                     },
                 ] = await getPeerConnectionsWithStatsReports(pcDataByPc);

--- a/packages/media/src/webrtc/stats/StatsMonitor/__tests__/peerConnection.spec.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/__tests__/peerConnection.spec.ts
@@ -44,13 +44,13 @@ describe("peerConnection", () => {
                     _scenario: "Creates empty mapping if stats are missing",
                     pcStats: [],
                     pcData: undefined,
-                    expectedPcData: { ssrcToTrackId: {}, currentSSRCs: {} },
+                    expectedSsrcTrackMappings: {},
                 },
                 {
                     _scenario: "Creates fake track id if no track can be found",
                     pcStats: [{ id: "inbound", type: "inbound-rtp", ssrc: 12 }],
                     pcData: undefined,
-                    expectedPcData: { ssrcToTrackId: { "12": "?12" }, currentSSRCs: {} },
+                    expectedSsrcTrackMappings: { "12": "?12" },
                 },
                 {
                     _scenario: "Uses media source track identifier for outbound stats",
@@ -59,7 +59,7 @@ describe("peerConnection", () => {
                         { id: "mediaSource", type: "media-source", trackIdentifier: "track" },
                     ],
                     pcData: undefined,
-                    expectedPcData: { ssrcToTrackId: { "12": "track" }, currentSSRCs: {} },
+                    expectedSsrcTrackMappings: { "12": "track" },
                 },
                 {
                     _scenario: "Uses existing mapping",
@@ -68,7 +68,7 @@ describe("peerConnection", () => {
                         { id: "mediaSource", type: "media-source", trackIdentifier: "track" },
                     ],
                     pcData: { ssrcToTrackId: { "12": "existingTrack" }, currentSSRCs: {} } as PCData,
-                    expectedPcData: { ssrcToTrackId: { "12": "existingTrack" }, currentSSRCs: {} },
+                    expectedSsrcTrackMappings: { "12": "existingTrack" },
                 },
                 {
                     _scenario: "Uses deprecated trackId as fallback",
@@ -81,7 +81,7 @@ describe("peerConnection", () => {
                         },
                     ],
                     pcData: undefined,
-                    expectedPcData: { ssrcToTrackId: { "12": "trackIdentifier" }, currentSSRCs: {} },
+                    expectedSsrcTrackMappings: { "12": "trackIdentifier" },
                 },
                 {
                     _scenario: "Uses tranceivers as fallback",
@@ -99,7 +99,7 @@ describe("peerConnection", () => {
                             stats: [{ id: "outbound", type: "outbound-rtp", ssrc: 13 }],
                         },
                     ],
-                    expectedPcData: { ssrcToTrackId: { "12": "receiverTrack", 13: "senderTrack" }, currentSSRCs: {} },
+                    expectedSsrcTrackMappings: { "12": "receiverTrack", 13: "senderTrack" },
                 },
                 {
                     _scenario: "Dont map when trackIdentifier is present on inbound",
@@ -117,9 +117,9 @@ describe("peerConnection", () => {
                             stats: [{ id: "outbound", type: "outbound-rtp", ssrc: 13 }],
                         },
                     ],
-                    expectedPcData: { ssrcToTrackId: {}, currentSSRCs: {} },
+                    expectedSsrcTrackMappings: {},
                 },
-            ])("$_scenario", async ({ pcStats, pcData, senders = [], receivers = [], expectedPcData }) => {
+            ])("$_scenario", async ({ pcStats, pcData, senders = [], receivers = [], expectedSsrcTrackMappings }) => {
                 const pc = createRTCPeerConnectionStub({
                     stats: new Map(pcStats.map((s) => [s.id, s])),
                     senders: senders.map(({ stats, track }) => {
@@ -139,10 +139,15 @@ describe("peerConnection", () => {
                 const pcDataByPc = new Map([[pc, pcData]]);
                 setPeerConnectionsForTests([pc]);
 
-                const [{ pc: _resultPc, report: _resultReport, pcData: resultPcData }] =
-                    await getPeerConnectionsWithStatsReports(pcDataByPc);
+                const [
+                    {
+                        pc: _resultPc,
+                        report: _resultReport,
+                        pcData: { ssrcToTrackId },
+                    },
+                ] = await getPeerConnectionsWithStatsReports(pcDataByPc);
 
-                expect(resultPcData).toEqual(expectedPcData);
+                expect(ssrcToTrackId).toEqual(expectedSsrcTrackMappings);
             });
         });
     });

--- a/packages/media/src/webrtc/stats/StatsMonitor/collectStats.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/collectStats.ts
@@ -110,7 +110,7 @@ export async function collectStats(
         state.lastUpdateTime = Date.now();
 
         // loop through current peer connections
-        (await getPeerConnectionsWithStatsReports()).forEach(([pc, report, pcData]) => {
+        (await getPeerConnectionsWithStatsReports()).forEach(({ pc, report, pcData }) => {
             // each new peer connection will get +1, to be able to see/count/correlate data
             const pcIndex = getPeerConnectionIndex(pc);
 
@@ -125,11 +125,11 @@ export async function collectStats(
             }
 
             // keep track of visited ssrcs for cleanup later
-            pcData.previousSSRCs = pcData.currentSSRCs || {};
+            pcData.previousSSRCs = pcData.currentSSRCs;
             pcData.currentSSRCs = {};
 
             // loop though each stats dictionary in report
-            report.forEach((currentRtcStats: any) => {
+            report.forEach((currentRtcStats) => {
                 if (currentRtcStats.type === "candidate-pair" && /inprogress|succeeded/.test(currentRtcStats.state)) {
                     const prevRtcStats = pcData._oldReport?.get(currentRtcStats.id);
                     const timeDiff = prevRtcStats ? currentRtcStats.timestamp - prevRtcStats.timestamp : interval;
@@ -180,7 +180,7 @@ export async function collectStats(
                     pcData.currentSSRCs[ssrc] = client.id;
                     // we need to stats reset when selected candidate pair changes
                     // todo: metrics should += diff, not use count directly
-                    if (prevRtcStats) {
+                    if (prevRtcStats && pcData._oldReport) {
                         const newTransport = report.get(currentRtcStats.transportId);
                         const oldTransport = pcData._oldReport.get(prevRtcStats.transportId);
                         if (
@@ -226,14 +226,14 @@ export async function collectStats(
             Object.keys(pcData.previousSSRCs)
                 .filter((ssrc) => !pcData.currentSSRCs[ssrc])
                 .forEach((ssrc) => {
-                    const clientId = pcData.previousSSRCs[ssrc];
+                    const clientId = pcData.previousSSRCs![ssrc];
                     if (clientId) {
                         // remove
                         const clientView = state.statsByView[clientId];
                         if (clientView) {
                             Object.values(clientView.tracks).forEach((trackStats) => {
-                                if (trackStats.ssrcs[ssrc as unknown as number]) {
-                                    delete trackStats.ssrcs[ssrc as unknown as number];
+                                if (trackStats.ssrcs[ssrc]) {
+                                    delete trackStats.ssrcs[ssrc];
                                 }
                             });
                         }

--- a/packages/media/src/webrtc/stats/StatsMonitor/peerConnection.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/peerConnection.ts
@@ -1,8 +1,9 @@
 import rtcStats from "../../rtcStatsService";
+import { PCData } from "../types";
 import { getCurrentPeerConnections } from "./peerConnectionTracker";
 
 // peer connection related data
-const PC_DATA_BY_PC = new WeakMap<RTCPeerConnection, any>();
+const PC_DATA_BY_PC = new WeakMap<RTCPeerConnection, PCData>();
 export let numMissingTrackSsrcLookups = 0;
 export let numFailedTrackSsrcLookups = 0;
 
@@ -11,7 +12,7 @@ export const getPeerConnectionsWithStatsReports = (pcDataByPc = PC_DATA_BY_PC) =
         getCurrentPeerConnections().map(async (pc: RTCPeerConnection) => {
             let pcData = pcDataByPc.get(pc);
             if (!pcData) {
-                pcData = { ssrcToTrackId: {} };
+                pcData = { ssrcToTrackId: {}, currentSSRCs: {} };
                 pcDataByPc.set(pc, pcData);
             }
 
@@ -20,7 +21,7 @@ export const getPeerConnectionsWithStatsReports = (pcDataByPc = PC_DATA_BY_PC) =
 
                 let missingSsrcs: any = null;
 
-                report.forEach((stats: any) => {
+                report.forEach((stats) => {
                     if (stats.type === "inbound-rtp" || stats.type === "outbound-rtp") {
                         if (!stats.trackIdentifier && !pcData.ssrcToTrackId[stats.ssrc]) {
                             // try to lookup by media-source
@@ -60,7 +61,7 @@ export const getPeerConnectionsWithStatsReports = (pcDataByPc = PC_DATA_BY_PC) =
 
                     const reports = await Promise.all(sendersAndReceivers.map((o) => o.getStats()));
                     reports.forEach((tReport, index) => {
-                        tReport.forEach((stats: any) => {
+                        tReport.forEach((stats) => {
                             if (stats.type === "inbound-rtp" || stats.type === "outbound-rtp") {
                                 pcData.ssrcToTrackId[stats.ssrc] = sendersAndReceivers[index].track!.id;
                             }
@@ -68,14 +69,14 @@ export const getPeerConnectionsWithStatsReports = (pcDataByPc = PC_DATA_BY_PC) =
                     });
 
                     // create fake track ids for anything not found
-                    missingSsrcs.forEach((ssrc: any) => {
+                    missingSsrcs.forEach((ssrc: number) => {
                         if (!pcData.ssrcToTrackId[ssrc]) {
                             numMissingTrackSsrcLookups++;
                             pcData.ssrcToTrackId[ssrc] = "?" + ssrc;
                         }
                     });
                 }
-                return [pc, report, pcData];
+                return { pc, report, pcData };
             } catch (e: any) {
                 rtcStats.sendEvent("trackSsrcLookupFailed", {
                     name: e?.name,
@@ -83,7 +84,7 @@ export const getPeerConnectionsWithStatsReports = (pcDataByPc = PC_DATA_BY_PC) =
                     message: e?.message,
                 });
                 numFailedTrackSsrcLookups++;
-                return [pc, [], pcData];
+                return { pc, report: new Map(), pcData };
             }
         }),
     );

--- a/packages/media/src/webrtc/stats/types.ts
+++ b/packages/media/src/webrtc/stats/types.ts
@@ -30,7 +30,7 @@ export type PressureRecord = {
 export interface TrackStats {
     startTime: number;
     updated: number;
-    ssrcs: Record<number, SsrcStats>;
+    ssrcs: Record<string, SsrcStats>;
 }
 
 export interface ViewStats {
@@ -97,3 +97,10 @@ export interface SsrcStats {
     sourceWidth?: number;
     sourceFps?: number;
 }
+
+export type PCData = {
+    ssrcToTrackId: Record<string, string>;
+    currentSSRCs: Record<string, string>;
+    previousSSRCs?: Record<string, string>;
+    _oldReport?: RTCStatsReport;
+};


### PR DESCRIPTION
### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->
* return `Map` instead of `Array` when `getStats` fails
* add typing
* return an object instead of array from `getPeerConnectionsWithStatsReports`

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
