### PR TITLE
common: fix crash in non-browser environments

### DIFF
--- a/.changeset/legal-actors-talk.md
+++ b/.changeset/legal-actors-talk.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/media": patch
+"@whereby.com/core": patch
+---
+
+Fix crash in non-browser environments

--- a/packages/core/src/redux/tests/store/nodeEnvironment.spec.ts
+++ b/packages/core/src/redux/tests/store/nodeEnvironment.spec.ts
@@ -1,0 +1,12 @@
+/**
+ * @jest-environment node
+ */
+
+describe("@whereby.com/core in a non-browser (Node) environment", () => {
+    it("does not throw when the redux slice (and its media dependency) is imported", () => {
+        expect(() => {
+            // eslint-disable-next-line
+            require("../../index");
+        }).not.toThrow();
+    });
+});

--- a/packages/media/src/utils/Logger.ts
+++ b/packages/media/src/utils/Logger.ts
@@ -1,4 +1,6 @@
-const debugOn = process.env.NODE_ENV === "development" || new URLSearchParams(window.location.search).has("debug");
+const debugOn =
+    process.env.NODE_ENV === "development" ||
+    (typeof window !== "undefined" && new URLSearchParams(window.location.search).has("debug"));
 
 export interface Debugger {
     print: (...args: any[]) => void;

--- a/packages/media/src/utils/__tests__/nodeEnvironment.spec.ts
+++ b/packages/media/src/utils/__tests__/nodeEnvironment.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment node
+ */
+
+describe("@whereby.com/media in a non-browser (Node) environment", () => {
+    it("does not throw when imported", () => {
+        expect(() => {
+            require("../../index");
+        }).not.toThrow();
+    });
+
+    it("exposes a server object with safe no-op defaults", () => {
+        const { rtcStats } = require("../../index");
+
+        expect(rtcStats.server.connected).toBe(false);
+        expect(rtcStats.server.attemptedConnectedAtLeastOnce).toBe(false);
+        expect(typeof rtcStats.server.trace).toBe("function");
+        expect(typeof rtcStats.server.close).toBe("function");
+        expect(typeof rtcStats.server.connect).toBe("function");
+    });
+
+    it("does not throw when sendEvent/sendAudioMuted/sendVideoMuted are called", () => {
+        const { rtcStats } = require("../../index");
+
+        expect(() => rtcStats.sendEvent("custom_event", { foo: "bar" })).not.toThrow();
+        expect(() => rtcStats.sendAudioMuted(true)).not.toThrow();
+        expect(() => rtcStats.sendVideoMuted(false)).not.toThrow();
+    });
+});

--- a/packages/media/src/utils/urls.ts
+++ b/packages/media/src/utils/urls.ts
@@ -41,4 +41,4 @@ export function fromLocation({ host = "whereby.com", protocol = "https:" } = {})
     };
 }
 
-export default fromLocation(window && window.location);
+export default fromLocation(typeof window !== "undefined" ? window.location : undefined);

--- a/packages/media/src/webrtc/MediaDevices.ts
+++ b/packages/media/src/webrtc/MediaDevices.ts
@@ -14,7 +14,7 @@ import { trackAnnotations } from "../utils/annotations";
 
 const logger = new Logger();
 
