### PR TITLE
common: Expose `parentId` (if present) with chat messages

### DIFF
--- a/.changeset/eighty-times-retire.md
+++ b/.changeset/eighty-times-retire.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/browser-sdk": patch
+"@whereby.com/core": patch
+---
+
+Expose parentId (if available) with chat messages to render reply interfaces

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -614,6 +614,17 @@ export default function VideoExperience({
                         {chatMessages.map((m) => {
                             return (
                                 <div key={m.id}>
+                                    {m.parentId && (
+                                        <div style={{ fontSize: "12px", fontWeight: "bold", marginBottom: "4px" }}>
+                                            Reply to{" "}
+                                            <i>
+                                                &quot;
+                                                {(chatMessages.find((cM) => cM.id === m.parentId) || {}).text}
+                                                &quot;
+                                            </i>
+                                            :{" "}
+                                        </div>
+                                    )}
                                     {m.removed ? <s>{m.text}</s> : m.text}{" "}
                                     {!m.removed && (m.sig || showHostControls) && (
                                         <button type="button" onClick={() => removeChatMessage(m.id, m.sig)}>

--- a/packages/core/src/client/RoomConnection/types.ts
+++ b/packages/core/src/client/RoomConnection/types.ts
@@ -37,7 +37,7 @@ export type ScreenshareState = Screenshare;
 
 export type LocalScreenshareStatus = "starting" | "active";
 
-export type ChatMessage = Pick<SignalChatMessage, "id" | "senderId" | "timestamp" | "text" | "sig"> & {
+export type ChatMessage = Pick<SignalChatMessage, "id" | "senderId" | "parentId" | "timestamp" | "text" | "sig"> & {
     removed: boolean;
 };
 

--- a/packages/core/src/redux/slices/__tests__/chat.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/chat.unit.ts
@@ -10,6 +10,7 @@ describe("chatSlice", () => {
                     id: "messageId",
                     userId: "userId",
                     senderId: "senderId",
+                    parentId: "parentId",
                     messageType: "text",
                     roomName: "roomName",
                     sig: "sig",
@@ -22,6 +23,7 @@ describe("chatSlice", () => {
                 {
                     id: "messageId",
                     senderId: "senderId",
+                    parentId: "parentId",
                     timestamp: "123",
                     text: "text",
                     sig: "sig",

--- a/packages/core/src/redux/slices/chat.ts
+++ b/packages/core/src/redux/slices/chat.ts
@@ -6,7 +6,7 @@ import { signalEvents } from "./signalConnection/actions";
 import { selectSignalConnectionRaw } from "./signalConnection";
 import { selectBreakoutCurrentId } from "./breakout";
 
-export type ChatMessage = Pick<SignalChatMessage, "id" | "senderId" | "timestamp" | "text" | "sig"> & {
+export type ChatMessage = Pick<SignalChatMessage, "id" | "senderId" | "parentId" | "timestamp" | "text" | "sig"> & {
     removed: boolean;
 };
 
@@ -30,6 +30,7 @@ export const chatSlice = createSlice({
             const message: ChatMessage = {
                 id: action.payload.id,
                 senderId: action.payload.senderId,
+                parentId: action.payload.parentId,
                 timestamp: action.payload.timestamp,
                 text: action.payload.text,
                 sig: action.payload.sig,

--- a/packages/core/src/redux/slices/notifications/index.ts
+++ b/packages/core/src/redux/slices/notifications/index.ts
@@ -126,6 +126,7 @@ startAppListening({
                         chatMessage: {
                             id: payload.id,
                             senderId: payload.senderId,
+                            parentId: payload.parentId,
                             timestamp: payload.timestamp,
                             text: payload.text,
                             sig: payload.sig,


### PR DESCRIPTION
### Description

Add `parentId` to chat messages returned to clients in Core and Browser SDKs so this property can be used to also create chat reply user interfaces.

**Related Issue:**

Follow up to basic chat replies functionality added to SDK in https://github.com/whereby/sdk/pull/1010

### Testing

1. Run `pnpm build && pnpm dev`
2. When storybook starts, navigate to "Stories" > "Custom UI" > "Room connection only"
3. Join a Whereby room from this UI
4. Send a chat message in the room via the storybook UI
6. When the chat message appears, select "Reply to: [text]" from the "Send to room" select dropdown and click "Send message".
7. Verify that the message appears as a 'reply' to the first message in the SDK interface.
8. Additionally: join the same Whereby room from the standard Whereby interface (non-SDK).
4. Send a chat message in the room via the Whereby interface (non-SDK)
6. In the SDK UI, when the chat message appears, select "Reply to: [text]" from the "Send to room" select dropdown and click "Send message".
7. Verify that the message appears as a 'reply' to the other (non-SDK) user's  message in the SDK interface.

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
