### PR TITLE
media: expose getUserMedia attempts on getStream result

### DIFF
--- a/.changeset/bright-frogs-skip.md
+++ b/.changeset/bright-frogs-skip.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": minor
+---
+
+Expose getUserMedia attempts on getStream result and error

--- a/packages/core/src/redux/tests/store/localMedia.spec.ts
+++ b/packages/core/src/redux/tests/store/localMedia.spec.ts
@@ -81,7 +81,7 @@ describe("actions", () => {
 
                 beforeEach(() => {
                     newStream = new MockMediaStream();
-                    mockedGetStream.mockResolvedValueOnce({ stream: newStream });
+                    mockedGetStream.mockResolvedValueOnce({ stream: newStream, attempts: [] });
                 });
 
                 it("should update state", async () => {
@@ -202,7 +202,7 @@ describe("actions", () => {
                     if (opts?.replaceStream) {
                         opts.replaceStream.addTrack(videoTrack);
                     }
-                    return { stream: opts?.replaceStream || new MockMediaStream([videoTrack]) };
+                    return { stream: opts?.replaceStream || new MockMediaStream([videoTrack]), attempts: [] };
                 });
 
                 await store.dispatch(localMediaSlice.doToggleCamera());
@@ -406,7 +406,7 @@ describe("actions", () => {
             };
 
             const stream = new MockMediaStream();
-            jest.spyOn(MediaDevices, "getStream").mockResolvedValueOnce({ stream });
+            jest.spyOn(MediaDevices, "getStream").mockResolvedValueOnce({ stream, attempts: [] });
 
             const store = createStore({
                 initialState: {

--- a/packages/media/src/webrtc/MediaDevices.ts
+++ b/packages/media/src/webrtc/MediaDevices.ts
@@ -7,6 +7,7 @@ import {
     GetStreamOptions,
     GetStreamResult,
     GetUpdatedDevicesResult,
+    GetUserMediaAttempt,
     UpdatedDevicesInfo,
 } from "./types";
 import { trackAnnotations } from "../utils/annotations";
@@ -177,16 +178,17 @@ export function replaceTracksInStream(stream: MediaStream, newStream: MediaStrea
  * @param constraintOpt - for mediaConstraints.getConstraints (audioId/videoId etc)
  * @param options.replaceStream - stream to put new tracks into (instead of returning fresh)
  * @param options.fallback - try to give working stream
- * @returns {Promise<{stream, error=null}>}
+ * @returns {Promise<{stream, error=null, attempts}>}
  */
 export async function getStream(
     constraintOpt: GetConstraintsOptions,
     { replaceStream, fallback = true }: GetStreamOptions = {},
 ): Promise<GetStreamResult> {
     let error: any;
-    let newConstraints: GetConstraintsOptions | undefined;
+    let newConstraints: MediaStreamConstraints | undefined;
     let retryConstraintOpt: any;
     let stream: MediaStream | null = null;
+    const attempts: GetUserMediaAttempt[] = [];
 
     const only = (constraintOpt.audioId === false && "video") || (constraintOpt.videoId === false && "audio");
     // Mobile can't open two devices at once. Firefox also can't open two audio devices at once.
@@ -194,6 +196,26 @@ export async function getStream(
     // unless required.
     const stopTracks = isMobile || only !== "video";
     const constraints = getConstraints(constraintOpt);
+
+    const attempt = async (c: MediaStreamConstraints): Promise<MediaStream> => {
+        try {
+            const s = await getUserMedia(c);
+            attempts.push({ constraints: c, outcome: { ok: true } });
+            return s;
+        } catch (e: any) {
+            attempts.push({
+                constraints: c,
+                outcome: {
+                    ok: false,
+                    errorName: e?.name ?? "UnknownError",
+                    errorMessage: e?.message ?? String(e),
+                    ...(e?.constraint && { constraint: e.constraint }),
+                },
+            });
+            throw e;
+        }
+    };
+
     const addDetails = (err?: any, orgErr?: any) => {
         if (err) {
             err.details = {
@@ -210,6 +232,11 @@ export async function getStream(
         }
     };
 
+    const attachAttempts = (err: any): any => {
+        if (err) err.attempts = attempts;
+        return err;
+    };
+
     const getSingleStream = async (e?: any) => {
         if (constraints.audio && constraints.video) {
             // Since we requested both audio and video, there's
@@ -217,14 +244,14 @@ export async function getStream(
             // let's try to only get one of them.
 
             try {
-                stream = await getUserMedia(getConstraints({ ...constraintOpt, audioId: false }));
+                stream = await attempt(getConstraints({ ...constraintOpt, audioId: false }));
             } catch (e2: any) {
                 if (e2?.name !== "NotFoundError") {
                     addDetails(e2, e);
                 }
             }
             try {
-                if (!stream) stream = await getUserMedia(getConstraints({ ...constraintOpt, videoId: false }));
+                if (!stream) stream = await attempt(getConstraints({ ...constraintOpt, videoId: false }));
             } catch (e2) {
                 addDetails(e2, e);
             }
@@ -233,11 +260,11 @@ export async function getStream(
 
     if (stopTracks && replaceStream) stopStreamTracks(replaceStream, only);
     try {
-        stream = await getUserMedia(constraints);
+        stream = await attempt(constraints);
     } catch (e: any) {
         error = e;
         if (!fallback) {
-            throw addDetails(e);
+            throw attachAttempts(addDetails(e));
         }
         if (e?.name === "OverconstrainedError") {
             const laxConstraints = {
@@ -268,7 +295,7 @@ export async function getStream(
                 // First of all, it seems like NotReadableError is REALLY a
                 // OverconstrainedError in many cases, let's try with laxer constraints
                 try {
-                    stream = await getUserMedia(
+                    stream = await attempt(
                         getConstraints({ ...constraintOpt, options: { ...constraintOpt.options, lax: true } }),
                     );
                 } catch (e2) {
@@ -281,7 +308,7 @@ export async function getStream(
                 ];
                 if (!stream && problemWith) {
                     try {
-                        stream = await getUserMedia(getConstraints({ ...constraintOpt, [problemWith]: null }));
+                        stream = await attempt(getConstraints({ ...constraintOpt, [problemWith]: null }));
                     } catch (e2) {
                         logger.warn(`Re-tried ${problemWith} with no constraints, but failed: ${"" + e2}`);
                     }
@@ -292,7 +319,7 @@ export async function getStream(
                     const tryOnly = problemWith ? [problemWith] : ["videoId", "audioId"];
                     for (const kind of tryOnly) {
                         try {
-                            stream = await getUserMedia(getConstraints({ ...constraintOpt, [kind]: false }));
+                            stream = await attempt(getConstraints({ ...constraintOpt, [kind]: false }));
                         } catch (e2) {
                             logger.warn(`Re-tried without ${kind}, but failed: ${"" + e2}`);
                         }
@@ -308,20 +335,21 @@ export async function getStream(
     }
     if (retryConstraintOpt) {
         const onlyConstraints = only ? { audio: { videoId: false }, video: { audioId: false } }[only] : {};
-        newConstraints = getConstraints({
+        const retryConstraints = getConstraints({
             ...constraintOpt,
             ...retryConstraintOpt,
             options: { ...constraintOpt.options, lax: retryConstraintOpt.lax },
             ...onlyConstraints,
         });
+        newConstraints = retryConstraints;
         try {
-            stream = await getUserMedia(newConstraints);
+            stream = await attempt(retryConstraints);
         } catch (e) {
-            throw addDetails(e, error);
+            throw attachAttempts(addDetails(e, error));
         }
     }
     if (!stream) {
-        throw addDetails(error);
+        throw attachAttempts(addDetails(error));
     }
     let replacedTracks;
     if (replaceStream) {
@@ -330,7 +358,7 @@ export async function getStream(
         replacedTracks = replaceTracksInStream(replaceStream, stream, only);
         stream = replaceStream;
     }
-    return { error: error && addDetails(error), stream, replacedTracks };
+    return { error: error && addDetails(error), stream, replacedTracks, attempts };
 }
 
 export function hasGetDisplayMedia() {

--- a/packages/media/src/webrtc/types.ts
+++ b/packages/media/src/webrtc/types.ts
@@ -151,10 +151,20 @@ export interface BuildDeviceListOptions {
     kind: MediaDeviceKind;
 }
 
+export type GetUserMediaAttemptOutcome =
+    | { ok: true }
+    | { ok: false; errorName: string; errorMessage: string; constraint?: string };
+
+export type GetUserMediaAttempt = {
+    constraints: MediaStreamConstraints;
+    outcome: GetUserMediaAttemptOutcome;
+};
+
 export type GetStreamResult = {
     error?: unknown;
     replacedTracks?: MediaStreamTrack[];
     stream: MediaStream;
+    attempts: GetUserMediaAttempt[];
 };
 
 export type UpdatedDeviceInfo = {


### PR DESCRIPTION
### Description

**Summary:**

Adds an `attempts` array to `getStream`'s result (and `error.attempts` on throw), one entry per underlying `getUserMedia` call with the constraints used and the outcome. Existing callers see no change.

**Related Issue:**

### Testing

### Screenshots/GIFs (if applicable)

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information