### PR TITLE
browser-sdk: pass this.roomUrl.href to iframe

### DIFF
--- a/.changeset/twelve-singers-read.md
+++ b/.changeset/twelve-singers-read.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": minor
+---
+
+Pass this.roomUrl.href to iframe

--- a/packages/browser-sdk/src/lib/embed/index.ts
+++ b/packages/browser-sdk/src/lib/embed/index.ts
@@ -365,7 +365,7 @@ define("WherebyEmbed", {
       <iframe
         title=${title || "Video calling component"}
         ref=${this.iframe}
-        src=${this.roomUrl}
+        src=${this.roomUrl.href}
         allow="autoplay; camera; microphone; fullscreen; speaker; display-capture; media-capture; compute-pressure; screen-wake-lock" />
       `;
     },


### PR DESCRIPTION
### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->
Instead of passing a URL, let's pass in the href to ensure that it's a string. 

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->
1. `pnpm build && pnpm dev`
2. visit the prebuilt ui with a valid room url: http://localhost:6006/?path=/story/examples-pre-built-ui--whereby-embed-element-example
3. ensure everything loads as expected, you can inspect too and see that it's definitely a string :) 

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
