### PR TITLE
core: decode roomName doAppStart

### DIFF
--- a/.changeset/wise-socks-enter.md
+++ b/.changeset/wise-socks-enter.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": minor
+---
+
+Decode roomUrl on doAppStart

--- a/packages/core/src/redux/slices/__tests__/app.unit.ts
+++ b/packages/core/src/redux/slices/__tests__/app.unit.ts
@@ -63,6 +63,88 @@ describe("appSlice", () => {
                     userAgent: "core:__PKG_VERSION__",
                 });
             });
+
+            it("should decode an encoded roomName", () => {
+                const initialConfig = {
+                    isNodeSdk: true,
+                    roomUrl: "https://some.url/r%C3%B6omname",
+                    roomKey: "roomKey",
+                    displayName: "displayName",
+                    externalId: "externalId",
+                };
+                const result = appSlice.reducer(undefined, appSlice.actions.doAppStart(initialConfig));
+
+                expect(result).toEqual({
+                    displayName: "displayName",
+                    externalId: "externalId",
+                    ignoreBreakoutGroups: false,
+                    initialConfig,
+                    isActive: true,
+                    isAssistant: false,
+                    isAudioRecorder: false,
+                    isDialIn: false,
+                    isNodeSdk: true,
+                    roomKey: "roomKey",
+                    roomName: "/röomname",
+                    roomUrl: "https://some.url/r%C3%B6omname",
+                    userAgent: "core:__PKG_VERSION__",
+                });
+            });
+
+            it("should leave an unencoded roomUrl unchanged", () => {
+                const initialConfig = {
+                    isNodeSdk: true,
+                    roomUrl: "https://some.url/roomname",
+                    roomKey: "roomKey",
+                    displayName: "displayName",
+                    externalId: "externalId",
+                };
+                const result = appSlice.reducer(undefined, appSlice.actions.doAppStart(initialConfig));
+
+                expect(result).toEqual({
+                    displayName: "displayName",
+                    externalId: "externalId",
+                    ignoreBreakoutGroups: false,
+                    initialConfig,
+                    isActive: true,
+                    isAssistant: false,
+                    isAudioRecorder: false,
+                    isDialIn: false,
+                    isNodeSdk: true,
+                    roomKey: "roomKey",
+                    roomName: "/roomname",
+                    roomUrl: "https://some.url/roomname",
+                    userAgent: "core:__PKG_VERSION__",
+                });
+            });
+
+            it("should return the original url if roomUrl contains a malformed URI", () => {
+                const initialConfig = {
+                    isNodeSdk: true,
+                    roomUrl: "https://some.url/%E0%A4%A",
+                    roomKey: "roomKey",
+                    displayName: "displayName",
+                    externalId: "externalId",
+                };
+
+                const result = appSlice.reducer(undefined, appSlice.actions.doAppStart(initialConfig));
+
+                expect(result).toEqual({
+                    displayName: "displayName",
+                    externalId: "externalId",
+                    ignoreBreakoutGroups: false,
+                    initialConfig,
+                    isActive: true,
+                    isAssistant: false,
+                    isAudioRecorder: false,
+                    isDialIn: false,
+                    isNodeSdk: true,
+                    roomKey: "roomKey",
+                    roomName: "/%E0%A4%A",
+                    roomUrl: "https://some.url/%E0%A4%A",
+                    userAgent: "core:__PKG_VERSION__",
+                });
+            });
         });
     });
 });

--- a/packages/core/src/redux/slices/app.ts
+++ b/packages/core/src/redux/slices/app.ts
@@ -2,6 +2,7 @@ import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { RootState } from "../store";
 import type { LocalMediaOptions } from "./localMedia";
 import { coreVersion } from "../../version";
+import decodeRoomName from "../../utils/decodeRoomName";
 
 /**
  * Reducer
@@ -60,7 +61,7 @@ export const appSlice = createSlice({
             return {
                 ...state,
                 ...action.payload,
-                roomName: url.pathname,
+                roomName: decodeRoomName(url.pathname),
                 initialConfig: { ...action.payload },
                 isActive: true,
                 isAssistant: Boolean(action.payload.assistantKey),

--- a/packages/core/src/utils/__tests__/decodeRoomName.spec.ts
+++ b/packages/core/src/utils/__tests__/decodeRoomName.spec.ts
@@ -1,0 +1,18 @@
+import decodeRoomName from "../decodeRoomName";
+
+describe(`decode path`, () => {
+    it(`should return the roomName decoded`, () => {
+        const result = decodeRoomName("/some%20roomname");
+        expect(result).toEqual(`/some roomname`);
+    });
+
+    it(`should return null if roomName is null`, () => {
+        const result = decodeRoomName(null);
+        expect(result).toEqual(null);
+    });
+
+    it(`should return the original roomName if it cannot be decoded`, () => {
+        const result = decodeRoomName("some%roomname");
+        expect(result).toEqual(`some%roomname`);
+    });
+});

--- a/packages/core/src/utils/decodeRoomName.ts
+++ b/packages/core/src/utils/decodeRoomName.ts
@@ -1,0 +1,10 @@
+export default function decodeRoomName(roomName: string | null): string | null {
+    if (!roomName) {
+        return null;
+    }
+    try {
+        return decodeURIComponent(roomName);
+    } catch {
+        return roomName;
+    }
+}


### PR DESCRIPTION
### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

In order to support rooms with special characters in the name, we need to do some decoding on `roomUrl`. This prevents clients trying to join rooms with the encoded URL, which technically is a non-existing room. 

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

Test instructions here: https://github.com/whereby/recording-service/pull/1096

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
