### PR TITLE
core: Fix camera effect persistence

### DIFF
--- a/.changeset/ten-cases-wish.md
+++ b/.changeset/ten-cases-wish.md
@@ -1,0 +1,7 @@
+---
+"@whereby.com/core": patch
+---
+
+Fix camera effects being lost when the camera is toggled off and on.
+
+The active effect is now remembered while the camera is off and automatically re-applied to the new camera track when the camera is turned back on, so effects keep working (and can still be changed) after a toggle.

--- a/packages/core/src/redux/slices/cameraEffects.ts
+++ b/packages/core/src/redux/slices/cameraEffects.ts
@@ -3,7 +3,13 @@ import { createAppAsyncThunk } from "../thunk";
 import { RootState } from "../store";
 import { startAppListening } from "../listenerMiddleware";
 import { doAppStop } from "./app";
-import { doLocalStreamEffect, selectLocalMediaIsSwitchingStream, selectLocalMediaStream } from "./localMedia";
+import {
+    doLocalStreamEffect,
+    doToggleCamera,
+    selectIsCameraEnabled,
+    selectLocalMediaIsSwitchingStream,
+    selectLocalMediaStream,
+} from "./localMedia";
 import { Setup, Params } from "@whereby.com/camera-effects";
 
 type TryUpdateFn = (presetId: string, setup: Setup, params: Params) => Promise<boolean>;
