### PR TITLE
common: bump @playwright/test to 1.60.0

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.15.0
+                  node-version-file: .nvmrc
                   cache: "pnpm"
                   cache-dependency-path: |
                       pnpm-lock.yaml

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -45,7 +45,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.15.0
+                  node-version-file: .nvmrc
                   cache: "pnpm"
                   cache-dependency-path: |
                       pnpm-lock.yaml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.15.0
+                  node-version-file: .nvmrc
                   cache: "pnpm"
                   cache-dependency-path: |
                       pnpm-lock.yaml

--- a/.github/workflows/exit-prerelease.yml
+++ b/.github/workflows/exit-prerelease.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.15.0
+                  node-version-file: .nvmrc
                   cache: "pnpm"
                   cache-dependency-path: |
                       pnpm-lock.yaml

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.15.0
+                  node-version-file: .nvmrc
                   cache: "pnpm"
                   cache-dependency-path: |
                       pnpm-lock.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.15.0
+                  node-version-file: .nvmrc
                   cache: "pnpm"
                   cache-dependency-path: |
                       pnpm-lock.yaml

--- a/apps/sample-app/package.json
+++ b/apps/sample-app/package.json
@@ -13,7 +13,7 @@
     "devDependencies": {
         "@whereby.com/prettier-config": "workspace:*",
         "@whereby.com/tsconfig": "workspace:*",
-        "@playwright/test": "^1.50.1",
+        "@playwright/test": "^1.60.0",
         "@vitejs/plugin-react": "^4.2.1",
         "vite": "^5.0.13",
         "prettier": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,7 +149,7 @@ importers:
         version: link:../../packages/browser-sdk
       next:
         specifier: 15.3.6
-        version: 15.3.6(@playwright/test@1.53.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.6(@playwright/test@1.60.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: catalog:react19
         version: 19.1.0
@@ -362,8 +362,8 @@ importers:
         version: 2.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.50.1
-        version: 1.53.1
+        specifier: ^1.60.0
+        version: 1.60.0
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.6.0(vite@5.4.19(@types/node@22.15.34)(lightningcss@1.30.2)(terser@5.43.1))
@@ -2755,8 +2755,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.53.1':
-    resolution: {integrity: sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7721,13 +7721,13 @@ packages:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
 
-  playwright-core@1.53.1:
-    resolution: {integrity: sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.53.1:
-    resolution: {integrity: sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -11798,9 +11798,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.53.1':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.53.1
+      playwright: 1.60.0
 
   '@popperjs/core@2.11.8': {}
 
@@ -17708,7 +17708,7 @@ snapshots:
 
   nested-error-stacks@2.0.1: {}
 
-  next@15.3.6(@playwright/test@1.53.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.6(@playwright/test@1.60.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.6
       '@swc/counter': 0.1.3
@@ -17728,7 +17728,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.3.5
       '@next/swc-win32-arm64-msvc': 15.3.5
       '@next/swc-win32-x64-msvc': 15.3.5
-      '@playwright/test': 1.53.1
+      '@playwright/test': 1.60.0
       sharp: 0.34.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -18058,11 +18058,11 @@ snapshots:
     dependencies:
       find-up: 3.0.0
 
-  playwright-core@1.53.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.53.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.53.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
### Description

**Summary:** Bumps `@playwright/test` from `^1.50.1` to `^1.60.0` in `apps/sample-app` (matches pwa). Revert node `24.15.0` pin in CI workflows, they now read from `.nvmrc` again.

**Related Issue:**

### Testing

### Screenshots/GIFs (if applicable)

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information