### PR TITLE
media: restore deviceId filter against devices list

### DIFF
--- a/.changeset/quiet-storms-return.md
+++ b/.changeset/quiet-storms-return.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Restore filtering of preferred deviceIds against the devices list in getConstraints

--- a/packages/media/src/webrtc/mediaConstraints.ts
+++ b/packages/media/src/webrtc/mediaConstraints.ts
@@ -76,10 +76,12 @@ export function getMediaConstraints({
 export default function getConstraints({ devices, videoId, audioId, options, type = "ideal" }: GetConstraintsOptions) {
     const audioDevices = devices.filter((d) => d.kind === "audioinput");
     const videoDevices = devices.filter((d) => d.kind === "videoinput");
+    const useDefaultAudio = !audioId || !audioDevices.some((d) => d.deviceId === audioId);
+    const useDefaultVideo = !videoId || !videoDevices.some((d) => d.deviceId === videoId);
     const constraints = getMediaConstraints({
         preferredDeviceIds: {
-            audioId: typeof audioId === "string" ? { [type]: audioId } : null,
-            videoId: typeof videoId === "string" ? { [type]: videoId } : null,
+            audioId: useDefaultAudio ? null : { [type]: audioId },
+            videoId: useDefaultVideo ? null : { [type]: videoId },
         },
         ...options,
     });


### PR DESCRIPTION
### Description

**Summary:**

Reverts #1022. Restores filtering of preferred deviceIds against the supplied `devices` list in `getConstraints`.

**Related Issue:**

### Testing

### Screenshots/GIFs (if applicable)

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information