### PR TITLE
media: buffer remote ICE candidates during a new local offer in P2P

### DIFF
--- a/.changeset/silent-skies-buffer.md
+++ b/.changeset/silent-skies-buffer.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Buffer remote ICE candidates during a new local offer in P2P

--- a/packages/media/src/model/connectionStatusConstants.ts
+++ b/packages/media/src/model/connectionStatusConstants.ts
@@ -16,4 +16,7 @@ export const TYPES = {
     CONNECTION_FAILED: "connection_failed",
     CONNECTION_SUCCESSFUL: "connection_successful",
     CONNECTION_DISCONNECTED: "connection_disconnected",
-};
+} as const;
+// Need `as const` here or the values are widened to strings and can't be used for typing.
+
+export type ConnectionStatus = (typeof TYPES)[keyof typeof TYPES];

--- a/packages/media/src/webrtc/P2pRtcManager.ts
+++ b/packages/media/src/webrtc/P2pRtcManager.ts
@@ -509,7 +509,7 @@ export default class P2pRtcManager implements RtcManager {
         this._roomSessionId = roomSessionId;
     }
 
-    _setConnectionStatus(session: Session, newStatus: string, clientId: string) {
+    _setConnectionStatus(session: Session, newStatus: CONNECTION_STATUS.ConnectionStatus, clientId: string) {
         const previousStatus = session.connectionStatus;
         if (previousStatus === newStatus) {
             return;

--- a/packages/media/src/webrtc/P2pRtcManager.ts
+++ b/packages/media/src/webrtc/P2pRtcManager.ts
@@ -1169,6 +1169,9 @@ export default class P2pRtcManager implements RtcManager {
                             throw e;
                         })
                         .then(() => {
+                            // committed to a new ICE generation; buffer remote candidates until the matching answer
+                            session.expectNewRemoteDescription();
+
                             const message = {
                                 sdp: offer.sdp,
                                 sdpU: offer.sdp,

--- a/packages/media/src/webrtc/Session.ts
+++ b/packages/media/src/webrtc/Session.ts
@@ -6,6 +6,7 @@ import rtcStats from "./rtcStatsService";
 import { MediaPrefs, SignalRTCSessionDescription } from "./types";
 import { P2PIncrementAnalyticMetric } from "./P2pRtcManager";
 import { trackAnnotations } from "../utils/annotations";
+import { type ConnectionStatus } from "../model";
 
 // @ts-ignore
 const adapter = adapterRaw.default ?? adapterRaw;
@@ -30,7 +31,7 @@ export default class Session {
     mdnsHostCandidateSeen: boolean;
     pc: RTCPeerConnection;
     wasEverConnected: boolean;
-    connectionStatus: any;
+    connectionStatus: ConnectionStatus | null;
     bandwidth: any;
     pending: any[];
     isOperationPending: boolean;
@@ -41,10 +42,10 @@ export default class Session {
     registerConnected?: (value: unknown) => void;
     _deprioritizeH264Encoding: boolean;
     _mediaPrefs?: MediaPrefs;
-    clientId: any;
+    clientId: string;
     peerConnectionConfig: RTCConfiguration;
-    signalingState: any;
-    srdComplete: any;
+    signalingState: RTCPeerConnection["signalingState"];
+    srdComplete?: ReturnType<RTCPeerConnection["setRemoteDescription"]>;
     _incrementAnalyticMetric: P2PIncrementAnalyticMetric;
     pendingReplaceTrackActions: (() => Promise<void>)[];
 

--- a/packages/media/src/webrtc/Session.ts
+++ b/packages/media/src/webrtc/Session.ts
@@ -158,6 +158,10 @@ export default class Session {
         });
     }
 
+    expectNewRemoteDescription() {
+        this.srdComplete = undefined;
+    }
+
     _setRemoteDescription(desc: SignalRTCSessionDescription): Promise<void> {
         // deprioritize H264 Encoding if set by option/flag
         if (this._deprioritizeH264Encoding) desc.sdp = sdpModifier.deprioritizeH264(desc.sdp);

--- a/packages/media/tests/webrtc/P2pRtcManager.spec.ts
+++ b/packages/media/tests/webrtc/P2pRtcManager.spec.ts
@@ -596,6 +596,89 @@ describe("P2pRtcManager", () => {
                 });
             });
 
+            describe("ICE_CANDIDATE before the answer", () => {
+                it("does not add a candidate to the PC before the initial answer arrives", async () => {
+                    const session = rtcManager._connect(clientId);
+                    jest.advanceTimersByTimeAsync(1);
+                    await new Promise(process.nextTick);
+
+                    const candidate = helpers.getValidCandidatePackage();
+                    serverSocketStub.emitFromServer(RELAY_MESSAGES.ICE_CANDIDATE, {
+                        clientId,
+                        message: candidate,
+                    });
+                    jest.advanceTimersByTimeAsync(1);
+                    await new Promise(process.nextTick);
+
+                    expect(session.pc.addIceCandidate).not.toHaveBeenCalled();
+                });
+
+                it("flushes the buffered candidate to the PC once the initial answer's SRD resolves", async () => {
+                    const session = rtcManager._connect(clientId);
+                    jest.advanceTimersByTimeAsync(1);
+                    await new Promise(process.nextTick);
+
+                    const candidate = helpers.getValidCandidatePackage();
+                    serverSocketStub.emitFromServer(RELAY_MESSAGES.ICE_CANDIDATE, {
+                        clientId,
+                        message: candidate,
+                    });
+                    jest.advanceTimersByTimeAsync(1);
+                    await new Promise(process.nextTick);
+
+                    // @ts-ignore
+                    session.pc.signalingState = "have-local-offer";
+                    const validSdp = (getValidSdpString() + "\n").split("\n").join("\r\n");
+                    serverSocketStub.emitFromServer(RELAY_MESSAGES.SDP_ANSWER, {
+                        clientId,
+                        message: { type: "answer", sdp: validSdp },
+                    });
+                    jest.advanceTimersByTimeAsync(1);
+                    await new Promise(process.nextTick);
+
+                    expect(session.pc.addIceCandidate).toHaveBeenCalledWith(candidate);
+                });
+
+                it("does not add a candidate to the PC while a renegotiation offer is in flight", async () => {
+                    const session = rtcManager._connect(clientId);
+                    jest.advanceTimersByTimeAsync(1);
+                    await new Promise(process.nextTick);
+
+                    // settle the initial answer so srdComplete becomes a resolved promise
+                    // @ts-ignore
+                    session.pc.signalingState = "have-local-offer";
+                    const validSdp = (getValidSdpString() + "\n").split("\n").join("\r\n");
+                    serverSocketStub.emitFromServer(RELAY_MESSAGES.SDP_ANSWER, {
+                        clientId,
+                        message: { type: "answer", sdp: validSdp },
+                    });
+                    jest.advanceTimersByTimeAsync(1);
+                    await new Promise(process.nextTick);
+                    // @ts-ignore
+                    session.pc.signalingState = "stable";
+                    session.isOperationPending = false;
+                    (session.pc.addIceCandidate as jest.Mock).mockClear();
+
+                    // mark the session as connected, then trigger a renegotiation
+                    // @ts-ignore
+                    session.pc.iceConnectionState = "connected";
+                    session.pc.oniceconnectionstatechange?.({} as Event);
+                    session.pc.onnegotiationneeded?.({} as Event);
+                    jest.advanceTimersByTimeAsync(1);
+                    await new Promise(process.nextTick);
+
+                    const candidate = helpers.getValidCandidatePackage();
+                    serverSocketStub.emitFromServer(RELAY_MESSAGES.ICE_CANDIDATE, {
+                        clientId,
+                        message: candidate,
+                    });
+                    jest.advanceTimersByTimeAsync(1);
+                    await new Promise(process.nextTick);
+
+                    expect(session.pc.addIceCandidate).not.toHaveBeenCalled();
+                });
+            });
+
             describe("MEDIASERVER_CONFIG", () => {
                 const iceServers = helpers.createIceServersConfig();
 
@@ -966,7 +1049,7 @@ describe("P2pRtcManager", () => {
                 pc.iceConnectionState = "disconnected";
                 // @ts-ignore
                 pc.localDescription = { type: "offer" };
-                const session: any = { pc };
+                const session: any = { pc, expectNewRemoteDescription: jest.fn() };
                 session.canModifyPeerConnection = jest.fn().mockReturnValue(true);
                 manager._maybeRestartIce(clientId, session);
                 expect(manager.analytics.numIceRestart).toBe(1);

--- a/packages/media/tests/webrtc/P2pRtcManager.spec.ts
+++ b/packages/media/tests/webrtc/P2pRtcManager.spec.ts
@@ -1043,13 +1043,12 @@ describe("P2pRtcManager", () => {
         describe("icerestart", () => {
             it("adds analytics for ICE restarts", async () => {
                 const manager = createRtcManager();
-                const { pc } = await manager._connect(clientId);
+                const session = manager._connect(clientId);
 
                 // @ts-ignore
-                pc.iceConnectionState = "disconnected";
+                session.pc.iceConnectionState = "disconnected";
                 // @ts-ignore
-                pc.localDescription = { type: "offer" };
-                const session: any = { pc, expectNewRemoteDescription: jest.fn() };
+                session.pc.localDescription = { type: "offer" };
                 session.canModifyPeerConnection = jest.fn().mockReturnValue(true);
                 manager._maybeRestartIce(clientId, session);
                 expect(manager.analytics.numIceRestart).toBe(1);


### PR DESCRIPTION
## Summary
Clear `Session.srdComplete` after the local offer's SLD so remote candidates arriving before the matching answer buffer in `earlyIceCandidates` instead of hitting `pc.addIceCandidate` against the stale remote description.