@@ -13,6 +19,9 @@ export interface CameraEffectsState {
     currentEffectId?: string | null;
     setup?: Setup;
     params?: Params;
+    backgroundUrl?: string;
+    allowSafari?: boolean;
+    isPaused: boolean;
     isSwitching: boolean;
     error?: unknown;
     raw: {
@@ -23,6 +32,7 @@ export interface CameraEffectsState {
 }
 
 const initialState: CameraEffectsState = {
+    isPaused: false,
     isSwitching: false,
     raw: {},
 };
@@ -38,6 +48,9 @@ export const cameraEffectsSlice = createSlice({
             state.currentEffectId = null;
             state.setup = undefined;
             state.params = undefined;
+            state.backgroundUrl = undefined;
+            state.allowSafari = undefined;
+            state.isPaused = false;
             state.raw = {};
             state.error = undefined;
             state.isSwitching = false;
@@ -48,14 +61,39 @@ export const cameraEffectsSlice = createSlice({
                 effectId: string;
                 setup?: Setup;
                 params?: Params;
+                backgroundUrl?: string;
+                allowSafari?: boolean;
                 raw?: { stop?: StopFn; tryUpdate?: TryUpdateFn; effectStream?: MediaStream };
             }>,
         ) {
-            const { effectId, setup, params, raw } = action.payload;
+            const { effectId, setup, params, backgroundUrl, allowSafari, raw } = action.payload;
             state.currentEffectId = effectId;
             state.setup = setup;
             state.params = params;
+            state.backgroundUrl = backgroundUrl;
+            state.allowSafari = allowSafari;
+            state.isPaused = false;
             if (raw) state.raw = raw;
+            state.error = undefined;
+            state.isSwitching = false;
+        },
+        cameraEffectsPaused(
+            state,
+            action: PayloadAction<
+                | { effectId?: string; setup?: Setup; params?: Params; backgroundUrl?: string; allowSafari?: boolean }
+                | undefined
+            >,
+        ) {
+            const payload = action.payload;
+            if (payload?.effectId !== undefined) {
+                state.currentEffectId = payload.effectId;
+                state.setup = payload.setup;
+                state.params = payload.params;
+                state.backgroundUrl = payload.backgroundUrl;
+                state.allowSafari = payload.allowSafari;
+            }
+            state.isPaused = true;
+            state.raw = {};
             state.error = undefined;
             state.isSwitching = false;
         },
@@ -66,12 +104,18 @@ export const cameraEffectsSlice = createSlice({
     },
 });
 
-export const { cameraEffectsSwitching, cameraEffectsCleared, cameraEffectsUpdated, cameraEffectsError } =
-    cameraEffectsSlice.actions;
+export const {
+    cameraEffectsSwitching,
+    cameraEffectsCleared,
+    cameraEffectsUpdated,
+    cameraEffectsPaused,
+    cameraEffectsError,
+} = cameraEffectsSlice.actions;
 
 export const selectCameraEffectsRaw = (state: RootState) => state.cameraEffects.raw;
 export const selectCameraEffectId = (state: RootState) => state.cameraEffects.currentEffectId;
 export const selectIsCameraEffectSwitching = (state: RootState) => state.cameraEffects.isSwitching;
+export const selectIsCameraEffectPaused = (state: RootState) => state.cameraEffects.isPaused;
 
 export const doCameraEffectsSwitchPreset = createAppAsyncThunk(
     "cameraEffects/switchPreset",
@@ -100,8 +144,14 @@ export const doCameraEffectsSwitchPreset = createAppAsyncThunk(
             const localStream = selectLocalMediaStream(state);
 
             if (!localStream?.getVideoTracks()?.[0]) {
-                // No local video, nothing to do
-                dispatch(cameraEffectsCleared());
+                if (!effectId) {
+                    // No local video and no effect wanted, nothing to do
+                    dispatch(cameraEffectsCleared());
+                } else {
+                    // The camera is off, so there is nothing to apply the effect to yet.
+                    // Remember it as paused and apply it automatically once the camera is on.
+                    dispatch(cameraEffectsPaused({ effectId, setup, params, backgroundUrl, allowSafari }));
+                }
                 return;
             }
 
@@ -118,7 +168,7 @@ export const doCameraEffectsSwitchPreset = createAppAsyncThunk(
             if (raw.tryUpdate) {
                 const ok = await raw.tryUpdate(effectId, { ...(setup || {}) }, mergedParams);
                 if (ok) {
-                    dispatch(cameraEffectsUpdated({ effectId, setup, params }));
+                    dispatch(cameraEffectsUpdated({ effectId, setup, params, backgroundUrl, allowSafari }));
                     return;
                 }
             }
@@ -152,7 +202,16 @@ export const doCameraEffectsSwitchPreset = createAppAsyncThunk(
             // Replace local media video track
             await dispatch(doLocalStreamEffect({ effectStream, only: "video" }));
 
-            dispatch(cameraEffectsUpdated({ effectId, setup, params, raw: { stop, tryUpdate, effectStream } }));
+            dispatch(
+                cameraEffectsUpdated({
+                    effectId,
+                    setup,
+                    params,
+                    backgroundUrl,
+                    allowSafari,
+                    raw: { stop, tryUpdate, effectStream },
+                }),
+            );
         } catch (error) {
             dispatch(cameraEffectsError({ error }));
             return rejectWithValue(error);
@@ -164,11 +223,53 @@ export const doCameraEffectsClear = createAppAsyncThunk("cameraEffects/clear", a
     await dispatch(doCameraEffectsSwitchPreset({ effectId: null }));
 });
 
+export const doCameraEffectsPause = createAppAsyncThunk("cameraEffects/pause", async (_, { dispatch, getState }) => {
+    const raw = selectCameraEffectsRaw(getState());
+
+    raw.stop?.();
+    await dispatch(doLocalStreamEffect({ effectStream: undefined, only: "video", stopBeforeTrack: true }));
+
+    dispatch(cameraEffectsPaused());
+});
+
+export const doCameraEffectsResume = createAppAsyncThunk("cameraEffects/resume", async (_, { dispatch, getState }) => {
+    const state = getState();
+    const effectId = selectCameraEffectId(state);
+    if (!effectId) {
+        return;
+    }
+
+    const { setup, params, backgroundUrl, allowSafari } = state.cameraEffects;
+    await dispatch(doCameraEffectsSwitchPreset({ effectId, setup, params, backgroundUrl, allowSafari }));
+});
+
 startAppListening({
     actionCreator: doAppStop,
     effect: (_, { dispatch, getState }) => {
         if (selectCameraEffectsRaw(getState()).stop) {
             dispatch(doCameraEffectsClear());
+        }
+    },
+});
+
+startAppListening({
+    actionCreator: doToggleCamera.fulfilled,
+    effect: (_, { dispatch, getState }) => {
+        const state = getState();
+        const cameraEnabled = selectIsCameraEnabled(state);
+        const effectId = selectCameraEffectId(state);
+        const isPaused = selectIsCameraEffectPaused(state);
+
+        if (!cameraEnabled) {
+            const raw = selectCameraEffectsRaw(state);
+            if (effectId && raw.stop && !isPaused) {
+                dispatch(doCameraEffectsPause());
+            }
+        } else if (effectId && isPaused) {
+            const stream = selectLocalMediaStream(state);
+            if (stream?.getVideoTracks()?.[0]) {
+                dispatch(doCameraEffectsResume());
+            }
         }
     },
 });

--- a/packages/core/src/redux/slices/localMedia.ts
+++ b/packages/core/src/redux/slices/localMedia.ts
@@ -810,7 +810,7 @@ startAppListening({
         const oldValue = selectCurrentCameraDeviceId(previousState);
         const newValue = selectCurrentCameraDeviceId(currentState);
         const isReady = selectLocalMediaStatus(previousState) === "started";
-        return isReady && oldValue !== newValue;
+        return isReady && !!oldValue && !!newValue && oldValue !== newValue;
     },
     effect: (_action, { dispatch }) => {
         dispatch(doSetDevice({ audio: false, video: true }));

--- a/packages/core/src/redux/tests/store/cameraEffects.spec.ts
+++ b/packages/core/src/redux/tests/store/cameraEffects.spec.ts
@@ -1,12 +1,71 @@
 import * as cameraEffectsSlice from "../../slices/cameraEffects";
+import * as localMediaSlice from "../../slices/localMedia";
+import * as MediaDevices from "@whereby.com/media";
 import { doAppStart, doAppStop } from "../../slices/app";
 import { createStore } from "../store.setup";
+import { RootState } from "../../store";
+
+import MockMediaStream from "../../../__mocks__/MediaStream";
+import MockMediaStreamTrack from "../../../__mocks__/MediaStreamTrack";
+
+Object.defineProperty(window, "MediaStream", {
+    writable: true,
+    value: MockMediaStream,
+});
+
+Object.defineProperty(window, "MediaStreamTrack", {
+    writable: true,
+    value: MockMediaStreamTrack,
+});
 
 jest.mock("@whereby.com/media", () => ({
     __esModule: true,
     getStream: jest.fn(() => Promise.resolve()),
     getUpdatedDevices: jest.fn(() => Promise.resolve({ addedDevices: {}, changedDevices: {} })),
+    getDeviceData: jest.fn(() => ({})),
+    replaceTracksInStream: jest.fn((stream: MediaStream, newStream: MediaStream, only: "audio" | "video") => {
+        const kind = only === "audio" ? "audio" : "video";
+        const replaced = stream.getTracks().filter((t) => t.kind === kind);
+        newStream.getTracks().forEach((t) => stream.addTrack(t));
+        replaced.forEach((t) => stream.removeTrack(t));
+        return replaced;
+    }),
 }));
+
+const mockEffectStop = jest.fn();
+jest.mock("@whereby.com/camera-effects", () => ({
+    __esModule: true,
+    createEffectStream: jest.fn(async () => ({
+        stream: new MockMediaStream([new MockMediaStreamTrack("video")]),
+        stop: mockEffectStop,
+        tryUpdate: jest.fn(async () => true),
+    })),
+    getUsablePresets: jest.fn(() => ["image-blur"]),
+}));
+
+// Flush queued microtasks so async listener chains (toggle -> pause/resume) settle.
+const flushMicrotasks = async () => {
+    for (let i = 0; i < 30; i++) {
+        await Promise.resolve();
+    }
+};
+
+const startedLocalMedia = (overrides: Partial<RootState["localMedia"]>): RootState["localMedia"] => ({
+    busyDeviceIds: [],
+    cameraEnabled: true,
+    devices: [],
+    hdMode: true,
+    isSettingCameraDevice: false,
+    isSettingMicrophoneDevice: false,
+    isSettingSpeakerDevice: false,
+    isSwitchingStream: false,
+    isTogglingCamera: false,
+    lowDataMode: false,
+    microphoneEnabled: true,
+    status: "started",
+    widescreenMode: true,
+    ...overrides,
+});
 
 describe("cameraEffectsSlice", () => {
     describe("reactors", () => {
@@ -52,6 +111,221 @@ describe("cameraEffectsSlice", () => {
 
             const state = store.getState().cameraEffects;
             expect(state.currentEffectId).toBeNull();
+            expect(state.raw).toEqual({});
+        });
+    });
+
+    describe("cameraEffectsPaused reducer", () => {
+        it("remembers the effect config and drops the live pipeline", () => {
+            const store = createStore();
+            const stop = jest.fn();
+
+            store.dispatch(cameraEffectsSlice.cameraEffectsUpdated({ effectId: "image-blur", raw: { stop } }));
+            store.dispatch(cameraEffectsSlice.cameraEffectsPaused());
+
+            const state = store.getState().cameraEffects;
+            expect(state.isPaused).toBe(true);
+            expect(state.currentEffectId).toBe("image-blur");
+            expect(state.raw).toEqual({});
+        });
+
+        it("can set the effect config from the payload (effect picked while camera off)", () => {
+            const store = createStore();
+
+            store.dispatch(
+                cameraEffectsSlice.cameraEffectsPaused({ effectId: "image-custom", backgroundUrl: "data:image/x" }),
+            );
+
+            const state = store.getState().cameraEffects;
+            expect(state.isPaused).toBe(true);
+            expect(state.currentEffectId).toBe("image-custom");
+            expect(state.backgroundUrl).toBe("data:image/x");
+        });
+
+        it("is reset when the effect is cleared", () => {
+            const store = createStore();
+
+            store.dispatch(cameraEffectsSlice.cameraEffectsPaused({ effectId: "image-blur" }));
+            store.dispatch(cameraEffectsSlice.cameraEffectsCleared());
+
+            const state = store.getState().cameraEffects;
+            expect(state.isPaused).toBe(false);
+            expect(state.currentEffectId).toBeNull();
+        });
+    });
+
+    describe("doCameraEffectsSwitchPreset with the camera off", () => {
+        it("remembers the requested effect as paused instead of clearing it", async () => {
+            const audioTrack = new MockMediaStreamTrack("audio");
+            const store = createStore({
+                initialState: {
+                    localMedia: startedLocalMedia({
+                        cameraEnabled: false,
+                        stream: new MockMediaStream([audioTrack]),
+                    }),
+                },
+            });
+
+            await store.dispatch(cameraEffectsSlice.doCameraEffectsSwitchPreset({ effectId: "image-blur" }));
+
+            const state = store.getState().cameraEffects;
+            expect(state.isPaused).toBe(true);
+            expect(state.currentEffectId).toBe("image-blur");
+        });
+    });
+
+    describe("doCameraEffectsPause", () => {
+        it("stops the pipeline and the source track, and marks the effect paused", async () => {
+            const stop = jest.fn();
+            const sourceTrack = new MockMediaStreamTrack("video");
+            const audioTrack = new MockMediaStreamTrack("audio");
+
+            const store = createStore({
+                initialState: {
+                    localMedia: startedLocalMedia({
+                        cameraEnabled: false,
+                        stream: new MockMediaStream([audioTrack]),
+                        beforeEffectTracks: { video: sourceTrack },
+                    }),
+                    cameraEffects: {
+                        currentEffectId: "image-blur",
+                        isPaused: false,
+                        isSwitching: false,
+                        raw: { stop, effectStream: new MockMediaStream() },
+                    },
+                },
+            });
+
+            await store.dispatch(cameraEffectsSlice.doCameraEffectsPause());
+
+            const state = store.getState().cameraEffects;
+            expect(stop).toHaveBeenCalledTimes(1);
+            expect(sourceTrack.stop).toHaveBeenCalledTimes(1);
+            expect(state.isPaused).toBe(true);
+            expect(state.currentEffectId).toBe("image-blur");
+            expect(state.raw).toEqual({});
+        });
+    });
+
+    describe("camera toggle coordination (via the real toggleCameraEnabled trigger)", () => {
+        it("pauses a running effect when toggleCameraEnabled(false) drives doToggleCamera", async () => {
+            const stop = jest.fn();
+            const effectTrack = new MockMediaStreamTrack("video");
+            const sourceTrack = new MockMediaStreamTrack("video");
+            const audioTrack = new MockMediaStreamTrack("audio");
+            const stream = new MockMediaStream([audioTrack, effectTrack]);
+
+            const store = createStore({
+                initialState: {
+                    localMedia: startedLocalMedia({
+                        cameraEnabled: true,
+                        stream,
+                        beforeEffectTracks: { video: sourceTrack },
+                    }),
+                    cameraEffects: {
+                        currentEffectId: "image-blur",
+                        isPaused: false,
+                        isSwitching: false,
+                        raw: { stop, tryUpdate: jest.fn(), effectStream: new MockMediaStream() },
+                    },
+                },
+            });
+
+            store.dispatch(localMediaSlice.toggleCameraEnabled({ enabled: false }));
+            await flushMicrotasks();
+
+            const state = store.getState().cameraEffects;
+            expect(stop).toHaveBeenCalledTimes(1);
+            expect(state.isPaused).toBe(true);
+            expect(state.raw).toEqual({});
+        });
+    });
+
+    describe("full off -> on cycle re-applies the effect", () => {
+        it("re-applies the effect when the camera is turned back on", async () => {
+            const stop = jest.fn();
+            const effectTrack = new MockMediaStreamTrack("video");
+            const sourceTrack = new MockMediaStreamTrack("video");
+            const audioTrack = new MockMediaStreamTrack("audio");
+            const stream = new MockMediaStream([audioTrack, effectTrack]);
+
+            const store = createStore({
+                initialState: {
+                    localMedia: startedLocalMedia({
+                        cameraEnabled: true,
+                        currentCameraDeviceId: "camera-1",
+                        stream,
+                        beforeEffectTracks: { video: sourceTrack },
+                    }),
+                    cameraEffects: {
+                        currentEffectId: "image-blur",
+                        isPaused: false,
+                        isSwitching: false,
+                        raw: { stop, tryUpdate: jest.fn(), effectStream: new MockMediaStream() },
+                    },
+                },
+            });
+
+            // Turn the camera off -> effect should pause (remembered).
+            store.dispatch(localMediaSlice.toggleCameraEnabled({ enabled: false }));
+            await flushMicrotasks();
+            expect(store.getState().cameraEffects.isPaused).toBe(true);
+
+            // When the camera is turned on, doToggleCamera acquires a fresh raw track.
+            jest.mocked(MediaDevices.getStream).mockImplementationOnce(async (_opts, options) => {
+                const newRawTrack = new MockMediaStreamTrack("video");
+                options?.replaceStream?.addTrack(newRawTrack);
+                return { stream: options?.replaceStream as MediaStream, attempts: [] };
+            });
+
+            // Turn the camera back on -> effect should be re-applied to the new track.
+            store.dispatch(localMediaSlice.toggleCameraEnabled({ enabled: true }));
+            await flushMicrotasks();
+
+            const createEffectStream = jest.mocked(
+                jest.requireMock("@whereby.com/camera-effects").createEffectStream,
+            );
+            const state = store.getState().cameraEffects;
+            expect(createEffectStream).toHaveBeenCalled();
+            expect(state.isPaused).toBe(false);
+            expect(state.currentEffectId).toBe("image-blur");
+            expect(state.raw.stop).toBe(mockEffectStop);
+        });
+    });
+
+    describe("camera toggle coordination", () => {
+        it("pauses a running effect when the camera is turned off", async () => {
+            const stop = jest.fn();
+            const effectTrack = new MockMediaStreamTrack("video");
+            const sourceTrack = new MockMediaStreamTrack("video");
+            const audioTrack = new MockMediaStreamTrack("audio");
+            const stream = new MockMediaStream([audioTrack, effectTrack]);
+
+            const store = createStore({
+                initialState: {
+                    // Camera has just been toggled off; doToggleCamera will tear down the
+                    // effect (video) track that is currently in the stream.
+                    localMedia: startedLocalMedia({
+                        cameraEnabled: false,
+                        stream,
+                        beforeEffectTracks: { video: sourceTrack },
+                    }),
+                    cameraEffects: {
+                        currentEffectId: "image-blur",
+                        isPaused: false,
+                        isSwitching: false,
+                        raw: { stop, effectStream: new MockMediaStream() },
+                    },
+                },
+            });
+
+            await store.dispatch(localMediaSlice.doToggleCamera());
+            await flushMicrotasks();
+
+            const state = store.getState().cameraEffects;
+            expect(stop).toHaveBeenCalledTimes(1);
+            expect(state.isPaused).toBe(true);
+            expect(state.currentEffectId).toBe("image-blur");
             expect(state.raw).toEqual({});
         });
     });


### PR DESCRIPTION
### Description
Fixes #1044.

Currently, there's a bug where a camera effect disappears when toggling camera off and on again. We need to remember the effect and re-apply it whenever camera is turned on again.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. `pnpm build && pnpm dev`
2. Go to the Room Connection with Camera effects story
3. join room, enable a camera effect
4. Turn off camera, and turn it on again
5. Verify that the effect is still active on the video feed
6. Change to a different effect, verify that it applies correctly

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
