### PR TITLE
common: Add video hd and widescreen toggle APIs to both Core and Browser SDKs

### DIFF
--- a/.changeset/afraid-olives-yell.md
+++ b/.changeset/afraid-olives-yell.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": minor
+---
+
+Add video HD mode and Widescreen mode toggles to Core SDK

--- a/.changeset/fuzzy-jobs-eat.md
+++ b/.changeset/fuzzy-jobs-eat.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": minor
+---
+
+Add video hd and widescreen toggle API to Browser SDK

--- a/packages/browser-sdk/src/lib/react/useLocalMedia/index.ts
+++ b/packages/browser-sdk/src/lib/react/useLocalMedia/index.ts
@@ -35,7 +35,12 @@ export function useLocalMedia(
     const setSpeakerDevice = React.useCallback((deviceId: string) => client.setSpeakerDevice(deviceId), [client]);
     const toggleCamera = React.useCallback((enabled?: boolean) => client.toggleCamera(enabled), [client]);
     const toggleMicrophone = React.useCallback((enabled?: boolean) => client.toggleMicrophone(enabled), [client]);
+    const toggleHdMode = React.useCallback((enabled?: boolean) => client.toggleHdMode(enabled), [client]);
     const toggleLowDataMode = React.useCallback((enabled?: boolean) => client.toggleLowDataMode(enabled), [client]);
+    const toggleWidescreenMode = React.useCallback(
+        (enabled?: boolean) => client.toggleWidescreenMode(enabled),
+        [client],
+    );
 
     return {
         state: localMediaState,
@@ -45,7 +50,9 @@ export function useLocalMedia(
             setSpeakerDevice,
             toggleCameraEnabled: toggleCamera,
             toggleMicrophoneEnabled: toggleMicrophone,
+            toggleHdModeEnabled: toggleHdMode,
             toggleLowDataModeEnabled: toggleLowDataMode,
+            toggleWidescreenModeEnabled: toggleWidescreenMode,
         },
     };
 }

