### PR TITLE
camera-effects: dedupe in-flight tflite wasm and model loads

### DIFF
--- a/.changeset/shiny-doodles-wear.md
+++ b/.changeset/shiny-doodles-wear.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/camera-effects": patch
+---
+
+Dedupe the in-flight tflite wasm loads so concurrent `createEffectStream` calls share a single fetch instead of each starting their own.

--- a/.changeset/shiny-doodles-wear.md
+++ b/.changeset/shiny-doodles-wear.md
@@ -2,4 +2,4 @@
 "@whereby.com/camera-effects": patch
 ---
 
-Dedupe the in-flight tflite wasm loads so concurrent `createEffectStream` calls share a single fetch instead of each starting their own.
+Dedupe the in-flight tflite wasm and segmentation model loads so concurrent `createEffectStream` calls share a single fetch instead of each starting their own.

--- a/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/segmentationModel.ts
+++ b/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/segmentationModel.ts
@@ -103,40 +103,60 @@ const loadTFLite = () => {
     return _tflitePromise;
 };
 
-let _currentModelAndInfo;
+let _modelPromise = null;
+let _modelPromiseUrl = null;
+
 export const loadSegmentationModel = async (segmentationModelId) => {
     const model = models[segmentationModelId];
     const modelUrl = resolveAssetUrl(await getModelUrl(model.id));
-    const tflite = await loadTFLite();
-    if (_currentModelAndInfo?.url === modelUrl) return _currentModelAndInfo; // only load model once
 
-    // fetch model
-    const modelResponse = await fetch(modelUrl);
-    const modelBuffer = await modelResponse.arrayBuffer();
-    // copy model to tflite and initialize
-    const modelBufferOffset = tflite._getModelBufferMemoryOffset();
-    tflite.HEAPU8.set(new Uint8Array(modelBuffer), modelBufferOffset);
-    tflite._loadModel(modelBuffer.byteLength);
-    // info
-    const inputHeight = tflite._getInputHeight();
-    const inputWidth = tflite._getInputWidth();
-    // TFLite memory will be accessed as float32
-    const inputMemoryOffset = tflite._getInputMemoryOffset() / 4;
-    const outputMemoryOffset = tflite._getOutputMemoryOffset() / 4;
-    const segmentationPixelCount = inputWidth * inputHeight;
+    // Cache the in-flight promise (keyed by model URL), not just the resolved value, so concurrent
+    // callers share a single load. Otherwise overlapping calls each fetch the model and write it into
+    // the shared tflite heap.
+    if (_modelPromiseUrl === modelUrl && _modelPromise) return _modelPromise;
 
-    // we run the model once to allow js engine optimizations?
-    tflite._runInference();
+    _modelPromiseUrl = modelUrl;
+    _modelPromise = (async () => {
+        try {
+            const tflite = await loadTFLite();
 
-    _currentModelAndInfo = {
-        tflite,
-        model,
-        url: modelUrl,
-        inputHeight,
-        inputWidth,
-        inputMemoryOffset,
-        outputMemoryOffset,
-        segmentationPixelCount,
-    };
-    return _currentModelAndInfo;
+            // fetch model
+            const modelResponse = await fetch(modelUrl);
+            const modelBuffer = await modelResponse.arrayBuffer();
+            // copy model to tflite and initialize
+            const modelBufferOffset = tflite._getModelBufferMemoryOffset();
+            tflite.HEAPU8.set(new Uint8Array(modelBuffer), modelBufferOffset);
+            tflite._loadModel(modelBuffer.byteLength);
+            // info
+            const inputHeight = tflite._getInputHeight();
+            const inputWidth = tflite._getInputWidth();
+            // TFLite memory will be accessed as float32
+            const inputMemoryOffset = tflite._getInputMemoryOffset() / 4;
+            const outputMemoryOffset = tflite._getOutputMemoryOffset() / 4;
+            const segmentationPixelCount = inputWidth * inputHeight;
+
+            // we run the model once to allow js engine optimizations?
+            tflite._runInference();
+
+            return {
+                tflite,
+                model,
+                url: modelUrl,
+                inputHeight,
+                inputWidth,
+                inputMemoryOffset,
+                outputMemoryOffset,
+                segmentationPixelCount,
+            };
+        } catch (err) {
+            // Don't cache a failed load, so a later call can retry (unless a newer model already replaced it).
+            if (_modelPromiseUrl === modelUrl) {
+                _modelPromise = null;
+                _modelPromiseUrl = null;
+            }
+            throw err;
+        }
+    })();
+
+    return _modelPromise;
 };

--- a/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/segmentationModel.ts
+++ b/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/segmentationModel.ts
@@ -70,25 +70,37 @@ const models = {
     },
 };
 
-let _tflite = null;
+let _tflitePromise = null;
 
-const loadTFLite = async () => {
-    if (_tflite) return _tflite;
-    const simdIsSupported = await simd();
+const loadTFLite = () => {
+    // Cache the in-flight promise, not just the resolved value, so concurrent callers share a single
+    // load. Otherwise overlapping calls (e.g. switching effects rapidly on a slow connection) each
+    // start their own wasm fetch before the first one resolves.
+    if (_tflitePromise) return _tflitePromise;
 
-    const createTfliteModule = await loadTfliteModule(simdIsSupported);
-    const wasmUrl = await getWasmUrl(simdIsSupported);
+    _tflitePromise = (async () => {
+        try {
+            const simdIsSupported = await simd();
 
-    _tflite = await createTfliteModule({
-        locateFile(path) {
-            if (path.endsWith(".wasm")) {
-                return resolveAssetUrl(wasmUrl);
-            }
-            return path;
-        },
-    });
+            const createTfliteModule = await loadTfliteModule(simdIsSupported);
+            const wasmUrl = await getWasmUrl(simdIsSupported);
 
-    return _tflite;
+            return await createTfliteModule({
+                locateFile(path) {
+                    if (path.endsWith(".wasm")) {
+                        return resolveAssetUrl(wasmUrl);
+                    }
+                    return path;
+                },
+            });
+        } catch (err) {
+            // Don't cache a failed load, so a later call can retry.
+            _tflitePromise = null;
+            throw err;
+        }
+    })();
+
+    return _tflitePromise;
 };
 
 let _currentModelAndInfo;


### PR DESCRIPTION
### Description

**Summary:**

`loadTFLite` and `loadSegmentationModel` cached the resolved module rather than the in-flight promise, so overlapping `createEffectStream` calls (e.g. switching effects rapidly on a slow connection) each started their own `tflite-simd.wasm` / segmentation model fetch before the first resolved. Cache the promise instead, and reset it on failure so a later attempt can retry.

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

1. Join the room with no camera effects selected on slow 3g network and devtools network tab open
2. Open the camera effects settings panel
3. Select light blur effect, then quickly strong blur, then light blur again => there should be just 1 `tflite-simd.wasm` and 1 `segm_lite_*.tlite` fetch request in the devtools network tab

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
