### PR TITLE
camera-effects: guard updateParams against running after terminate

### DIFF
--- a/.changeset/twenty-sheep-arrive.md
+++ b/.changeset/twenty-sheep-arrive.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/camera-effects": patch
+---
+
+Guard `Processor.updateParams` against running after the processor was terminated, so a stale or in-flight update no longer dereferences a null engine.

--- a/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/Processor.ts
+++ b/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/Processor.ts
@@ -144,6 +144,12 @@ class Processor extends EventEmitter {
 
     // updates params for adjusting or achieving a different effect
     updateParams({ params, initialBackgroundFrame }) {
+        // The engine is disposed on terminate(). updateParams can still arrive
+        // afterwards (e.g. an async update that was in flight when the effect
+        // was stopped, or a stale reference held by the caller) so bail
+        // instead of dereferencing a null engine.
+        if (this._terminated || !this.engine) return;
+
         this.params = params;
 
         // reset background in case it has changed


### PR DESCRIPTION
### Description

**Summary:**

`this.engine` is disposed (set to null) on `terminate()`, but `updateParams` could still run afterwards (e.g. an async update in flight when the effect was stopped, or a stale reference held by the caller) throwing "can't access property updateBackgroundFrame, this.engine is null". Bail early when the processor is already terminated.

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

1. Open camera effects in pwa
2. Throttle your CPU by 20x, keep your browser console open
3. Quickly switch back and forth between the bg image, blur and no effect options => there should be no `can't access property "updateBackgroundFrame", this.engine is null` error in the console, effects should work (but switch could be slow due to the CPU throttling 🤓 )

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
