### PR TITLE
media: catch errors for early ice candidates in P2P

### DIFF
--- a/.changeset/quiet-rivers-bloom.md
+++ b/.changeset/quiet-rivers-bloom.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Catch errors for early ice candidates in P2P

--- a/packages/media/src/webrtc/P2pRtcManager.ts
+++ b/packages/media/src/webrtc/P2pRtcManager.ts
@@ -85,6 +85,7 @@ type P2PAnalytics = {
     P2PRelayedIceCandidate: number;
     P2PSessionAddTrack: number;
     P2PAddTrackToPeerConnections: number;
+    P2PAddIceCandidateFailure: number;
 };
 
 type P2PAnalyticMetric = keyof P2PAnalytics;
@@ -199,6 +200,7 @@ export default class P2pRtcManager implements RtcManager {
             P2PRelayedIceCandidate: 0,
             P2PSessionAddTrack: 0,
             P2PAddTrackToPeerConnections: 0,
+            P2PAddIceCandidateFailure: 0,
         };
     }
 

--- a/packages/media/src/webrtc/Session.ts
+++ b/packages/media/src/webrtc/Session.ts
@@ -165,7 +165,7 @@ export default class Session {
         // wrapper around SRD which stores a promise
         this.srdComplete = this.pc.setRemoteDescription(desc);
         return this.srdComplete.then(() => {
-            this.earlyIceCandidates.forEach((candidate) => this.pc.addIceCandidate(candidate));
+            this.earlyIceCandidates.forEach((candidate) => this.addIceCandidate(candidate));
             this.earlyIceCandidates = [];
         });
     }
@@ -237,6 +237,14 @@ export default class Session {
             }
             this.pc.addIceCandidate(candidate).catch((e: any) => {
                 logger.warn("Failed to add ICE candidate ('%s'): %s", candidate ? candidate.candidate : null, e);
+                this._incrementAnalyticMetric("P2PAddIceCandidateFailure");
+                rtcStats.sendEvent("P2PAddIceCandidateFailure", {
+                    clientId: this.clientId,
+                    errorName: e?.name,
+                    errorMessage: e?.message,
+                    signalingState: this.pc.signalingState,
+                    iceConnectionState: this.pc.iceConnectionState,
+                });
             });
         });
     }


### PR DESCRIPTION
## Summary
- Route the early-candidate flush in `Session._setRemoteDescription` through `Session.addIceCandidate` so it shares the existing catch handler. The previous fire-and-forget calls surfaced `addIceCandidate` failures as unhandled promise rejections.
- Report `addIceCandidate` failures via new `P2PAddIceCandidateFailure` analytics counter and a matching rtcstats event (clientId, error name/message, signalingState, iceConnectionState).
