### PR TITLE
media: pass preferred deviceId through to gUM

### DIFF
--- a/.changeset/quiet-mountains-listen.md
+++ b/.changeset/quiet-mountains-listen.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Forward preferred deviceId to gUM even when the device list is sparse

--- a/packages/media/src/webrtc/mediaConstraints.ts
+++ b/packages/media/src/webrtc/mediaConstraints.ts
@@ -76,12 +76,10 @@ export function getMediaConstraints({
 export default function getConstraints({ devices, videoId, audioId, options, type = "ideal" }: GetConstraintsOptions) {
     const audioDevices = devices.filter((d) => d.kind === "audioinput");
     const videoDevices = devices.filter((d) => d.kind === "videoinput");
-    const useDefaultAudio = !audioId || !audioDevices.some((d) => d.deviceId === audioId);
-    const useDefaultVideo = !videoId || !videoDevices.some((d) => d.deviceId === videoId);
     const constraints = getMediaConstraints({
         preferredDeviceIds: {
-            audioId: useDefaultAudio ? null : { [type]: audioId },
-            videoId: useDefaultVideo ? null : { [type]: videoId },
+            audioId: typeof audioId === "string" ? { [type]: audioId } : null,
+            videoId: typeof videoId === "string" ? { [type]: videoId } : null,
         },
         ...options,
     });


### PR DESCRIPTION
### Description

**Summary:**

`getConstraints` dropped a caller's preferred `audioId`/`videoId` when the device wasn't in the supplied `devices` list. On Firefox/Safari `enumerateDevices()` is sparse before the first `gUM` call, so the preferred device was silently swapped for the browser default. Forward the deviceId whenever the caller passes one as a string and let `gUM` surface `OverconstrainedError` if the device is genuinely missing.

**Related Issue:**

### Testing

### Screenshots/GIFs (if applicable)

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information