### PR TITLE
common: Add chat message reply flows and APIs

### DIFF
--- a/.changeset/happy-bushes-do.md
+++ b/.changeset/happy-bushes-do.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Add parentId to ChatMessage type definition

--- a/.changeset/tall-dodos-carry.md
+++ b/.changeset/tall-dodos-carry.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/browser-sdk": minor
+"@whereby.com/media": minor
+---
+
+Add replies capability when sending in-room chat messages

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -68,7 +68,10 @@ export function useRoomConnection(
         client.initialize(roomConfig);
         return client.joinRoom();
     }, [client]);
-    const sendChatMessage = React.useCallback((text: string) => client.sendChatMessage(text), [client]);
+    const sendChatMessage = React.useCallback(
+        (text: string, parentId?: string) => client.sendChatMessage(text, parentId),
+        [client],
+    );
     const removeChatMessage = React.useCallback(
         (id: string, sig?: string | null) => client.removeChatMessage(id, sig),
         [client],

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -30,7 +30,7 @@ export interface RoomConnectionActions {
     kickParticipant: (clientId: string) => void;
     endMeeting: (stayBehind?: boolean) => void;
     rejectWaitingParticipant: (participantId: string) => void;
-    sendChatMessage: (text: string) => void;
+    sendChatMessage: (text: string, parentId?: string) => void;
     removeChatMessage: (id: string, sig?: string | null) => void;
     setDisplayName: (displayName: string) => void;
     startCloudRecording: () => void;

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -37,6 +37,7 @@ export default function VideoExperience({
     showCameraEffects?: boolean;
 }) {
     const [chatMessage, setChatMessage] = useState("");
+    const [chatMessageParent, setChatMessageParent] = useState("");
     const [isLocalScreenshareActive, setIsLocalScreenshareActive] = useState(false);
     const [effectPresets, setEffectPresets] = useState<Array<string>>([]);
 
@@ -626,11 +627,24 @@ export default function VideoExperience({
                         <form
                             onSubmit={(e) => {
                                 e.preventDefault();
-                                sendChatMessage(chatMessage);
+                                sendChatMessage(chatMessage, chatMessageParent);
                                 setChatMessage("");
+                                setChatMessageParent("");
                             }}
                         >
                             <input type="text" value={chatMessage} onChange={(e) => setChatMessage(e.target.value)} />
+                            <select value={chatMessageParent} onChange={(e) => setChatMessageParent(e.target.value)}>
+                                <option key="chat-select-room" value="">
+                                    Send to room
+                                </option>
+                                {chatMessages.map((m) => {
+                                    return (
+                                        <option key={`chat-select-${m.id}`} value={m.id}>
+                                            Reply to: {m.text}
+                                        </option>
+                                    );
+                                })}
+                            </select>
                             <button type="submit">Send message</button>
                         </form>
                     </div>

--- a/packages/core/src/client/RoomConnection/index.ts
+++ b/packages/core/src/client/RoomConnection/index.ts
@@ -405,8 +405,8 @@ export class RoomConnectionClient extends BaseClient<RoomConnectionState, RoomCo
      * Send a chat message to the room.
      * @param text - The message text to send.
      */
-    public sendChatMessage(text: string) {
-        this.store.dispatch(doSendChatMessage({ text }));
+    public sendChatMessage(text: string, parentId?: string) {
+        this.store.dispatch(doSendChatMessage({ text, parentId }));
     }
 
     /**

--- a/packages/core/src/redux/slices/chat.ts
+++ b/packages/core/src/redux/slices/chat.ts
@@ -61,13 +61,14 @@ export const chatSlice = createSlice({
  * Action creators
  */
 export const doSendChatMessage = createRoomConnectedThunk(
-    (payload: { text: string; isBroadcast?: boolean }) => (_, getState) => {
+    (payload: { text: string; isBroadcast?: boolean; parentId?: string }) => (_, getState) => {
         const state = getState();
         const socket = selectSignalConnectionRaw(state).socket;
         const breakoutCurrentId = selectBreakoutCurrentId(state);
 
         socket?.emit("chat_message", {
             text: payload.text,
+            ...(payload.parentId && { parentId: payload.parentId }),
             ...(breakoutCurrentId && { breakoutGroup: breakoutCurrentId }),
             ...(payload.isBroadcast && { broadcast: true }),
         });

--- a/packages/core/src/redux/tests/store/chat.spec.ts
+++ b/packages/core/src/redux/tests/store/chat.spec.ts
@@ -2,12 +2,22 @@ import { createStore, mockSignalEmit } from "../store.setup";
 import { doSendChatMessage, doRemoveChatMessage } from "../../slices/chat";
 
 describe("actions", () => {
-    it("doSendChatMessage", () => {
-        const store = createStore({ withSignalConnection: true, connectToRoom: true });
+    describe("doSendChatMessage", () => {
+        it("should send chat message", () => {
+            const store = createStore({ withSignalConnection: true, connectToRoom: true });
 
-        store.dispatch(doSendChatMessage({ text: "text" }));
+            store.dispatch(doSendChatMessage({ text: "text" }));
 
-        expect(mockSignalEmit).toHaveBeenCalledWith("chat_message", { text: "text" });
+            expect(mockSignalEmit).toHaveBeenCalledWith("chat_message", { text: "text" });
+        });
+
+        it("should send chat message with parent id if provided", () => {
+            const store = createStore({ withSignalConnection: true, connectToRoom: true });
+
+            store.dispatch(doSendChatMessage({ text: "text", parentId: "parent-id" }));
+
+            expect(mockSignalEmit).toHaveBeenCalledWith("chat_message", { text: "text", parentId: "parent-id" });
+        });
     });
 
     describe("doRemoveChatMessage", () => {

--- a/packages/media/src/utils/types.ts
+++ b/packages/media/src/utils/types.ts
@@ -96,6 +96,7 @@ export interface ChatMessage {
     userId: string;
     breakoutGroup?: string;
     broadcast?: boolean;
+    parentId?: string;
 }
 
 export interface ChatMessageRemoved {
@@ -428,6 +429,13 @@ export interface SignalEvents {
     live_captions_stopped: void;
 }
 
+export interface ChatMessageRequest {
+    text: string;
+    parentId?: string;
+    breakoutGroup?: string;
+    broadcast?: boolean;
+}
+
 export interface IdentifyDeviceRequest {
     deviceCredentials: Credentials;
 }
@@ -477,7 +485,7 @@ export interface RemoveSpotlightRequest {
 
 export interface SignalRequests {
     add_spotlight: AddSpotlightRequest;
-    chat_message: { text: string };
+    chat_message: ChatMessageRequest;
     enable_audio: { enabled: boolean };
     enable_video: { enabled: boolean };
     handle_knock: { action: "accept" | "reject"; clientId: string; response: unknown };


### PR DESCRIPTION
### Description

Add an optional `parentId` value to the `sendChatMessage` API in both Core and Browser SDKs. By passing the `id` of the message that we want to reply to in this `parentId` argument, we can construct threaded messaging within rooms.

**Related Issue:**

Built on top of https://github.com/whereby/sdk/pull/1008 due to shared code space.

### Testing

1. Run `pnpm build && pnpm dev`
2. When storybook starts, navigate to "Stories" > "Custom UI" > "Room connection only"
3. Join a Whereby room from this UI
4. Additionally, join the same Whereby room from the standard Whereby interface (non-SDK).
5. Send a chat message in the room via the storybook UI
6. When the chat message appears, select "Reply to: [text]" from the "Send to room" select dropdown and click "Send message".
7. Verify that the message appears as a 'reply' to the first message in the standard Whereby interface.

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
