### PR TITLE
core: release camera and microphone when the local client is kicked

### DIFF
--- a/.changeset/fast-drinks-end.md
+++ b/.changeset/fast-drinks-end.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/core": patch
+---
+
+core: release camera and microphone when the local client is kicked, eg when the meeting is ended by the host

--- a/packages/core/src/redux/slices/roomConnection/index.ts
+++ b/packages/core/src/redux/slices/roomConnection/index.ts
@@ -305,6 +305,13 @@ startAppListening({
 });
 
 startAppListening({
+    actionCreator: signalEvents.clientKicked,
+    effect: (_, { dispatch }) => {
+        dispatch(doAppStop());
+    },
+});
+
+startAppListening({
     actionCreator: doAppStop,
     effect: (_, { dispatch, getState }) => {
         const state = getState();

--- a/packages/core/src/redux/tests/store/localMedia.spec.ts
+++ b/packages/core/src/redux/tests/store/localMedia.spec.ts
@@ -1,4 +1,6 @@
 import * as localMediaSlice from "../../slices/localMedia";
+import { initialState as appInitialState } from "../../slices/app";
+import { signalEvents } from "../../slices/signalConnection/actions";
 import { createStore } from "../store.setup";
 import { diff } from "deep-object-diff";
 import * as MediaDevices from "@whereby.com/media";
@@ -157,6 +159,27 @@ describe("actions", () => {
                     status: "stopped",
                     stream: undefined,
                 });
+            });
+
+            it("should stop all tracks when the local client is kicked", () => {
+                const store = createStore({
+                    withSignalConnection: true,
+                    connectToRoom: true,
+                    initialState: {
+                        ...initialState,
+                        localMedia: {
+                            ...initialState.localMedia!,
+                            options: { audio: true, video: true },
+                        },
+                        app: { ...appInitialState, isActive: true },
+                    },
+                });
+
+                store.dispatch(signalEvents.clientKicked({ clientId: "self-client-id" }));
+
+                expect(audioTrack.stop).toHaveBeenCalled();
+                expect(videoTrack.stop).toHaveBeenCalled();
+                expect(store.getState().localMedia.status).toEqual("stopped");
             });
         });
     });

--- a/packages/core/src/redux/tests/store/roomConnection.spec.ts
+++ b/packages/core/src/redux/tests/store/roomConnection.spec.ts
@@ -1,5 +1,7 @@
 import { createStore, mockSignalEmit } from "../store.setup";
 import { doKnockRoom, doConnectRoom } from "../../slices/roomConnection";
+import { initialState as appInitialState } from "../../slices/app";
+import { signalEvents } from "../../slices/signalConnection/actions";
 import { diff } from "deep-object-diff";
 
 describe("actions", () => {
@@ -27,6 +29,23 @@ describe("actions", () => {
 
             expect(() => store.dispatch(doKnockRoom())).toThrow("Room is not locked, knock aborted");
             expect(mockSignalEmit).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("signalEvents.clientKicked", () => {
+        it("should stop the app so local media and connections are cleaned up", () => {
+            const store = createStore({
+                withSignalConnection: true,
+                connectToRoom: true,
+                initialState: {
+                    app: { ...appInitialState, isActive: true },
+                },
+            });
+
+            store.dispatch(signalEvents.clientKicked({ clientId: "self-client-id" }));
+
+            expect(store.getState().roomConnection.status).toEqual("kicked");
+            expect(store.getState().app.isActive).toEqual(false);
         });
     });
 


### PR DESCRIPTION
### Description
Fixes #1055.

We're missing the clean up (`doAppStop`), when a client is kicked. This also applies to when the host ends meeting for all (as that is technically the host kicking everyone with the reason `end-meeting`.

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. `pnpm build && pnpm dev`
2. Go to the Room Connection with Host Controls story, and open it in 2 tabs
3. Click the end meeting button
4. Verify that the mic/cam is released from both tabs. 

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
