### PR TITLE
media: remove P2P addTrack investigation metrics

### DIFF
--- a/.changeset/warm-poems-rest.md
+++ b/.changeset/warm-poems-rest.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Remove P2P addTrack investigation metrics

--- a/packages/media/src/webrtc/P2pRtcManager.ts
+++ b/packages/media/src/webrtc/P2pRtcManager.ts
@@ -84,8 +84,6 @@ type P2PAnalytics = {
     P2PMicNotWorking: number;
     P2PLocalNetworkFailed: number;
     P2PRelayedIceCandidate: number;
-    P2PSessionAddTrack: number;
-    P2PAddTrackToPeerConnections: number;
     P2PAddIceCandidateFailure: number;
 };
 
@@ -201,8 +199,6 @@ export default class P2pRtcManager implements RtcManager {
             P2PMicNotWorking: 0,
             P2PLocalNetworkFailed: 0,
             P2PRelayedIceCandidate: 0,
-            P2PSessionAddTrack: 0,
-            P2PAddTrackToPeerConnections: 0,
             P2PAddIceCandidateFailure: 0,
         };
     }
@@ -935,12 +931,6 @@ export default class P2pRtcManager implements RtcManager {
     }
 
     _addTrackToPeerConnections(track: MediaStreamTrack) {
-        this.analytics.P2PAddTrackToPeerConnections++;
-        rtcStats.sendEvent("P2PAddTrackToPeerConnections", {
-            trackId: track.id,
-            kind: track.kind,
-            readyState: track.readyState,
-        });
         this._forEachPeerConnection((session: Session) => {
             this._withForcedRenegotiation(session, () => session.addTrack(track));
         });

--- a/packages/media/src/webrtc/Session.ts
+++ b/packages/media/src/webrtc/Session.ts
@@ -126,15 +126,6 @@ export default class Session {
 
         const stream = this.streams[0];
 
-        this._incrementAnalyticMetric("P2PSessionAddTrack");
-        rtcStats.sendEvent("P2PSessionAddTrack", {
-            trackId: track.id,
-            kind: track.kind,
-            hasSessionStream: !!stream,
-            trackOfSameKindInStream: !!stream?.getTracks().filter((t) => t.kind === track.kind && t.id !== track.id)
-                .length,
-        });
-
         // TODO: remove responsibility to add track from Session.
         stream?.addTrack(track);
 


### PR DESCRIPTION
### Description

**Summary:**

Remove the `P2PSessionAddTrack` and `P2PAddTrackToPeerConnections` analytics counters and their rtcstats events.

**Related Issue:**

### Testing

### Screenshots/GIFs (if applicable)

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information