-export const isMobile = /mobi/i.test(navigator.userAgent);
+export const isMobile = typeof navigator !== "undefined" && /mobi/i.test(navigator.userAgent);
 
 export class NoDevicesError extends Error {
     constructor(...args: any) {
@@ -371,8 +371,8 @@ export function hasGetDisplayMedia() {
 
 const defaultDisplayMediaConstraints = {
     video: {
-        width: { max: window.screen.width },
-        height: { max: window.screen.height },
+        width: { max: typeof window !== "undefined" ? window.screen.width : 0 },
+        height: { max: typeof window !== "undefined" ? window.screen.height : 0 },
     },
 };
 /**

--- a/packages/media/src/webrtc/rtcStatsService.ts
+++ b/packages/media/src/webrtc/rtcStatsService.ts
@@ -179,14 +179,27 @@ function rtcStatsConnection(wsURL: string, logger: any = console) {
 }
 
 const RTCSTATS_URL = process.env.RTCSTATS_URL;
-const server = rtcStatsConnection(RTCSTATS_URL || "wss://rtcstats.srv.whereby.com");
-const stats = rtcstats(
-    server.trace,
-    10000, // query once every 10 seconds.
-    [""], // only shim unprefixed RTCPeerConnecion.
-);
-// on node clients this function can be undefined
-resetDelta = stats?.resetDelta || noop;
+
+const noopServer = {
+    connected: false,
+    attemptedConnectedAtLeastOnce: false,
+    trace: noop,
+    close: noop,
+    connect: noop,
+};
+
+// rtcstats relies on browser globals which aren't relevant in a
+// node context
+let server: ReturnType<typeof rtcStatsConnection> | typeof noopServer;
+
+if (typeof window !== "undefined") {
+    server = rtcStatsConnection(RTCSTATS_URL || "wss://rtcstats.srv.whereby.com");
+    const stats = rtcstats(server.trace, 10000, [""]);
+    // on node clients this function can be undefined
+    resetDelta = stats?.resetDelta || noop;
+} else {
+    server = noopServer;
+}
 
 const rtcStats = {
     sendEvent: (type: any, value: any) => {

--- a/packages/media/src/webrtc/stats/StatsMonitor/peerConnectionTracker.ts
+++ b/packages/media/src/webrtc/stats/StatsMonitor/peerConnectionTracker.ts
@@ -6,7 +6,7 @@ export const removePeerConnection = (pc: RTCPeerConnection) => {
     peerConnections = peerConnections.filter((old) => old !== pc);
 };
 
-if (window.RTCPeerConnection) {
+if (typeof window !== "undefined" && window.RTCPeerConnection) {
     const OriginalRTCPeerConnection = window.RTCPeerConnection;
     function PatchedRTCPeerConnection(rtcConfig?: RTCConfiguration) {
         const pc = new OriginalRTCPeerConnection(rtcConfig);
@@ -26,7 +26,5 @@ if (window.RTCPeerConnection) {
 }
 
 export const getCurrentPeerConnections = () => peerConnections.filter((p) => p.connectionState !== "closed");
-
 export const getPeerConnectionIndex = (pc: RTCPeerConnection) => peerConnectionData.get(pc)?.index;
-
 export const setPeerConnectionsForTests = (pcs: RTCPeerConnection[]) => (peerConnections = pcs);


### PR DESCRIPTION
### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->
Whilst updating to the latest core in some of the workers in the recording-service (in [this](https://github.com/whereby/recording-service/pull/1096) PR), I uncovered some references in the `media` package to `window` and `navigator` that execute immediately when the package is imported. This will cause issues for any Node consumer that imports `media` and by default `core`, which should sipport non-browser usage. 

This wasn't actually an issue for us directly in the captioner for example, since we import browser polyfills from the `assistant-sdk` - I only uncovered this error when our media mock stopped working in the captioner-worker, and since Jest didn't pick up the polyfills the tests were crashing. But it would be an issue for any Node consumer that imports core without these polyfills - so let's guard it just incase. 

This PR includes: 
- Guards against browser global references calls to prevent the package import throwing
- Tests in media to ensure that a node environment is supported
- Tests in core to make sure that a node environment is supported


**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->
See a write up of the investigation here: https://linear.app/whereby/issue/PAN-2722/captioner-tests-failing-with-the-latest-core-sdk-version

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->
There's some tests in this PR to check the new guards. You can also checkout this branch in the recording service: 
https://github.com/whereby/recording-service/pull/1096 and follow the test instructions to test out the new functionality. Or even just test out the captioner on that branch to make sure it looks good! 



### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
