### PR TITLE
media: stop retrying with looser constraints after a denied permission

### DIFF
--- a/.changeset/brave-lions-wait.md
+++ b/.changeset/brave-lions-wait.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": patch
+---
+
+Stop retrying with looser constraints after a denied permission during initial acquisition

--- a/packages/media/src/webrtc/MediaDevices.ts
+++ b/packages/media/src/webrtc/MediaDevices.ts
@@ -256,9 +256,16 @@ export async function getInitialStream(constraintOpt: GetInitialStreamOptions): 
             try {
                 stream = await attempt(getConstraints(retryOpts));
                 return stream;
-            } catch (e) {
+            } catch (e: any) {
                 logger.error(e);
+                lastError = e;
             }
+        }
+
+        // An ask carrying an exact deviceId can be rejected as overconstrained while the permission
+        // is denied, so the ask without one is the first to report the denial.
+        if (lastError?.name === "NotAllowedError") {
+            return;
         }
 
         // Try with lax constraints.


### PR DESCRIPTION
### Description

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->
Don't try with laxer constraints per kind if we got `NotAllowedError` after dropping exact `deviceId`.


**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

<!-- Describe the steps to test the changes made in this PR. Include details
about the test environment, any specific configurations or data required, and
the expected outcomes. -->

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
