### PR TITLE
media: emit rtcstats events for SFU connection lifecycle

### DIFF
--- a/.changeset/quiet-socks-warn.md
+++ b/.changeset/quiet-socks-warn.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Emit rtcstats events for SFU connection lifecycle

--- a/packages/media/src/webrtc/VegaConnectionManager.ts
+++ b/packages/media/src/webrtc/VegaConnectionManager.ts
@@ -53,6 +53,7 @@ export function createVegaConnectionManager(config: {
     onConnected?: (vegaConnection: VegaConnection, info: ConnectionInfo) => void;
     onDisconnected?: () => void;
     onFailed?: () => void;
+    onAttemptFailed?: (info: { host: string; dc: string }) => void;
 }) {
     let connectionInfo: ConnectionInfo;
     let lastDisconnectTime: number | undefined;
@@ -257,6 +258,8 @@ export function createVegaConnectionManager(config: {
                             lastDisconnectTime = Date.now();
                             hasNotifiedDisconnect = true;
                             config.onDisconnected?.();
+                        } else {
+                            config.onAttemptFailed?.({ host, dc });
                         }
                         handleFailedOrAbortedConnection();
                     });

--- a/packages/media/src/webrtc/VegaRtcManager/index.ts
+++ b/packages/media/src/webrtc/VegaRtcManager/index.ts
@@ -370,7 +370,14 @@ export default class VegaRtcManager implements RtcManager {
     }
 
     _connect() {
-        if (this._isConnectingOrConnected) return;
+        if (this._isConnectingOrConnected) {
+            // TEMP investigation event for COB-2771 — remove once understood
+            rtcStats.sendEvent("SfuConnectEarlyBail", {
+                readyState: this._vegaConnection?.socket?.readyState,
+                bufferedAmount: this._vegaConnection?.socket?.bufferedAmount,
+            });
+            return;
+        }
 
         if (!this._serverSocket.isConnected()) {
             // Consider reconnecting to SFU within glitchfree reconnect threshold.
@@ -425,6 +432,9 @@ export default class VegaRtcManager implements RtcManager {
                     this._isConnectingOrConnected = false;
                     this._onClose();
                 },
+                onAttemptFailed: ({ host, dc }) => {
+                    rtcStats.sendEvent("SfuConnectAttemptFailed", { host, dc });
+                },
             });
         }
         this._vegaConnectionManager.connect((metric: VegaAnalyticMetric) => this.analytics[metric]++);
@@ -450,11 +460,13 @@ export default class VegaRtcManager implements RtcManager {
 
         this._qualityMonitor.close();
         this._emitToPWA(rtcManagerEvents.SFU_CONNECTION_CLOSED);
+        rtcStats.sendEvent("SfuConnectionClosed", {});
     }
 
     async _join() {
         logger.info("_join()");
         this._emitToPWA(rtcManagerEvents.SFU_CONNECTION_OPEN);
+        rtcStats.sendEvent("SfuConnectionOpened", {});
 
         try {
             if (!this._vegaConnection) {


### PR DESCRIPTION
### Description

**Summary:**

Adds rtcstats events for the SFU WebSocket lifecycle, plus a temporary investigation event on `_connect()` early bail.

**Related Issue:**

### Testing

### Screenshots/GIFs (if applicable)

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information