### PR TITLE
common: Send `roomUrl` when starting bandwidth tests

### DIFF
--- a/packages/browser-sdk/README.md
+++ b/packages/browser-sdk/README.md
@@ -80,7 +80,7 @@ joining — running it during a call takes bandwidth away from the call.
 import { usePreCallTest } from "@whereby.com/browser-sdk/react";
 
 function MyNetworkCheck() {
-    const { state, actions } = usePreCallTest();
+    const { state, actions } = usePreCallTest("<room_url>");
     const { status, result, error } = state;
 
     return (
@@ -155,7 +155,7 @@ The `useRoomConnection` hook provides a way to connect participants in a given
 room, subscribe to state updates, and perform actions on the connection, like
 toggling camera or microphone.
 
-Note: from V3 this requires the `WherebyProvder` as a parent of this component. See [the docs](https://docs.whereby.com/reference/react-hooks-reference/guides-and-concepts/migrate-from-version-2.x-to-3) for details 
+Note: from V3 this requires the `WherebyProvder` as a parent of this component. See [the docs](https://docs.whereby.com/reference/react-hooks-reference/guides-and-concepts/migrate-from-version-2.x-to-3) for details
 
 ```js
 import { useEffect } from "react"
@@ -176,7 +176,7 @@ function MyCallUX( { roomUrl, localStream }) {
     const { connectionState, remoteParticipants } = state;
     const { toggleCamera, toggleMicrophone, joinRoom, leaveRoom } = actions;
     const { VideoView } = components;
-    
+
     useEffect(() => {
         /* join the room when this component renders */
         joinRoom()

--- a/packages/browser-sdk/src/lib/react/usePreCallTest/index.ts
+++ b/packages/browser-sdk/src/lib/react/usePreCallTest/index.ts
@@ -11,7 +11,7 @@ import { WherebyContext } from "../Provider";
  * room and no local media, but it does compete for bandwidth with any call
  * already in progress, so run it before joining.
  */
-export function usePreCallTest(): UsePreCallTestResult {
+export function usePreCallTest(roomUrl: string): UsePreCallTestResult {
     const client = React.useContext(WherebyContext)?.getPreCallTest();
 
     if (!client) {
@@ -34,7 +34,10 @@ export function usePreCallTest(): UsePreCallTestResult {
         };
     }, [client]);
 
-    const startTest = React.useCallback(() => client.startTest(), [client]);
+    const startTest = React.useCallback(() => {
+        client.initialize({ roomUrl });
+        return client.startTest();
+    }, [client]);
     const stopTest = React.useCallback(() => client.stopTest(), [client]);
 
     return {

--- a/packages/browser-sdk/src/stories/components/PreCallTestExperience.tsx
+++ b/packages/browser-sdk/src/stories/components/PreCallTestExperience.tsx
@@ -14,11 +14,11 @@ function Verdict({ result }: { result: PreCallTestResult }) {
     return <strong className="preCallTestVerdictFailure">Connection is too poor for a call</strong>;
 }
 
-export default function PreCallTestExperience() {
+export default function PreCallTestExperience({ roomUrl }: { roomUrl: string }) {
     const {
         state: { status, result, error },
         actions: { startTest, stopTest },
-    } = usePreCallTest();
+    } = usePreCallTest(roomUrl);
 
     const isRunning = status === "running";
 

--- a/packages/browser-sdk/src/stories/pre-call-test.stories.tsx
+++ b/packages/browser-sdk/src/stories/pre-call-test.stories.tsx
@@ -1,16 +1,16 @@
 import * as React from "react";
 
-import { Meta } from "@storybook/react-vite";
+import { StoryObj } from "@storybook/react-vite";
 import "./styles.css";
 import { Provider as WherebyProvider } from "../lib/react/Provider";
 import { usePreCallTest } from "../lib/react";
 import PreCallTestExperience from "./components/PreCallTestExperience";
 import VideoExperience from "./components/VideoExperience";
 
-const defaultArgs: Meta = {
-    title: "Examples/Pre-call test",
+const defaultArgs: StoryObj = {
+    name: "Examples/Pre-call test",
     argTypes: {
-        roomUrl: { control: "text" },
+        roomUrl: { control: "text", type: { required: true } },
         displayName: { control: "text" },
     },
     args: {
@@ -30,8 +30,12 @@ export default defaultArgs;
 
 const roomRegEx = new RegExp(/^https:\/\/.*\/.*/);
 
-export const BandwidthTest = () => {
-    return <PreCallTestExperience />;
+export const BandwidthTest = ({ roomUrl }: { roomUrl: string }) => {
+    if (!roomUrl || !roomUrl.match(roomRegEx)) {
+        return <p>Set room url on the Controls panel</p>;
+    }
+
+    return <PreCallTestExperience roomUrl={roomUrl} />;
 };
 
 /**
@@ -39,7 +43,11 @@ export const BandwidthTest = () => {
  * keeps its result around for the next reader, while unmounting a running test
  * stops it so it no longer eats bandwidth.
  */
-export const BandwidthTestUnmount = () => {
+export const BandwidthTestUnmount = ({ roomUrl }: { roomUrl: string }) => {
+    if (!roomUrl || !roomUrl.match(roomRegEx)) {
+        return <p>Set room url on the Controls panel</p>;
+    }
+
     const [isMounted, setIsMounted] = React.useState(true);
 
     return (
@@ -50,7 +58,7 @@ export const BandwidthTestUnmount = () => {
                 </button>
             </div>
             {isMounted ? (
-                <PreCallTestExperience />
+                <PreCallTestExperience roomUrl={roomUrl} />
             ) : (
                 <p>Unmounted. Mount again to see the state the test was left in.</p>
             )}
@@ -66,7 +74,7 @@ export const BandwidthTestBeforeJoiningRoom = ({ roomUrl, displayName }: { roomU
     const {
         state: { status, result },
         actions: { startTest },
-    } = usePreCallTest();
+    } = usePreCallTest(roomUrl);
     const [hasJoined, setHasJoined] = React.useState(false);
 
     if (!roomUrl || !roomUrl.match(roomRegEx)) {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -98,8 +98,13 @@ Typical usage:
 import { isPreCallTestSupported } from "@whereby.com/core";
 
 if (!isPreCallTestSupported()) {
-    return; 
+    return;
 }
+
+// initialize with your room URL
+preCallTest.initialize({
+    roomUrl: "https://your-subdomain.whereby.com/your-room",
+});
 
 // runs for a fixed duration, exported as PRE_CALL_TEST_DURATION_S
 const result = await preCallTest.startTest();

--- a/packages/core/src/api/bandwidthTestTokenService/index.ts
+++ b/packages/core/src/api/bandwidthTestTokenService/index.ts
@@ -1,7 +1,7 @@
 import ApiClient from "../ApiClient";
 import BandwidthTestToken from "../BandwidthTestToken";
 import Response from "../Response";
-import { RateLimitError } from "../errors";
+import { ForbiddenError, RateLimitError } from "../errors";
 /**
  * Related to device calls needed to obtain credentials
  */
@@ -39,6 +39,10 @@ export default class BandwidthTestTokenService {
                 if (res instanceof Response) {
                     if (res.status === 429) {
                         throw new RateLimitError(res.statusText);
+                    }
+
+                    if (res.status === 403) {
+                        throw new ForbiddenError(res.statusText);
                     }
 
                     throw new Error(res.statusText);

--- a/packages/core/src/api/bandwidthTestTokenService/index.ts
+++ b/packages/core/src/api/bandwidthTestTokenService/index.ts
@@ -24,10 +24,13 @@ export default class BandwidthTestTokenService {
      * @return {Promise} A promise which is fulfilled or failed based on the
      * response.
      */
-    getToken(): Promise<BandwidthTestToken> {
+    getToken(roomUrl: string): Promise<BandwidthTestToken> {
         return this._apiClient
             .request("/bandwidth-test-token", {
-                method: "get",
+                method: "post",
+                data: {
+                    roomUrl,
+                },
             })
             .then(({ data }) => {
                 return BandwidthTestToken.fromJson(data);

--- a/packages/core/src/api/bandwidthTestTokenService/tests/index.spec.ts
+++ b/packages/core/src/api/bandwidthTestTokenService/tests/index.spec.ts
@@ -20,23 +20,26 @@ describe("BandwidthTestTokenService", () => {
     });
 
     describe("getToken", () => {
+        const roomUrl = "testRoomUrl";
+
         const url = "/bandwidth-test-token";
-        const method = "get";
+        const method = "post";
 
         beforeEach(() => {
             apiClient.request.mockResolvedValue(new Response({ data: bandwidthTestTokenResponse }));
         });
 
         it("should call request with correct params", async () => {
-            await bandwidthTestTokenService.getToken();
+            await bandwidthTestTokenService.getToken(roomUrl);
 
             expect(apiClient.request).toBeCalledWith(url, {
                 method,
+                data: { roomUrl },
             });
         });
 
         it("should be fulfilled with the token success", async () => {
-            const result = await bandwidthTestTokenService.getToken();
+            const result = await bandwidthTestTokenService.getToken(roomUrl);
 
             expect(result).toEqual(new BandwidthTestToken(bandwidthTestTokenResponse.bandwidthTestToken));
         });
@@ -45,14 +48,14 @@ describe("BandwidthTestTokenService", () => {
             const error = new Error("some error");
             apiClient.request.mockRejectedValue(error);
 
-            await expect(bandwidthTestTokenService.getToken()).rejects.toThrow(error);
+            await expect(bandwidthTestTokenService.getToken(roomUrl)).rejects.toThrow(error);
         });
 
         it("should return rate limit error if the request was rate limited", async () => {
             const response = new Response({ status: 429 });
             apiClient.request.mockRejectedValue(response);
 
-            await expect(bandwidthTestTokenService.getToken()).rejects.toThrow(RateLimitError);
+            await expect(bandwidthTestTokenService.getToken(roomUrl)).rejects.toThrow(RateLimitError);
         });
     });
 });

--- a/packages/core/src/api/bandwidthTestTokenService/tests/index.spec.ts
+++ b/packages/core/src/api/bandwidthTestTokenService/tests/index.spec.ts
@@ -2,7 +2,7 @@ import BandwidthTestTokenService from "../index";
 import ApiClient from "../../ApiClient";
 import BandwidthTestToken from "../../BandwidthTestToken";
 import Response from "../../Response";
-import { RateLimitError } from "../../errors";
+import { ForbiddenError, RateLimitError } from "../../errors";
 
 jest.mock("../../ApiClient");
 
@@ -49,6 +49,13 @@ describe("BandwidthTestTokenService", () => {
             apiClient.request.mockRejectedValue(error);
 
             await expect(bandwidthTestTokenService.getToken(roomUrl)).rejects.toThrow(error);
+        });
+
+        it("should return forbidden error if the request was not allowed", async () => {
+            const response = new Response({ status: 403 });
+            apiClient.request.mockRejectedValue(response);
+
+            await expect(bandwidthTestTokenService.getToken(roomUrl)).rejects.toThrow(ForbiddenError);
         });
 
         it("should return rate limit error if the request was rate limited", async () => {

--- a/packages/core/src/api/errors.ts
+++ b/packages/core/src/api/errors.ts
@@ -1,1 +1,2 @@
+export class ForbiddenError extends Error {}
 export class RateLimitError extends Error {}

--- a/packages/core/src/client/PreCallTest/index.ts
+++ b/packages/core/src/client/PreCallTest/index.ts
@@ -1,6 +1,7 @@
 import { doStartPreCallTest, doStopPreCallTest, type PreCallTestResult } from "../../redux";
 import type { Store as AppStore } from "../../redux/store";
 import { BaseClient } from "../BaseClient";
+import { PrecallTestOptions } from "../RoomConnection/types";
 import {
     PRE_CALL_TEST_ERROR_CHANGED,
     PRE_CALL_TEST_RESULT_CHANGED,
@@ -19,12 +20,15 @@ import type { PreCallTestError, PreCallTestState, PreCallTestStatus } from "./ty
  * any call already in progress.
  */
 export class PreCallTestClient extends BaseClient<PreCallTestState, PreCallTestEvents> {
+    protected options: Partial<PrecallTestOptions>;
+
     private statusSubscribers = new Set<(status: PreCallTestStatus) => void>();
     private resultSubscribers = new Set<(result: PreCallTestResult | null) => void>();
     private errorSubscribers = new Set<(error: PreCallTestError | null) => void>();
 
     constructor(store: AppStore) {
         super(store);
+        this.options = {};
     }
 
     protected handleStateChanges(state: PreCallTestState, previousState: PreCallTestState): void {
@@ -71,12 +75,27 @@ export class PreCallTestClient extends BaseClient<PreCallTestState, PreCallTestE
     /* Actions */
 
     /**
+     * Initialize the precall test with options.
+     * This method can be called multiple times to update options.
+     * @param options<PrecallTestOptions> - Options for the Precall Test.
+     */
+    public initialize(options: PrecallTestOptions) {
+        this.options = options;
+    }
+
+    /**
      * Runs a test and resolves with its result, or with `null` if the test could
      * not complete - read `getState().error` for why. Calling this while a test
      * is already running resolves with `null` and leaves that test alone.
      */
     public async startTest(): Promise<PreCallTestResult | null> {
-        return await this.store.dispatch(doStartPreCallTest()).unwrap();
+        const { roomUrl } = this.options;
+
+        if (!roomUrl) {
+            throw new Error("Room URL is required to run a bandwidth test.");
+        }
+
+        return await this.store.dispatch(doStartPreCallTest({ roomUrl })).unwrap();
     }
 
     /** Aborts a running test and returns to the idle state. */

--- a/packages/core/src/client/PreCallTest/index.ts
+++ b/packages/core/src/client/PreCallTest/index.ts
@@ -1,3 +1,4 @@
+import { fromLocation } from "@whereby.com/media";
 import { doStartPreCallTest, doStopPreCallTest, type PreCallTestResult } from "../../redux";
 import type { Store as AppStore } from "../../redux/store";
 import { BaseClient } from "../BaseClient";
@@ -95,7 +96,11 @@ export class PreCallTestClient extends BaseClient<PreCallTestState, PreCallTestE
             throw new Error("Room URL is required to run a bandwidth test.");
         }
 
-        return await this.store.dispatch(doStartPreCallTest({ roomUrl })).unwrap();
+        const url = new URL(roomUrl);
+        const urls = fromLocation({ host: url.hostname });
+        const resolvedRoomUrl = `https://${urls.subdomain}.whereby.com${url.pathname}`;
+
+        return await this.store.dispatch(doStartPreCallTest({ roomUrl: resolvedRoomUrl })).unwrap();
     }
 
     /** Aborts a running test and returns to the idle state. */

--- a/packages/core/src/client/RoomConnection/types.ts
+++ b/packages/core/src/client/RoomConnection/types.ts
@@ -20,6 +20,11 @@ export interface WherebyClientOptions {
     externalId?: string | null;
     isNodeSdk?: boolean;
 }
+
+export interface PrecallTestOptions {
+    roomUrl?: string;
+}
+
 export type RemoteParticipantState = Omit<RemoteParticipant, "newJoiner" | "streams"> & {
     breakoutGroupAssigned: string;
 };

--- a/packages/core/src/redux/slices/preCallTest.ts
+++ b/packages/core/src/redux/slices/preCallTest.ts
@@ -6,6 +6,7 @@ import { startAppListening } from "../listenerMiddleware";
 import { doAppStop } from "./app";
 import { selectIsHDModeEnabled, selectIsLowDataModeEnabled } from "./localMedia";
 import { RateLimitError } from "../../api/errors";
+import { PrecallTestOptions } from "../../client/RoomConnection/types";
 
 export const PRE_CALL_TEST_DURATION_S = 15;
 
@@ -141,9 +142,21 @@ export function isPreCallTestSupported(): boolean {
  * Thunks
  */
 
-export const doStartPreCallTest = createAppAsyncThunk<PreCallTestResult | null, void>(
+export const doStartPreCallTest = createAppAsyncThunk<PreCallTestResult | null, PrecallTestOptions>(
     "preCallTest/start",
-    async (_, { dispatch, getState, extra }) => {
+    async ({ roomUrl }, { dispatch, getState, extra }) => {
+        if (!roomUrl) {
+            dispatch(
+                preCallTestFailed({
+                    error: {
+                        reason: "unsupported",
+                        message: "The pre-call test requires a roomUrl to be provided and none was present.",
+                    },
+                }),
+            );
+            return null;
+        }
+
         const state = getState();
 
         if (selectIsPreCallTestRunning(state)) {

--- a/packages/core/src/redux/slices/preCallTest.ts
+++ b/packages/core/src/redux/slices/preCallTest.ts
@@ -182,7 +182,7 @@ export const doStartPreCallTest = createAppAsyncThunk<PreCallTestResult | null, 
         let tester: BandwidthTester;
 
         try {
-            const { token } = await extra.services.bandwidthTestTokenService.getToken();
+            const { token } = await extra.services.bandwidthTestTokenService.getToken(roomUrl);
 
             tester = new BandwidthTester({
                 token,

--- a/packages/core/src/redux/slices/preCallTest.ts
+++ b/packages/core/src/redux/slices/preCallTest.ts
@@ -5,14 +5,20 @@ import { RootState } from "../store";
 import { startAppListening } from "../listenerMiddleware";
 import { doAppStop } from "./app";
 import { selectIsHDModeEnabled, selectIsLowDataModeEnabled } from "./localMedia";
-import { RateLimitError } from "../../api/errors";
+import { ForbiddenError, RateLimitError } from "../../api/errors";
 import { PrecallTestOptions } from "../../client/RoomConnection/types";
 
 export const PRE_CALL_TEST_DURATION_S = 15;
 
 export type PreCallTestStatus = "idle" | "running" | "completed" | "failed";
 
-export type PreCallTestErrorReason = "invalidClaim" | "rateLimited" | "timeout" | "unsupported" | "unknown";
+export type PreCallTestErrorReason =
+    | "forbidden"
+    | "invalidClaim"
+    | "rateLimited"
+    | "timeout"
+    | "unsupported"
+    | "unknown";
 
 export interface PreCallTestError {
     reason: PreCallTestErrorReason;
@@ -25,15 +31,15 @@ export interface PreCallTestError {
  */
 interface PreCallTestErrorDetails {
     invalidClaim?: boolean;
-    rateLimited?: boolean;
     timeout?: boolean;
 }
 
-const PRE_CALL_TEST_ERROR_FLAGS = ["invalidClaim", "rateLimited", "timeout"] as const;
+const PRE_CALL_TEST_ERROR_FLAGS = ["invalidClaim", "timeout"] as const;
 
 const PRE_CALL_TEST_ERROR_MESSAGES: Record<PreCallTestErrorReason, string> = {
     invalidClaim: "The pre-call test was rejected with an invalid bandwidth test claim",
     rateLimited: "The pre-call test was rate limited by the Whereby media servers",
+    forbidden: "Not authorized to access this service",
     timeout: "Timed out connecting to the Whereby media servers",
     unsupported: "The pre-call test is not supported in this environment",
     unknown: "The connection to the Whereby media servers failed",
@@ -194,16 +200,18 @@ export const doStartPreCallTest = createAppAsyncThunk<PreCallTestResult | null, 
                 },
             });
         } catch (error) {
+            const reason =
+                error instanceof ForbiddenError
+                    ? "forbidden"
+                    : error instanceof RateLimitError
+                      ? "rateLimited"
+                      : "unknown";
+
             dispatch(
                 preCallTestFailed({
                     error: {
-                        reason: error instanceof RateLimitError ? "rateLimited" : "unknown",
-                        message:
-                            error instanceof RateLimitError
-                                ? PRE_CALL_TEST_ERROR_MESSAGES["rateLimited"]
-                                : error instanceof Error
-                                  ? error.message
-                                  : "Failed to set up the pre-call test",
+                        reason,
+                        message: PRE_CALL_TEST_ERROR_MESSAGES[reason],
                     },
                 }),
             );

--- a/packages/core/src/redux/tests/store/preCallTest.spec.ts
+++ b/packages/core/src/redux/tests/store/preCallTest.spec.ts
@@ -58,7 +58,7 @@ const flushMicrotasks = async () => {
 };
 
 const startTest = async (store: ReturnType<typeof createStore>) => {
-    const dispatched = store.dispatch(doStartPreCallTest());
+    const dispatched = store.dispatch(doStartPreCallTest({ roomUrl: "roomUrl" }));
     await flushMicrotasks();
 
     return {


### PR DESCRIPTION
### Description

**Summary:**

Require `roomUrl` to be sent when starting bandwidth tests.

Built on top of https://github.com/whereby/sdk/pull/1072

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
