### PR TITLE
media: skip getStream fallback attempt that would request no kinds

### DIFF
--- a/.changeset/brave-hills-wander.md
+++ b/.changeset/brave-hills-wander.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Skip the getStream fallback attempt that would leave no kinds to request

--- a/packages/media/src/webrtc/MediaDevices.ts
+++ b/packages/media/src/webrtc/MediaDevices.ts
@@ -415,8 +415,11 @@ export async function getStream(
                     // to at least get SOMETHING working
                     const tryOnly = problemWith ? [problemWith] : ["videoId", "audioId"];
                     for (const kind of tryOnly) {
+                        const withoutKind = getConstraints({ ...constraintOpt, [kind]: false });
+                        // Dropping this kind leaves nothing to ask for
+                        if (!withoutKind.audio && !withoutKind.video) continue;
                         try {
-                            stream = await attempt(getConstraints({ ...constraintOpt, [kind]: false }));
+                            stream = await attempt(withoutKind);
                         } catch (e2) {
                             logger.warn(`Re-tried without ${kind}, but failed: ${"" + e2}`);
                         }


### PR DESCRIPTION
### Description

**Summary:**

In the `getStream` fallback ladder, skip the attempt that drops a kind when dropping it would leave a request with neither audio nor video. Such a request is rejected by the `getUserMedia` wrapper without reaching the browser, so the attempt cannot succeed.

**Related Issue:**

### Testing

### Screenshots/GIFs (if applicable)

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information