--- a/packages/browser-sdk/src/lib/react/useLocalMedia/types.ts
+++ b/packages/browser-sdk/src/lib/react/useLocalMedia/types.ts
@@ -6,7 +6,9 @@ interface LocalMediaActions {
     setSpeakerDevice: (deviceId: string) => void;
     toggleCameraEnabled: (enabled?: boolean) => void;
     toggleMicrophoneEnabled: (enabled?: boolean) => void;
+    toggleHdModeEnabled: (enabled?: boolean) => void;
     toggleLowDataModeEnabled: (enabled?: boolean) => void;
+    toggleWidescreenModeEnabled: (enabled?: boolean) => void;
 }
 
 export type UseLocalMediaResult = { state: LocalMediaState; actions: LocalMediaActions };

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -81,7 +81,12 @@ export function useRoomConnection(
     const setDisplayName = React.useCallback((displayName: string) => client.setDisplayName(displayName), [client]);
     const toggleCamera = React.useCallback((enabled?: boolean) => client.toggleCamera(enabled), [client]);
     const toggleMicrophone = React.useCallback((enabled?: boolean) => client.toggleMicrophone(enabled), [client]);
+    const toggleHdMode = React.useCallback((enabled?: boolean) => client.toggleHdMode(enabled), [client]);
     const toggleLowDataMode = React.useCallback((enabled?: boolean) => client.toggleLowDataMode(enabled), [client]);
+    const toggleWidescreenMode = React.useCallback(
+        (enabled?: boolean) => client.toggleWidescreenMode(enabled),
+        [client],
+    );
     const toggleRaiseHand = React.useCallback((enabled?: boolean) => client.toggleRaiseHand(enabled), [client]);
     const askToSpeak = React.useCallback((participantId: string) => client.askToSpeak(participantId), [client]);
     const askToTurnOnCamera = React.useCallback(
@@ -149,8 +154,6 @@ export function useRoomConnection(
         state,
         events,
         actions: {
-            toggleLowDataMode,
-            toggleRaiseHand,
             askToSpeak,
             askToTurnOnCamera,
             acceptWaitingParticipant,
@@ -175,6 +178,10 @@ export function useRoomConnection(
             stopScreenshare,
             toggleCamera,
             toggleMicrophone,
+            toggleRaiseHand,
+            toggleHdMode,
+            toggleLowDataMode,
+            toggleWidescreenMode,
             spotlightParticipant,
             removeSpotlight,
             joinBreakoutGroup,

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -15,8 +15,6 @@ export interface UseRoomConnectionOptions extends Omit<RoomConnectionOptions, "l
 }
 
 export interface RoomConnectionActions {
-    toggleLowDataMode: (enabled?: boolean) => void;
-    toggleRaiseHand: (enabled?: boolean) => void;
     askToSpeak: (participantId: string) => void;
     askToTurnOnCamera: (participantId: string) => void;
     acceptWaitingParticipant: (participantId: string) => void;
@@ -41,6 +39,10 @@ export interface RoomConnectionActions {
     stopScreenshare: () => void;
     toggleCamera: (enabled?: boolean) => void;
     toggleMicrophone: (enabled?: boolean) => void;
+    toggleRaiseHand: (enabled?: boolean) => void;
+    toggleHdMode: (enabled?: boolean) => void;
+    toggleLowDataMode: (enabled?: boolean) => void;
+    toggleWidescreenMode: (enabled?: boolean) => void;
     spotlightParticipant: (clientId: string) => void;
     removeSpotlight: (clientId: string) => void;
     joinBreakoutGroup: (group: string) => void;

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -78,7 +78,9 @@ export default function VideoExperience({
         endMeeting,
         toggleCamera,
         toggleMicrophone,
+        toggleHdMode,
         toggleLowDataMode,
+        toggleWidescreenMode,
         toggleRaiseHand,
         askToSpeak,
         acceptWaitingParticipant,
@@ -594,6 +596,8 @@ export default function VideoExperience({
                         <button onClick={() => toggleCamera()}>Toggle camera</button>
                         <button onClick={() => toggleMicrophone()}>Toggle microphone</button>
                         <button onClick={() => toggleLowDataMode()}>Toggle low data mode</button>
+                        <button onClick={() => toggleHdMode()}>Toggle hd video mode</button>
+                        <button onClick={() => toggleWidescreenMode()}>Toggle widescreen video mode</button>
                         <button onClick={() => toggleRaiseHand()}>Toggle raise hand</button>
                         <button
                             onClick={() => {

--- a/packages/core/src/client/LocalMedia/index.ts
+++ b/packages/core/src/client/LocalMedia/index.ts
@@ -2,7 +2,9 @@ import {
     doStartLocalMedia,
     toggleCameraEnabled,
     toggleMicrophoneEnabled,
+    toggleHdModeEnabled,
     toggleLowDataModeEnabled,
+    toggleWidescreenModeEnabled,
     setCurrentCameraDeviceId,
     setCurrentMicrophoneDeviceId,
     setCurrentSpeakerDeviceId,
@@ -214,8 +216,16 @@ export class LocalMediaClient extends BaseClient<LocalMediaState, LocalMediaEven
         this.store.dispatch(toggleMicrophoneEnabled({ enabled }));
     }
 
+    public toggleHdMode(enabled?: boolean) {
+        this.store.dispatch(toggleHdModeEnabled({ enabled }));
+    }
+
     public toggleLowDataMode(enabled?: boolean) {
         this.store.dispatch(toggleLowDataModeEnabled({ enabled }));
+    }
+
+    public toggleWidescreenMode(enabled?: boolean) {
+        this.store.dispatch(toggleWidescreenModeEnabled({ enabled }));
     }
 
     public setCameraDevice(deviceId: string) {

--- a/packages/core/src/client/RoomConnection/index.ts
+++ b/packages/core/src/client/RoomConnection/index.ts
@@ -32,7 +32,9 @@ import {
     signalEvents,
     startAppListening,
     toggleCameraEnabled,
+    toggleHdModeEnabled,
     toggleLowDataModeEnabled,
+    toggleWidescreenModeEnabled,
     toggleMicrophoneEnabled,
     AppConfig,
 } from "../../redux";
@@ -468,12 +470,30 @@ export class RoomConnectionClient extends BaseClient<RoomConnectionState, RoomCo
     }
 
     /**
+     * Toggle video hd mode on or off.
+     * @param enabled - If true, enables hd mode; if false, disables it.
+     * If undefined, toggles the current state.
+     */
+    public toggleHdMode(enabled?: boolean) {
+        this.store.dispatch(toggleHdModeEnabled({ enabled }));
+    }
+
+    /**
      * Toggle low data mode on or off.
      * @param enabled - If true, enables low data mode; if false, disables it.
      * If undefined, toggles the current state.
      */
     public toggleLowDataMode(enabled?: boolean) {
         this.store.dispatch(toggleLowDataModeEnabled({ enabled }));
+    }
+
+    /**
+     * Toggle video widescreen mode on or off.
+     * @param enabled - If true, enables widescreen mode; if false, disables it.
+     * If undefined, toggles the current state.
+     */
+    public toggleWidescreenMode(enabled?: boolean) {
+        this.store.dispatch(toggleWidescreenModeEnabled({ enabled }));
     }
 
     /**

--- a/packages/core/src/redux/slices/localMedia.ts
+++ b/packages/core/src/redux/slices/localMedia.ts
@@ -16,6 +16,10 @@ export type LocalMediaOptions = {
  * Reducer
  */
 export interface LocalMediaState {
+    beforeEffectTracks?: {
+        audio?: MediaStreamTrack;
+        video?: MediaStreamTrack;
+    };
     busyDeviceIds: string[];
     cameraDeviceError?: unknown;
     cameraEnabled: boolean;
@@ -23,24 +27,22 @@ export interface LocalMediaState {
     currentMicrophoneDeviceId?: string;
     currentSpeakerDeviceId?: string;
     devices: MediaDeviceInfo[];
+    hdMode: boolean;
     isSettingCameraDevice: boolean;
     isSettingMicrophoneDevice: boolean;
     isSettingSpeakerDevice: boolean;
+    isSwitchingStream: boolean;
     isTogglingCamera: boolean;
     lowDataMode: boolean;
     microphoneDeviceError?: unknown;
     microphoneEnabled: boolean;
-    speakerDeviceError?: unknown;
+    onDeviceChange?: () => void;
     options?: LocalMediaOptions;
+    speakerDeviceError?: unknown;
     status: "inactive" | "stopped" | "starting" | "started" | "error";
     startError?: unknown;
     stream?: MediaStream;
-    isSwitchingStream: boolean;
-    onDeviceChange?: () => void;
-    beforeEffectTracks?: {
-        audio?: MediaStreamTrack;
-        video?: MediaStreamTrack;
-    };
+    widescreenMode: boolean;
 }
 
 export const initialLocalMediaState: LocalMediaState = {
@@ -48,15 +50,17 @@ export const initialLocalMediaState: LocalMediaState = {
     cameraEnabled: false,
     currentSpeakerDeviceId: "default",
     devices: [],
+    hdMode: true,
     isSettingCameraDevice: false,
     isSettingMicrophoneDevice: false,
     isSettingSpeakerDevice: false,
+    isSwitchingStream: false,
     isTogglingCamera: false,
     lowDataMode: false,
     microphoneEnabled: false,
     status: "inactive",
     stream: undefined,
-    isSwitchingStream: false,
+    widescreenMode: true,
 };
 
 export const localMediaSlice = createSlice({
@@ -103,10 +107,22 @@ export const localMediaSlice = createSlice({
                 currentSpeakerDeviceId: action.payload.deviceId ?? "default",
             };
         },
+        toggleHdModeEnabled(state, action: PayloadAction<{ enabled?: boolean }>) {
+            return {
+                ...state,
+                hdMode: action.payload.enabled ?? !state.hdMode,
+            };
+        },
         toggleLowDataModeEnabled(state, action: PayloadAction<{ enabled?: boolean }>) {
             return {
                 ...state,
                 lowDataMode: action.payload.enabled ?? !state.lowDataMode,
+            };
+        },
+        toggleWidescreenModeEnabled(state, action: PayloadAction<{ enabled?: boolean }>) {
+            return {
+                ...state,
+                widescreenMode: action.payload.enabled ?? !state.widescreenMode,
             };
         },
         setDevices(state, action: PayloadAction<{ devices: MediaDeviceInfo[] }>) {
@@ -279,7 +295,9 @@ export const {
     setCurrentSpeakerDeviceId,
     toggleCameraEnabled,
     toggleMicrophoneEnabled,
+    toggleHdModeEnabled,
     toggleLowDataModeEnabled,
+    toggleWidescreenModeEnabled,
     setLocalMediaOptions,
     setLocalMediaStream,
     localMediaStopped,
@@ -350,7 +368,7 @@ const doToggleMicrophone = createAppAsyncThunk("localMedia/doToggleMicrophone", 
 
     audioTrack.enabled = enabled;
 });
-export const doToggleLowDataMode = createAppThunk(() => (dispatch, getState) => {
+export const doTriggerLocalStreamRefresh = createAppThunk(() => (dispatch, getState) => {
     const state = getState();
     const stream = selectLocalMediaStream(state);
     if (!stream) {
@@ -638,7 +656,9 @@ export const selectCurrentMicrophoneDeviceId = (state: RootState) => state.local
 export const selectCurrentSpeakerDeviceId = (state: RootState) => state.localMedia.currentSpeakerDeviceId;
 export const selectIsCameraEnabled = (state: RootState) => state.localMedia.cameraEnabled;
 export const selectIsMicrophoneEnabled = (state: RootState) => state.localMedia.microphoneEnabled;
+export const selectIsHDModeEnabled = (state: RootState) => state.localMedia.hdMode;
 export const selectIsLowDataModeEnabled = (state: RootState) => state.localMedia.lowDataMode;
+export const selectIsWidescreenModeEnabled = (state: RootState) => state.localMedia.widescreenMode;
 export const selectIsSettingCameraDevice = (state: RootState) => state.localMedia.isSettingCameraDevice;
 export const selectIsSettingMicrophoneDevice = (state: RootState) => state.localMedia.isSettingMicrophoneDevice;
 export const selectIsToggleCamera = (state: RootState) => state.localMedia.isTogglingCamera;
@@ -656,19 +676,21 @@ export const selectLocalMediaConstraintsOptions = createSelector(
     selectLocalMediaDevices,
     selectCurrentCameraDeviceId,
     selectCurrentMicrophoneDeviceId,
+    selectIsHDModeEnabled,
     selectIsLowDataModeEnabled,
-    (devices, videoId, audioId, lowDataMode) => ({
+    selectIsWidescreenModeEnabled,
+    (devices, videoId, audioId, hd, lowDataMode, widescreen) => ({
         devices,
         videoId,
         audioId,
         options: {
             disableAEC: false,
             disableAGC: false,
-            hd: true,
+            hd,
             lax: false,
             lowDataMode,
             simulcast: true,
-            widescreen: true,
+            widescreen,
         },
     }),
 );
@@ -741,14 +763,29 @@ startAppListening({
 
 startAppListening({
     predicate: (_action, currentState, previousState) => {
-        const oldValue = selectIsLowDataModeEnabled(previousState);
-        const newValue = selectIsLowDataModeEnabled(currentState);
-
         const isReady = selectLocalMediaStatus(previousState) === "started";
-        return isReady && oldValue !== newValue;
+
+        if (!isReady) {
+            return false;
+        }
+
+        const oldLowDataModeValue = selectIsLowDataModeEnabled(previousState);
+        const newLowDataModeValue = selectIsLowDataModeEnabled(currentState);
+
+        const oldHDModeValue = selectIsHDModeEnabled(previousState);
+        const newHDModeValue = selectIsHDModeEnabled(currentState);
+
+        const oldWidescreenModeValue = selectIsWidescreenModeEnabled(previousState);
+        const newWidescreenModeValue = selectIsWidescreenModeEnabled(currentState);
+
+        const hasLowDataModeChanged = oldLowDataModeValue !== newLowDataModeValue;
+        const hasHDModeChanged = oldHDModeValue !== newHDModeValue;
+        const hasWidescreenModeChanged = oldWidescreenModeValue !== newWidescreenModeValue;
+
+        return hasLowDataModeChanged || hasHDModeChanged || hasWidescreenModeChanged;
     },
     effect: (_action, { dispatch }) => {
-        dispatch(doToggleLowDataMode());
+        dispatch(doTriggerLocalStreamRefresh());
     },
 });
 

--- a/packages/core/src/redux/tests/store/localMedia.spec.ts
+++ b/packages/core/src/redux/tests/store/localMedia.spec.ts
@@ -120,15 +120,17 @@ describe("actions", () => {
                         busyDeviceIds: [],
                         cameraEnabled: true,
                         devices: [],
+                        hdMode: true,
                         isSettingCameraDevice: false,
                         isSettingMicrophoneDevice: false,
                         isSettingSpeakerDevice: false,
+                        isSwitchingStream: false,
                         isTogglingCamera: false,
                         lowDataMode: false,
                         microphoneEnabled: true,
                         status: "started",
                         stream: new MockMediaStream([audioTrack, videoTrack]),
-                        isSwitchingStream: false,
+                        widescreenMode: true,
                     },
                 };
             });
@@ -174,15 +176,17 @@ describe("actions", () => {
                         busyDeviceIds: [],
                         cameraEnabled: true,
                         devices: [],
+                        hdMode: true,
                         isSettingCameraDevice: false,
                         isSettingMicrophoneDevice: false,
                         isSettingSpeakerDevice: false,
+                        isSwitchingStream: false,
                         isTogglingCamera: false,
                         lowDataMode: false,
                         microphoneEnabled: true,
                         status: "started",
                         stream: localStream,
-                        isSwitchingStream: false,
+                        widescreenMode: true,
                     },
                 };
             });
@@ -229,15 +233,17 @@ describe("actions", () => {
                         busyDeviceIds: [],
                         cameraEnabled: false,
                         devices: [],
+                        hdMode: true,
                         isSettingCameraDevice: false,
                         isSettingMicrophoneDevice: false,
                         isSettingSpeakerDevice: false,
+                        isSwitchingStream: false,
                         isTogglingCamera: false,
                         lowDataMode: false,
                         microphoneEnabled: true,
                         status: "started",
                         stream: localStream,
-                        isSwitchingStream: false,
+                        widescreenMode: true,
                     },
                 };
             });
@@ -278,8 +284,8 @@ describe("actions", () => {
         });
     });
 
-    describe("doToggleLowDataMode", () => {
-        describe("when low data mode is enabled", () => {
+    describe("toggleHdModeEnabled", () => {
+        describe("when video hd mode is disabled", () => {
             let initialState: Partial<RootState>;
             beforeEach(() => {
                 initialState = {
@@ -287,15 +293,17 @@ describe("actions", () => {
                         busyDeviceIds: [],
                         cameraEnabled: true,
                         devices: [],
+                        hdMode: true,
                         isSettingCameraDevice: false,
                         isSettingMicrophoneDevice: false,
                         isSettingSpeakerDevice: false,
+                        isSwitchingStream: false,
                         isTogglingCamera: false,
                         lowDataMode: false,
                         microphoneEnabled: true,
                         status: "started",
                         stream: new MockMediaStream(),
-                        isSwitchingStream: false,
+                        widescreenMode: true,
                     },
                 };
             });
@@ -305,7 +313,85 @@ describe("actions", () => {
                 const store = createStore({ initialState });
                 const before = store.getState().localMedia;
 
-                store.dispatch(localMediaSlice.doToggleLowDataMode());
+                store.dispatch(localMediaSlice.toggleHdModeEnabled({ enabled: false }));
+
+                expect(localMediaSlice.doSwitchLocalStream).toHaveBeenCalledTimes(1);
+                const after = store.getState().localMedia;
+
+                expect(diff(before, after)).toMatchObject({ isSwitchingStream: true });
+            });
+        });
+    });
+
+    describe("toggleLowDataModeEnabled", () => {
+        describe("when low data mode is enabled", () => {
+            let initialState: Partial<RootState>;
+            beforeEach(() => {
+                initialState = {
+                    localMedia: {
+                        busyDeviceIds: [],
+                        cameraEnabled: true,
+                        devices: [],
+                        hdMode: true,
+                        isSettingCameraDevice: false,
+                        isSettingMicrophoneDevice: false,
+                        isSettingSpeakerDevice: false,
+                        isSwitchingStream: false,
+                        isTogglingCamera: false,
+                        lowDataMode: false,
+                        microphoneEnabled: true,
+                        status: "started",
+                        stream: new MockMediaStream(),
+                        widescreenMode: true,
+                    },
+                };
+            });
+
+            it("should call doSwitchLocalStream", () => {
+                jest.spyOn(localMediaSlice, "doSwitchLocalStream");
+                const store = createStore({ initialState });
+                const before = store.getState().localMedia;
+
+                store.dispatch(localMediaSlice.toggleLowDataModeEnabled({ enabled: true }));
+
+                expect(localMediaSlice.doSwitchLocalStream).toHaveBeenCalledTimes(1);
+                const after = store.getState().localMedia;
+
+                expect(diff(before, after)).toMatchObject({ isSwitchingStream: true });
+            });
+        });
+    });
+
+    describe("toggleWidescreenModeEnabled", () => {
+        describe("when video widescreen mode is disabled", () => {
+            let initialState: Partial<RootState>;
+            beforeEach(() => {
+                initialState = {
+                    localMedia: {
+                        busyDeviceIds: [],
+                        cameraEnabled: true,
+                        devices: [],
+                        hdMode: true,
+                        isSettingCameraDevice: false,
+                        isSettingMicrophoneDevice: false,
+                        isSettingSpeakerDevice: false,
+                        isSwitchingStream: false,
+                        isTogglingCamera: false,
+                        lowDataMode: false,
+                        microphoneEnabled: true,
+                        status: "started",
+                        stream: new MockMediaStream(),
+                        widescreenMode: true,
+                    },
+                };
+            });
+
+            it("should call doSwitchLocalStream", () => {
+                jest.spyOn(localMediaSlice, "doSwitchLocalStream");
+                const store = createStore({ initialState });
+                const before = store.getState().localMedia;
+
+                store.dispatch(localMediaSlice.toggleWidescreenModeEnabled({ enabled: false }));
 
                 expect(localMediaSlice.doSwitchLocalStream).toHaveBeenCalledTimes(1);
                 const after = store.getState().localMedia;
@@ -339,15 +425,17 @@ describe("actions", () => {
                         currentCameraDeviceId: dev2.deviceId,
                         cameraEnabled: true,
                         devices: [dev1, dev2],
+                        hdMode: true,
                         isSettingCameraDevice: false,
                         isSettingMicrophoneDevice: false,
                         isSettingSpeakerDevice: false,
+                        isSwitchingStream: false,
                         isTogglingCamera: false,
                         lowDataMode: false,
                         microphoneEnabled: true,
                         status: "started",
                         stream: new MockMediaStream(),
-                        isSwitchingStream: false,
+                        widescreenMode: true,
                     },
                 },
             });
@@ -415,15 +503,17 @@ describe("actions", () => {
                         currentCameraDeviceId: videoId,
                         cameraEnabled: true,
                         devices: [dev1, dev2, dev3],
+                        hdMode: true,
                         isSettingCameraDevice: false,
                         isSettingMicrophoneDevice: false,
                         isSettingSpeakerDevice: false,
+                        isSwitchingStream: false,
                         isTogglingCamera: false,
                         lowDataMode: false,
                         microphoneEnabled: true,
                         status: "started",
                         stream,
-                        isSwitchingStream: false,
+                        widescreenMode: true,
                     },
                 },
             });
@@ -470,15 +560,17 @@ describe("actions", () => {
                         busyDeviceIds: [],
                         cameraEnabled: true,
                         devices: [],
+                        hdMode: true,
                         isSettingCameraDevice: false,
                         isSettingMicrophoneDevice: false,
                         isSettingSpeakerDevice: false,
+                        isSwitchingStream: false,
                         isTogglingCamera: false,
                         lowDataMode: false,
                         microphoneEnabled: true,
                         status: "started",
                         stream,
-                        isSwitchingStream: false,
+                        widescreenMode: true,
                     },
                 },
             });
@@ -515,15 +607,17 @@ describe("actions", () => {
                         busyDeviceIds: [],
                         cameraEnabled: true,
                         devices: [],
+                        hdMode: true,
                         isSettingCameraDevice: false,
                         isSettingMicrophoneDevice: false,
                         isSettingSpeakerDevice: false,
+                        isSwitchingStream: false,
                         isTogglingCamera: false,
                         lowDataMode: false,
                         microphoneEnabled: true,
                         status: "started",
                         stream,
-                        isSwitchingStream: false,
+                        widescreenMode: true,
                     },
                 },
             });


### PR DESCRIPTION
### Description

**Summary:**

Add video hd and widescreen toggle APIs to both Core and Browser SDKs.

### Testing

- Run `pnpm build && pnpm dev`
- Connect to http://localhost:6006/?path=/story/examples-custom-ui--room-connection-with-local-media and join the room.
- Join the room in another tab as well so you can check the video stream.
- Toggle widescreen mode OFF using the "Toggle video widescreen mode" button.
- Verify that the stream width/height has a 4:3  width/height ratio when widescreen mode toggle is disabled.
- Toggle widescreen mode ON using the "Toggle video widescreen mode" button.
- Verify that the stream width/height has a 16:9 width/height ratio when widescreen mode toggle is enabled.
- Type `!stats` in the other browser tab to observe live in-call media metrics.
- Toggle hd mode OFF using the "Toggle video hd mode" button.
- Verify that the SDK client's video does not exceed 640x480 pixels in the receiving client.
- Toggle hd mode ON using the "Toggle video hd mode" button.
- Verify that the SDK client's video is greater than 640x480 pixels in the receiving client (might take a few seconds to switch).

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [x] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
