### PR TITLE
media: skip the final getStream retry when a stream was already acquired

### DIFF
--- a/.changeset/plain-fields-settle.md
+++ b/.changeset/plain-fields-settle.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Keep an already acquired stream instead of running a final retry in getStream

--- a/packages/media/src/webrtc/MediaDevices.ts
+++ b/packages/media/src/webrtc/MediaDevices.ts
@@ -430,7 +430,7 @@ export async function getStream(
             await getSingleStream(e);
         }
     }
-    if (retryConstraintOpt) {
+    if (!stream && retryConstraintOpt) {
         const onlyConstraints = only ? { audio: { videoId: false }, video: { audioId: false } }[only] : {};
         const retryConstraints = getConstraints({
             ...constraintOpt,


### PR DESCRIPTION
### Description

**Summary:**

`getStream` no longer runs its closing retry when the fallback ladder has already
produced a working stream, so a call that acquired a stream can no longer fail or
leave the acquired tracks running.

**Related Issue:**

### Testing

### Screenshots/GIFs (if applicable)

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information
