### PR TITLE
common: Add option to reply to a chat message with a file

### DIFF
--- a/.changeset/wise-otters-reply.md
+++ b/.changeset/wise-otters-reply.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/core": patch
+"@whereby.com/browser-sdk": patch
+---
+
+Allow sharing files as a chat message reply. `sendFiles` now takes an options argument with `parentId` and `isBroadcast`, so files can be attached to a reply and broadcast to all breakout groups

--- a/packages/browser-sdk/src/lib/react/index.ts
+++ b/packages/browser-sdk/src/lib/react/index.ts
@@ -22,6 +22,7 @@ export type {
     ChatFileShare,
     FileUpload,
     FileShareError,
+    SendFilesOptions,
     CloudRecordingState as CloudRecording,
     LiveStreamState as LiveStreaming,
     BreakoutState as Breakout,

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/index.ts
@@ -4,6 +4,7 @@ import {
     ChatFileShare,
     NotificationsEventEmitter,
     RoomConnectionState,
+    SendFilesOptions,
     StartBreakoutSessionOptions,
     UpdateBreakoutSessionOptions,
 } from "@whereby.com/core";
@@ -84,7 +85,10 @@ export function useRoomConnection(
         (id: string, sig?: string | null) => client.removeChatMessage(id, sig),
         [client],
     );
-    const sendFiles = React.useCallback((files: File[]) => client.sendFiles(files), [client]);
+    const sendFiles = React.useCallback(
+        (files: File[], options?: SendFilesOptions) => client.sendFiles(files, options),
+        [client],
+    );
     const downloadFile = React.useCallback((file: ChatFileShare) => client.downloadFile(file), [client]);
     const knock = React.useCallback(() => client.knock(), [client]);
     const cancelKnock = React.useCallback(() => client.cancelKnock(), [client]);

--- a/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
+++ b/packages/browser-sdk/src/lib/react/useRoomConnection/types.ts
@@ -2,6 +2,7 @@ import {
     ChatFileShare,
     LocalMediaOptions,
     RoomJoinedSuccess,
+    SendFilesOptions,
     StartBreakoutSessionOptions,
     UpdateBreakoutSessionOptions,
 } from "@whereby.com/core";
@@ -37,7 +38,7 @@ export interface RoomConnectionActions {
     rejectWaitingParticipant: (participantId: string, response?: string) => void;
     sendChatMessage: (text: string, parentId?: string, isBroadcast?: boolean) => void;
     removeChatMessage: (id: string, sig?: string | null) => void;
-    sendFiles: (files: File[]) => void;
+    sendFiles: (files: File[], options?: SendFilesOptions) => void;
     downloadFile: (file: ChatFileShare) => Promise<Blob>;
     setDisplayName: (displayName: string) => void;
     startCloudRecording: () => void;

--- a/packages/browser-sdk/src/stories/components/VideoExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/VideoExperience.tsx
@@ -17,6 +17,18 @@ import {
     LiveCaptionsState,
 } from "@whereby.com/core";
 
+type ChatMessageWithFile = { text: string; file?: { name: string } };
+
+function describeChatMessage(message?: ChatMessageWithFile) {
+    if (!message) {
+        return "unknown message";
+    }
+    if (message.text) {
+        return message.text;
+    }
+    return message.file ? `📎 ${message.file.name}` : "(empty message)";
+}
+
 export default function VideoExperience({
     displayName,
     roomName,
@@ -47,6 +59,7 @@ export default function VideoExperience({
     const [chatMessage, setChatMessage] = useState("");
     const [chatMessageParent, setChatMessageParent] = useState("");
     const [chatBroadcast, setChatBroadcast] = useState(false);
+    const [stagedFiles, setStagedFiles] = useState<File[]>([]);
     const [isLocalScreenshareActive, setIsLocalScreenshareActive] = useState(false);
     const [effectPresets, setEffectPresets] = useState<Array<string>>([]);
     const [audioDenoiserSupported, setAudioDenoiserSupported] = useState<boolean | null>(null);
@@ -733,17 +746,13 @@ export default function VideoExperience({
                     <div className="chat">
                         {chatMessages.length > 0 && <h3>Chat messages</h3>}
                         {chatMessages.map((m) => {
+                            const parent = m.parentId ? chatMessages.find((cM) => cM.id === m.parentId) : undefined;
+
                             return (
                                 <div key={m.id}>
                                     {m.parentId && (
                                         <div style={{ fontSize: "12px", fontWeight: "bold", marginBottom: "4px" }}>
-                                            Reply to{" "}
-                                            <i>
-                                                &quot;
-                                                {(chatMessages.find((cM) => cM.id === m.parentId) || {}).text}
-                                                &quot;
-                                            </i>
-                                            :{" "}
+                                            Reply to <i>&quot;{describeChatMessage(parent)}&quot;</i>:{" "}
                                         </div>
                                     )}
                                     {m.removed ? <s>{m.text}</s> : m.text}{" "}
@@ -757,6 +766,11 @@ export default function VideoExperience({
                                             ⬇ {m.file.name} ({Math.round(m.file.size / 1024)} KB)
                                         </button>
                                     )}
+                                    {!m.removed && (
+                                        <button type="button" onClick={() => setChatMessageParent(m.id)}>
+                                            Reply
+                                        </button>
+                                    )}
                                     <hr />
                                 </div>
                             );
@@ -764,12 +778,56 @@ export default function VideoExperience({
                         <form
                             onSubmit={(e) => {
                                 e.preventDefault();
-                                sendChatMessage(chatMessage, chatMessageParent, chatBroadcast);
+
+                                const parentId = chatMessageParent || undefined;
+
+                                if (chatMessage) {
+                                    sendChatMessage(chatMessage, parentId, chatBroadcast);
+                                }
+                                if (showFileSharing && stagedFiles.length) {
+                                    sendFiles(stagedFiles, { parentId, isBroadcast: chatBroadcast });
+                                }
+
                                 setChatMessage("");
+                                setStagedFiles([]);
                                 setChatMessageParent("");
                             }}
                         >
-                            <input type="text" value={chatMessage} onChange={(e) => setChatMessage(e.target.value)} />
+                            {chatMessageParent && (
+                                <div className="chatReplyTarget">
+                                    Replying to{" "}
+                                    <i>
+                                        &quot;
+                                        {describeChatMessage(chatMessages.find((m) => m.id === chatMessageParent))}
+                                        &quot;
+                                    </i>{" "}
+                                    <button type="button" onClick={() => setChatMessageParent("")}>
+                                        Cancel reply
+                                    </button>
+                                </div>
+                            )}
+                            <input
+                                type="text"
+                                placeholder="Message"
+                                value={chatMessage}
+                                onChange={(e) => setChatMessage(e.target.value)}
+                            />
+                            {showFileSharing && (
+                                <label>
+                                    Attach files:{" "}
+                                    <input
+                                        type="file"
+                                        multiple
+                                        onChange={(e) => {
+                                            const files = Array.from(e.target.files ?? []);
+                                            if (files.length) {
+                                                setStagedFiles((prev) => [...prev, ...files]);
+                                            }
+                                            e.target.value = "";
+                                        }}
+                                    />
+                                </label>
+                            )}
                             {breakout.isActive ? (
                                 <label>
                                     <input
@@ -787,39 +845,48 @@ export default function VideoExperience({
                                 {chatMessages.map((m) => {
                                     return (
                                         <option key={`chat-select-${m.id}`} value={m.id}>
-                                            Reply to: {m.text}
+                                            Reply to: {describeChatMessage(m)}
                                         </option>
                                     );
                                 })}
                             </select>
-                            <button type="submit">Send message</button>
+                            <button type="submit" disabled={!chatMessage && !stagedFiles.length}>
+                                {stagedFiles.length
+                                    ? `Send message with ${stagedFiles.length} file(s)`
+                                    : "Send message"}
+                            </button>
                         </form>
-                        {showFileSharing && (
+                        {showFileSharing && stagedFiles.length > 0 && (
                             <div className="fileSharing">
-                                <label>
-                                    Share files:{" "}
-                                    <input
-                                        type="file"
-                                        multiple
-                                        onChange={(e) => {
-                                            const files = Array.from(e.target.files ?? []);
-                                            if (files.length) {
-                                                sendFiles(files);
-                                            }
-                                            e.target.value = "";
-                                        }}
-                                    />
-                                </label>
-                                {fileUploads.length > 0 && (
-                                    <ul className="fileUploads">
-                                        {fileUploads.map((upload) => (
-                                            <li key={upload.id}>
-                                                {upload.name} —{" "}
-                                                {upload.status === "error" ? `error: ${upload.error}` : upload.status}
-                                            </li>
-                                        ))}
-                                    </ul>
-                                )}
+                                <h4>Attached, not sent yet</h4>
+                                <ul className="stagedFiles">
+                                    {stagedFiles.map((file, index) => (
+                                        <li key={`${file.name}-${index}`}>
+                                            {file.name} ({Math.round(file.size / 1024)} KB){" "}
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    setStagedFiles((prev) => prev.filter((_, i) => i !== index))
+                                                }
+                                            >
+                                                Remove
+                                            </button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
+                        {showFileSharing && fileUploads.length > 0 && (
+                            <div className="fileSharing">
+                                <h4>Uploads</h4>
+                                <ul className="fileUploads">
+                                    {fileUploads.map((upload) => (
+                                        <li key={upload.id}>
+                                            {upload.name} —{" "}
+                                            {upload.status === "error" ? `error: ${upload.error}` : upload.status}
+                                        </li>
+                                    ))}
+                                </ul>
                             </div>
                         )}
                     </div>

--- a/packages/browser-sdk/src/stories/custom-ui.stories.tsx
+++ b/packages/browser-sdk/src/stories/custom-ui.stories.tsx
@@ -445,5 +445,5 @@ export const RoomConnectionWithFileSharing = ({ roomUrl, displayName }: { roomUr
         return <p>Set room url on the Controls panel</p>;
     }
 
-    return <VideoExperience displayName={displayName} roomName={roomUrl} showFileSharing />;
+    return <VideoExperience displayName={displayName} roomName={roomUrl} showFileSharing showBreakoutGroups />;
 };

--- a/packages/browser-sdk/src/stories/styles.css
+++ b/packages/browser-sdk/src/stories/styles.css
@@ -197,9 +197,17 @@
     gap: 4px;
 }
 
-.fileUploads {
+.fileUploads,
+.stagedFiles {
     margin: 0;
     padding-left: 18px;
+}
+
+.chatReplyTarget {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
 }
 
 /* Breakout */

--- a/packages/core/src/client/RoomConnection/index.ts
+++ b/packages/core/src/client/RoomConnection/index.ts
@@ -68,6 +68,7 @@ import type {
     RemoteParticipantState,
     RoomConnectionState,
     RoomJoinedSuccess,
+    SendFilesOptions,
     ScreenshareState,
     WaitingParticipantState,
     WherebyClientOptions,
@@ -466,11 +467,16 @@ export class RoomConnectionClient extends BaseClient<RoomConnectionState, RoomCo
     }
 
     /**
-     * Upload files and share them with the room as chat messages.
+     * Upload files and share them with the room as chat messages. Each file is shared as its own
+     * chat message, so replying with both text and files means calling
+     * {@link RoomConnectionClient.sendChatMessage} and this method with the same `parentId`.
      * @param files - The files to share.
+     * @param options.parentId - Optional id of the message the files are a reply to.
+     * @param options.isBroadcast - When true and a breakout session is active, the files are broadcast
+     * to all breakout groups instead of only the sender's group.
      */
-    public sendFiles(files: File[]) {
-        this.store.dispatch(doSendFiles({ files }));
+    public sendFiles(files: File[], options?: SendFilesOptions) {
+        this.store.dispatch(doSendFiles({ files, ...options }));
     }
 
     /**

--- a/packages/core/src/client/RoomConnection/types.ts
+++ b/packages/core/src/client/RoomConnection/types.ts
@@ -4,7 +4,7 @@ import { ClientView, ConnectionStatus, FileUpload, NotificationsEventEmitter } f
 import LiveCaption from "../../api/models/LiveCaption";
 
 export type { RoomJoinedSuccess, ChatFileShare, KnockResponse, KnockResponseSender } from "@whereby.com/media";
-export type { FileUpload, FileShareError } from "../../redux";
+export type { FileUpload, FileShareError, SendFilesOptions } from "../../redux";
 
 export type LocalMediaOptions = {
     audio: boolean;

--- a/packages/core/src/redux/slices/fileShare.ts
+++ b/packages/core/src/redux/slices/fileShare.ts
@@ -134,9 +134,14 @@ function uploadFile(file: File, uploadUrl: FileUploadUrl["uploadUrl"]) {
     return fetch(uploadUrl.url, { method: "POST", body: form });
 }
 
+export interface SendFilesOptions {
+    parentId?: string;
+    isBroadcast?: boolean;
+}
+
 export const doSendFiles = createAsyncRoomConnectedThunk(
     "fileShare/sendFiles",
-    async (payload: { files: File[] }, { dispatch, getState }) => {
+    async (payload: { files: File[] } & SendFilesOptions, { dispatch, getState }) => {
         const state = getState();
 
         if (state.fileShare.requestInFlight) {
@@ -239,7 +244,9 @@ export const doSendFiles = createAsyncRoomConnectedThunk(
                             type: file.type,
                             key: urls.uploadUrl.fields.key,
                         },
+                        ...(payload.parentId && { parentId: payload.parentId }),
                         ...(breakoutCurrentId && { breakoutGroup: breakoutCurrentId }),
+                        ...(payload.isBroadcast && { broadcast: true }),
                     });
 
                     dispatch(fileUploadSucceeded({ id: upload.id }));

--- a/packages/core/src/redux/tests/store/fileShare.spec.ts
+++ b/packages/core/src/redux/tests/store/fileShare.spec.ts
@@ -46,6 +46,66 @@ describe("fileShare actions", () => {
             expect(store.getState().fileShare.requestInFlight).toBe(false);
         });
 
+        it("shares each file as a reply when a parentId is given", async () => {
+            const store = createStore({ withSignalConnection: true, connectToRoom: true });
+            global.fetch = jest.fn().mockResolvedValue({ ok: true });
+
+            mockSignalEmit.mockImplementation((event: string, _payload: unknown, ack?: (urls: unknown) => void) => {
+                if (event === "request_file_upload_url" && ack) {
+                    ack([
+                        { downloadUrl: "https://dl/a", uploadUrl: { url: "https://s3", fields: { key: "key-a" } } },
+                        { downloadUrl: "https://dl/b", uploadUrl: { url: "https://s3", fields: { key: "key-b" } } },
+                    ]);
+                }
+            });
+
+            const files = [
+                new File(["abc"], "a.txt", { type: "text/plain" }),
+                new File(["abc"], "b.txt", { type: "text/plain" }),
+            ];
+
+            await store.dispatch(doSendFiles({ files, parentId: "parent-1" }));
+
+            expect(mockSignalEmit).toHaveBeenCalledWith("chat_message", {
+                text: "",
+                file: {
+                    downloadUrl: "https://dl/a",
+                    name: "a.txt",
+                    size: 3,
+                    type: "text/plain",
+                    key: "key-a",
+                },
+                parentId: "parent-1",
+            });
+            expect(mockSignalEmit).toHaveBeenCalledWith(
+                "chat_message",
+                expect.objectContaining({
+                    file: expect.objectContaining({ name: "b.txt" }),
+                    parentId: "parent-1",
+                }),
+            );
+        });
+
+        it("broadcasts file messages to all breakout groups when isBroadcast is set", async () => {
+            const store = createStore({ withSignalConnection: true, connectToRoom: true });
+            global.fetch = jest.fn().mockResolvedValue({ ok: true });
+
+            mockSignalEmit.mockImplementation((event: string, _payload: unknown, ack?: (urls: unknown) => void) => {
+                if (event === "request_file_upload_url" && ack) {
+                    ack([{ downloadUrl: "https://dl/a", uploadUrl: { url: "https://s3", fields: { key: "key-a" } } }]);
+                }
+            });
+
+            const file = new File(["abc"], "a.txt", { type: "text/plain" });
+
+            await store.dispatch(doSendFiles({ files: [file], parentId: "parent-1", isBroadcast: true }));
+
+            expect(mockSignalEmit).toHaveBeenCalledWith(
+                "chat_message",
+                expect.objectContaining({ parentId: "parent-1", broadcast: true }),
+            );
+        });
+
         it("fails the whole batch when the server rejects the request", async () => {
             const store = createStore({ withSignalConnection: true, connectToRoom: true });
             global.fetch = jest.fn().mockResolvedValue({ ok: true });


### PR DESCRIPTION
### Description

Add option to reply to a chat message with a file, and also support sending files as broadcast chat messages.

`sendFiles` now takes an options argument:

`sendFiles(files: File[], options?: { parentId?: string; isBroadcast?: boolean });`


**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
1. `pnpm build && pnpm dev`
2. Open the Room Connection With File Sharing story (x2)
3. Send a chat message, share a file and verify that you can share it as a reply to the previous chat message.
4. Verify that it's displayed correctly in the prebuilt ui as well

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
