### PR TITLE
media: Adds quality issue tracking

### DIFF
--- a/.changeset/free-camels-decide.md
+++ b/.changeset/free-camels-decide.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": minor
+---
+
+media: Adds media quality tracking

--- a/packages/media/src/webrtc/P2pRtcManager.ts
+++ b/packages/media/src/webrtc/P2pRtcManager.ts
@@ -28,6 +28,7 @@ import {
 import { ClearableTimeout, ScreenshareStoppedEvent, ServerSocket, sortCodecs, trackAnnotations } from "../utils";
 import { maybeTurnOnly, external_stun_servers, turnServerOverride } from "../utils/iceServers";
 import getConstraints from "./mediaConstraints";
+import { updateRenderedDimensions } from "./stats/StatsMonitor";
 
 interface CreateSessionOptions {
     clientId: string;
@@ -128,6 +129,7 @@ export default class P2pRtcManager implements RtcManager {
     analytics: P2PAnalytics;
     _rtcStatsDisconnectTimeout?: ReturnType<typeof setTimeout>;
     _webcamPaused?: boolean;
+    _videoTrackIdByStreamId: Record<string, string>;
 
     constructor({ selfId, room, emitter, serverSocket, webrtcProvider, features }: RtcManagerOptions) {
         const { name, session, iceServers, turnServers, mediaserverConfigTtlSeconds } = room;
@@ -145,6 +147,7 @@ export default class P2pRtcManager implements RtcManager {
         this._features = features || {};
         this._isAudioOnlyMode = false;
         this._closed = false;
+        this._videoTrackIdByStreamId = {};
 
         // Timeouts
         this._fetchMediaServersTimer = null;
@@ -744,6 +747,7 @@ export default class P2pRtcManager implements RtcManager {
                 });
                 return;
             }
+            if (event.track.kind === "video") this._videoTrackIdByStreamId[stream.id] = event.track.id;
             if (session.streamIds.indexOf(stream.id) === -1) {
                 session.streamIds.push(stream.id);
                 this._emit(CONNECTION_STATUS.EVENTS.STREAM_ADDED as string, {
@@ -1292,7 +1296,20 @@ export default class P2pRtcManager implements RtcManager {
     }
 
     // this does not (currently) make sense for peer-to-peer connections
-    updateStreamResolution(/* streamId, clientId, resolution */) {}
+    updateStreamResolution(
+        streamId: string,
+        _ignored: any,
+        {
+            width,
+            height,
+        }: {
+            width: number;
+            height: number;
+        },
+    ) {
+        const trackId = this._videoTrackIdByStreamId[streamId];
+        if (trackId) updateRenderedDimensions(trackId, { width, height, time: Date.now() });
+    }
 
     stopOrResumeAudio(/*localStream, enable*/) {
         // detaches the audio from the peerconnection. No-op in P2P mode.

--- a/packages/media/src/webrtc/VegaRtcManager/index.ts
+++ b/packages/media/src/webrtc/VegaRtcManager/index.ts
@@ -26,6 +26,7 @@ import { addProducerCpuOveruseWatch, getLayers, getNumberOfActiveVideos, getNumb
 import { ClearableTimeout, ServerSocket, trackAnnotations } from "../../utils";
 import { createVegaConnectionManager, HostListEntryOptionalDC } from "../VegaConnectionManager";
 import { RtpCapabilities } from "mediasoup-client/lib/RtpParameters";
+import { updateRenderedDimensions } from "../stats/StatsMonitor";
 import {
     VegaCreateTransportResponse,
     VegaGetCapabilitiesResponse,
@@ -1747,6 +1748,7 @@ export default class VegaRtcManager implements RtcManager {
             this._streamIdToVideoResolution.set(streamId, { width, height });
             return;
         }
+        updateRenderedDimensions(consumer.track?.id, { width, height, time: Date.now() });
 
         const numberOfActiveVideos = getNumberOfActiveVideos(this._consumers);
         const numberOfTemporalLayers = getNumberOfTemporalLayers(consumer);

--- a/packages/media/src/webrtc/stats/IssueMonitor/index.ts
+++ b/packages/media/src/webrtc/stats/IssueMonitor/index.ts
@@ -1,6 +1,6 @@
 import { IssueCheckData, IssueDetector, issueDetectors } from "./issueDetectors";
 import { subscribeStats } from "../StatsMonitor";
-import { StatsClient, ViewStats } from "../types";
+import { RenderedDimensionsReport, StatsClient, ViewStats } from "../types";
 
 type IssueSubscription = {
     onUpdatedIssues: (
@@ -275,7 +275,11 @@ export function issueDetectorOrMetricEnabled(issueDetectorOrMetric: IssueDetecto
     return enabled && (issueDetectorOrMetric.enabled ? issueDetectorOrMetric.enabled(checkData) : true);
 }
 
-function onUpdatedStats(statsByView: Record<string, ViewStats>, clients: StatsClient[]) {
+function onUpdatedStats(
+    statsByView: Record<string, ViewStats>,
+    clients: StatsClient[],
+    renderedDimensionsByTrack: Record<string, RenderedDimensionsReport>,
+) {
     // reset aggregated current metrics
     Object.values(aggregatedMetrics).forEach((metricData: MetricDataAggregated) => {
         metricData.curTicks = 0;
@@ -325,6 +329,7 @@ function onUpdatedStats(statsByView: Record<string, ViewStats>, clients: StatsCl
                 kind,
                 track,
                 trackStats,
+                renderedDimensions: track?.id ? renderedDimensionsByTrack[track.id] : undefined,
                 stats,
                 hasLiveTrack,
                 ssrc0,

--- a/packages/media/src/webrtc/stats/IssueMonitor/issueDetectors.ts
+++ b/packages/media/src/webrtc/stats/IssueMonitor/issueDetectors.ts
@@ -1,5 +1,13 @@
-import { MediaStreamTrackWithDenoiserContext, SsrcStats, StatsClient, TrackStats, ViewStats } from "../types";
+import {
+    MediaStreamTrackWithDenoiserContext,
+    RenderedDimensionsReport,
+    SsrcStats,
+    StatsClient,
+    TrackStats,
+    ViewStats,
+} from "../types";
 import { getRoomMode } from "../../RtcManagerDispatcher";
+import { qualityCriticalDetector, qualityWarningDetector } from "./qualityDetectors";
 
 export interface IssueDetector {
     id: string;
@@ -13,6 +21,7 @@ export interface IssueCheckData {
     clients: StatsClient[];
     kind: string;
     track: MediaStreamTrack | MediaStreamTrackWithDenoiserContext | undefined;
+    renderedDimensions?: RenderedDimensionsReport;
     trackStats?: TrackStats;
     stats?: ViewStats;
     hasLiveTrack: boolean;
@@ -290,6 +299,8 @@ export const issueDetectors: IssueDetector[] = [
             (ssrc0.audioLevel || 0) >= 0.001 &&
             (ssrc0.audioAcceleration || 0) >= 0.1,
     },
+    qualityWarningDetector,
+    qualityCriticalDetector,
     // todo:
     // jitter/congestion - increasing jitter for several "ticks"
     // encodeTime?

--- a/packages/media/src/webrtc/stats/IssueMonitor/qualityDetectors.ts
+++ b/packages/media/src/webrtc/stats/IssueMonitor/qualityDetectors.ts
@@ -1,0 +1,118 @@
+import { IssueDetector } from "./issueDetectors";
+
+const createQualityDetector = (type: "warning" | "critical") => {
+    return {
+        id: `quality-${type}`,
+        // we're ignoring screenshares and outgoing streams for now
+        enabled: ({ client }) => !client.isLocalClient && !client.isPresentation,
+        check: ({ ssrc0, renderedDimensions, hasLiveTrack, kind }) => {
+            // if there are no track, or no bitrate, we mark as quality issue
+            // the client of these issues can ignore setup time for new videos by ignoring initial ticks
+            if (!hasLiveTrack) return true;
+            if (!ssrc0) return true;
+            if (!ssrc0.bitrate) return true;
+
+            // for incoming video we look at resolution, framerate, freezes and bitrate to detect quality issues
+            if (kind === "video") {
+                if (renderedDimensions && renderedDimensions.width && renderedDimensions.height) {
+                    const maxSideRendered = Math.max(renderedDimensions.width, renderedDimensions.height);
+                    const maxSideReceived = Math.max(ssrc0.width || 0, ssrc0.height || 0);
+
+                    const fpsReceived = ssrc0.fps || 0;
+
+                    // metrics/issue collection is run every 2s.
+                    // we expect a framerate of at least 24fps for normal operation
+                    // but consider 15 as the limit, as it is very common for many webcams to send 15fps in dim lightning
+                    // a half second glitch/freeze in 30fps would result in a max calculated framerate of
+                    // 26fps (since half of the lost frames might belong to previous sample)
+                    // so it is not enough to look at framerate
+
+                    // any number of freezes during interval we consider a freeze
+                    // according to webrtc spec it is counted when it lasts for 3 or more frames considering
+                    // current average framerate
+                    //
+                    // a freeze may start in previous sample and continue in next - and we assume
+                    // we don't need to do anything special to detect 1 continous long freeze
+                    // spanning multiple samples, as then it should show on framerate
+                    const hadFreeze = !!ssrc0.freezeRate;
+
+                    // even with good resolution+framerate, and no freezes, there can still be heavy compression
+                    // we choose to verify the bitrate is at least above a low threshold for this.
+                    // the qpSum in webrtc varies by codec, and possibly by content (lots of details changing),
+                    // so we're not using it for now.
+                    // we assume webrtc will use available bitrate even if sending video with little detail
+                    const bitrate = ssrc0.bitrate || 0;
+
+                    // targets minimum tile size (current max 80x80 in pwa?)
+                    if (maxSideRendered < 100) {
+                        // we expect lowest layer here, but accept a bit lower
+                        // we expect 50% framerate, but even lower is ok when rendering as a tile
+                        // we don't care about freezes that doesn't affect framerate
+
+                        if (type === "warning" && maxSideReceived < 160) return true;
+                        if (type === "critical" && maxSideReceived < 90) return true;
+
+                        if (type === "warning" && fpsReceived < 5) return true;
+                        if (type === "critical" && fpsReceived < 2) return true;
+
+                        if (type === "warning" && bitrate < 10000) return true;
+                        if (type === "critical" && bitrate < 5000) return true;
+                    } else if (maxSideRendered < 480) {
+                        // we expect lowest layer also here
+                        // but here we care more about the quality and freezes
+                        if (type === "warning" && maxSideReceived < 240) return true;
+                        if (type === "critical" && maxSideReceived < 120) return true;
+
+                        if (type === "warning" && fpsReceived < 14) return true;
+                        if (type === "critical" && fpsReceived < 9) return true;
+
+                        if (hadFreeze) return true;
+
+                        if (type === "warning" && bitrate < 50000) return true;
+                        if (type === "critical" && bitrate < 20000) return true;
+                    } else {
+                        // we expect middle or high resolution here
+                        // we don't consider it a quality issue if receiving middle resolution
+                        if (type === "warning" && maxSideReceived < 480) return true;
+                        if (type === "critical" && maxSideReceived < 240) return true;
+
+                        if (type === "warning" && fpsReceived < 14) return true;
+                        if (type === "critical" && fpsReceived < 9) return true;
+
+                        if (type === "warning" && bitrate < 200000) return true;
+                        if (type === "critical" && bitrate < 50000) return true;
+
+                        if (hadFreeze) return true;
+                    }
+                }
+            } else if (kind === "audio") {
+                // for audio we only consider distortion above thresholds as quality issue
+                // bitrate might be close to 0 because of dtx, so we don't care about it
+                // probably no way to detect crappy audio source without using ML
+
+                const audioLevel = ssrc0.audioLevel || 0;
+                const concealment = ssrc0.audioConcealment || 0;
+                const acceleration = ssrc0.audioAcceleration || 0;
+                const deceleration = ssrc0.audioDeceleration || 0;
+                const audioDistortion = concealment + acceleration + deceleration;
+
+                // how much distortion is noticeable? some say anything above 5% may.
+                // some say it varies, samples in a row is worse than samples inbetween
+                // modern versions using ML may handle it better then old etc.
+                // testing at 5% it feels a bit trigger happy on packetloss that isn't affecting video
+                // we try 10% for warning, 20% for critical
+
+                // we only care if there is audio level
+                if (audioLevel >= 0.01) {
+                    if (type === "warning" && audioDistortion > 0.1) return true;
+                    if (type === "critical" && audioDistortion > 0.2) return true;
+                }
+            }
+
+            return false;
+        },
+    } as IssueDetector;
+};
+
+export const qualityWarningDetector = createQualityDetector("warning");
+export const qualityCriticalDetector = createQualityDetector("critical");

--- a/packages/media/src/webrtc/stats/StatsMonitor/__tests__/index.spec.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/__tests__/index.spec.ts
@@ -19,6 +19,7 @@ describe("subscribeStats", () => {
             statsByView: {},
             subscriptions: [],
             numFailedStatsReports: 0,
+            renderedDimensionsByTrack: {},
         };
         options = { interval: 2000, logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() } };
     });

--- a/packages/media/src/webrtc/stats/StatsMonitor/collectStats.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/collectStats.ts
@@ -8,7 +8,7 @@ import {
 } from "./metrics";
 import { getPeerConnectionsWithStatsReports } from "./peerConnection";
 import { getPeerConnectionIndex, removePeerConnection } from "./peerConnectionTracker";
-import { StatsClient, ViewStats } from "../types";
+import { RenderedDimensionsReport, StatsClient, ViewStats } from "../types";
 import rtcStats from "../../rtcStatsService";
 
 const getOrCreateSsrcMetricsContainer = (
@@ -44,14 +44,20 @@ const getOrCreateSsrcMetricsContainer = (
     return ssrcStats;
 };
 
-const removeNonUpdatedStats = (statsByView: Record<string, ViewStats>, time: number) => {
+const removeNonUpdatedStats = (
+    statsByView: Record<string, ViewStats>,
+    time: number,
+    renderedDimensionsByTrack: Record<string, RenderedDimensionsReport>,
+) => {
     Object.entries(statsByView).forEach(([viewId, viewStats]) => {
         if (viewStats.updated !== undefined && viewStats.updated < time) {
+            Object.keys(viewStats.tracks).forEach((trackId) => delete renderedDimensionsByTrack[trackId]);
             delete statsByView[viewId];
         } else {
             Object.entries(viewStats.tracks).forEach(([trackId, trackStats]) => {
                 if (trackStats.updated < time) {
                     delete viewStats.tracks[trackId];
+                    delete renderedDimensionsByTrack[trackId];
                 } else {
                     Object.entries(trackStats.ssrcs).forEach(([ssrc, ssrcStats]) => {
                         if (ssrcStats.updated < time) {
@@ -101,7 +107,9 @@ export async function collectStats(
         const timeSinceLastUpdate = Date.now() - state.lastUpdateTime;
         if (timeSinceLastUpdate < 400) {
             if (immediate) return state.statsByView;
-            state.subscriptions.forEach((subscription) => subscription.onUpdatedStats?.(state.statsByView, clients));
+            state.subscriptions.forEach((subscription) =>
+                subscription.onUpdatedStats?.(state.statsByView, clients, state.renderedDimensionsByTrack),
+            );
             state.nextTimeout = setTimeout(collectStatsBound, interval);
             return;
         }
@@ -241,7 +249,7 @@ export async function collectStats(
                 });
         });
 
-        removeNonUpdatedStats(state.statsByView, state.lastUpdateTime);
+        removeNonUpdatedStats(state.statsByView, state.lastUpdateTime, state.renderedDimensionsByTrack);
 
         // mark candidatepairs as active/inactive
         Object.entries(defaultViewStats?.candidatePairs || {}).forEach(([cpKey, cp]) => {
@@ -262,7 +270,9 @@ export async function collectStats(
         if (immediate) {
             return state.statsByView;
         } else {
-            state.subscriptions.forEach((subscription) => subscription.onUpdatedStats?.(state.statsByView, clients));
+            state.subscriptions.forEach((subscription) =>
+                subscription.onUpdatedStats?.(state.statsByView, clients, state.renderedDimensionsByTrack),
+            );
         }
     } catch (e: any) {
         logger.warn(e);

--- a/packages/media/src/webrtc/stats/StatsMonitor/index.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/index.ts
@@ -2,7 +2,7 @@ import { collectStats } from "./collectStats";
 import { PressureObserver, startCpuObserver } from "./cpuObserver";
 import { numFailedTrackSsrcLookups, numMissingTrackSsrcLookups } from "./peerConnection";
 
-import { PressureRecord, StatsClient, ViewStats } from "../types";
+import { PressureRecord, StatsClient, ViewStats, RenderedDimensionsReport } from "../types";
 import Logger from "../../../utils/Logger";
 
 interface StatsMonitor {
@@ -11,7 +11,11 @@ interface StatsMonitor {
 }
 
 export interface StatsSubscription {
-    onUpdatedStats: (statsByView: Record<string, ViewStats>, clients: StatsClient[]) => void;
+    onUpdatedStats: (
+        statsByView: Record<string, ViewStats>,
+        clients: StatsClient[],
+        renderedDimensionsByTrack: Record<string, RenderedDimensionsReport>,
+    ) => void;
 }
 
 export interface StatsMonitorState {
@@ -21,6 +25,7 @@ export interface StatsMonitorState {
     lastUpdateTime: number;
     nextTimeout?: number;
     pressureObserver?: PressureObserver;
+    renderedDimensionsByTrack: Record<string, RenderedDimensionsReport>;
     statsByView: Record<string, ViewStats>;
     subscriptions: StatsSubscription[];
     numFailedStatsReports: number;
@@ -35,6 +40,7 @@ const STATE: StatsMonitorState = {
     currentMonitor: null,
     getClients: () => [],
     lastUpdateTime: 0,
+    renderedDimensionsByTrack: {},
     statsByView: {},
     subscriptions: [],
     numFailedStatsReports: 0,
@@ -58,6 +64,10 @@ export const getNumFailedTrackSsrcLookups = () => numFailedTrackSsrcLookups;
 export const getUpdatedStats = () => STATE.currentMonitor?.getUpdatedStats();
 
 export const setClientProvider = (provider: () => StatsClient[]) => (STATE.getClients = provider);
+
+export const updateRenderedDimensions = (trackId: string, data: RenderedDimensionsReport) => {
+    STATE.renderedDimensionsByTrack[trackId] = data;
+};
 
 function startStatsMonitor(state: StatsMonitorState, { interval, logger }: StatsMonitorOptions) {
     const collectStatsBound = collectStats.bind(null, state, { interval, logger });

--- a/packages/media/src/webrtc/stats/StatsMonitor/metrics.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/metrics.ts
@@ -215,6 +215,9 @@ export function captureVideoSsrcMetrics(
         const qpsumDiff = currentSsrcStats.qpSum - (prevSsrcStats?.qpSum || 0);
         ssrcMetrics.qpf = qpsumDiff / frameCountDiff;
         ssrcMetrics.fps = (frameCountDiff * 1000) / timeDiff;
+
+        const freezeCountDiff = (currentSsrcStats.freezeCount || 0) - (prevSsrcStats?.freezeCount || 0);
+        ssrcMetrics.freezeRate = (freezeCountDiff * 1000) / timeDiff;
     } else {
         const kfCountDiff = currentSsrcStats.keyFramesEncoded - (prevSsrcStats?.keyFramesEncoded || 0);
 

--- a/packages/media/src/webrtc/stats/types.ts
+++ b/packages/media/src/webrtc/stats/types.ts
@@ -27,10 +27,17 @@ export type PressureRecord = {
     time: number;
 };
 
+export type RenderedDimensionsReport = {
+    time: number;
+    width: number;
+    height: number;
+};
+
 export interface TrackStats {
     startTime: number;
     updated: number;
     ssrcs: Record<string, SsrcStats>;
+    renderedDimensions?: RenderedDimensionsReport;
 }
 
 export interface ViewStats {
@@ -96,6 +103,7 @@ export interface SsrcStats {
     encodeTime?: number;
     sourceWidth?: number;
     sourceFps?: number;
+    freezeRate?: number;
 }
 
 export type PCData = {


### PR DESCRIPTION
### Description

This adds issues for media quality (warning+critical), for driving quality indicators and stats.
It forwards resolution reports to the issue monitor, and adds a freezeRate metric for detecting freezes.
The calculation/thresholds probably needs to be tweaked as we test/learn more.

Currently only for remote streams, and no presentations. 
```
rem-cam-audio-quality-warning
rem-cam-audio-quality-critical
rem-cam-video-quality-warning
rem-cam-video-quality-critical
```

