### PR TITLE
browser-sdk: Re-export getUsableCameraEffecPresets and isAudioDenoiserSupported from core

### DIFF
--- a/.changeset/grumpy-mangos-export.md
+++ b/.changeset/grumpy-mangos-export.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/browser-sdk": minor
+---
+
+Re-export `getUsableCameraEffectPresets()` and `isAudioDenoiserSupported()` from the `@whereby.com/browser-sdk/react` entry, so consumers can query camera effect and audio denoiser capabilities without depending on `@whereby.com/core` directly. Like in core, these load the underlying package on demand via dynamic import.

--- a/packages/browser-sdk/src/lib/react/index.ts
+++ b/packages/browser-sdk/src/lib/react/index.ts
@@ -10,6 +10,8 @@ export {
     ParticipantMenuTrigger,
 } from "./Grid/ParticipantMenu";
 
+export { getUsableCameraEffectPresets, isAudioDenoiserSupported } from "@whereby.com/core";
+
 export type { UseLocalMediaResult } from "./useLocalMedia/types";
 
 export type { RoomConnectionActions, RoomConnectionOptions } from "./useRoomConnection/types";

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -4,6 +4,7 @@ import DisplayNameForm from "./DisplayNameForm";
 import { UseLocalMediaResult } from "../../lib/react/useLocalMedia/types";
 import { useRoomConnection } from "../../lib/react/useRoomConnection";
 import { VideoView } from "../../lib/react/VideoView";
+import { getUsableCameraEffectPresets, isAudioDenoiserSupported } from "../../lib/react";
 import {
     ChatMessageEvent,
     RequestAudioEvent,
@@ -11,8 +12,6 @@ import {
     StickyReactionEvent,
     NotificationEvents,
     RequestVideoEvent,
-    getUsableCameraEffectPresets,
-    isAudioDenoiserSupported,
 } from "@whereby.com/core";
 
 export default function VideoExperience({

--- a/packages/browser-sdk/src/stories/custom-ui.stories.tsx
+++ b/packages/browser-sdk/src/stories/custom-ui.stories.tsx
@@ -1,8 +1,14 @@
 import React, { useCallback, useState, useEffect } from "react";
-import { useLocalMedia, UseLocalMediaResult, useRoomConnection, VideoView } from "../lib/react";
+import {
+    useLocalMedia,
+    UseLocalMediaResult,
+    useRoomConnection,
+    VideoView,
+    getUsableCameraEffectPresets,
+} from "../lib/react";
 import PrecallExperience from "./components/PrecallExperience";
 import VideoExperience from "./components/VideoExperience";
-import { getFakeMediaStream, getUsableCameraEffectPresets } from "@whereby.com/core";
+import { getFakeMediaStream } from "@whereby.com/core";
 import "./styles.css";
 import Grid from "./components/Grid";
 import { Provider as WherebyProvider } from "../lib/react/Provider";


### PR DESCRIPTION
### Description
Re-exporting so consumers of browser-sdk won't need to call core directly.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [ ] My code follows the project's coding standards.
-   [ ] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [ ] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
