### PR TITLE
Pin Node.js to 24.15.0 in CI workflows

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version-file: .nvmrc
+                  node-version: 24.15.0
                   cache: "pnpm"
                   cache-dependency-path: |
                       pnpm-lock.yaml

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -45,7 +45,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version-file: .nvmrc
+                  node-version: 24.15.0
                   cache: "pnpm"
                   cache-dependency-path: |
                       pnpm-lock.yaml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version-file: .nvmrc
+                  node-version: 24.15.0
                   cache: "pnpm"
                   cache-dependency-path: |
                       pnpm-lock.yaml

--- a/.github/workflows/exit-prerelease.yml
+++ b/.github/workflows/exit-prerelease.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version-file: .nvmrc
+                  node-version: 24.15.0
                   cache: "pnpm"
                   cache-dependency-path: |
                       pnpm-lock.yaml

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version-file: .nvmrc
+                  node-version: 24.15.0
                   cache: "pnpm"
                   cache-dependency-path: |
                       pnpm-lock.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version-file: .nvmrc
+                  node-version: 24.15.0
                   cache: "pnpm"
                   cache-dependency-path: |
                       pnpm-lock.yaml


### PR DESCRIPTION
### Description

**Summary:** Pin `node-version` to `24.15.0` in all GitHub Actions workflows so CI runs against a fixed Node.js version instead of floating to the latest 24.x. `.nvmrc` is left unchanged (`v24`) so local development still tracks the latest.

**Related Issue:**

### Testing

### Screenshots/GIFs (if applicable)

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information