### PR TITLE
browser-sdk: Fix first mount empty grid

### DIFF
--- a/.changeset/lucky-moons-render.md
+++ b/.changeset/lucky-moons-render.md
@@ -1,0 +1,6 @@
+---
+"@whereby.com/browser-sdk": patch
+---
+
+Fix an empty grid when it mounts after the client views have settled. useGridParticipants now
+seeds its state from the current grid snapshot instead of waiting for the next change event.

--- a/packages/browser-sdk/src/lib/react/Grid/__tests__/useGridParticipants.unit.ts
+++ b/packages/browser-sdk/src/lib/react/Grid/__tests__/useGridParticipants.unit.ts
@@ -1,4 +1,38 @@
-import { calculateSubgridViews } from "../useGridParticipants";
+import * as React from "react";
+import { renderHook } from "@testing-library/react";
+
+import { ClientView, GridState, WherebyClient } from "@whereby.com/core";
+import { WherebyContext } from "../../Provider";
+import { calculateSubgridViews, useGridParticipants } from "../useGridParticipants";
+
+function makeFakeGridClient(clientViews: ClientView[]) {
+    const subscribers = new Set<() => void>();
+
+    return {
+        getState: (): GridState => ({
+            allClientViews: clientViews,
+            spotlightedParticipants: [],
+            numParticipants: clientViews.length,
+        }),
+        subscribeClientViews: (cb: (views: ClientView[]) => void) => {
+            const notify = () => cb(clientViews);
+            subscribers.add(notify);
+            return () => subscribers.delete(notify);
+        },
+        subscribeSpotlightedParticipants: () => () => {},
+        subscribeNumberOfClientViews: () => () => {},
+    };
+}
+
+function renderGridParticipants(clientViews: ClientView[]) {
+    const grid = makeFakeGridClient(clientViews);
+    const client = { getGrid: () => grid } as unknown as WherebyClient;
+
+    return renderHook(() => useGridParticipants(), {
+        wrapper: ({ children }: { children: React.ReactNode }) =>
+            React.createElement(WherebyContext.Provider, { value: client }, children),
+    });
+}
 
 describe("useGridParticipants", () => {
     const client1 = { id: "some-stream-id-1" };
@@ -54,5 +88,19 @@ describe("useGridParticipants", () => {
                 ).toEqual(result);
             },
         );
+    });
+
+    describe("mounting after the state has settled", () => {
+        it("returns the client views already present when the hook mounts", () => {
+            const { result } = renderGridParticipants([videoLocalClient as ClientView]);
+
+            expect(result.current.clientViewsInGrid).toEqual([videoLocalClient]);
+        });
+
+        it("returns an empty grid when there are no client views", () => {
+            const { result } = renderGridParticipants([]);
+
+            expect(result.current.clientViewsInGrid).toEqual([]);
+        });
     });
 });

--- a/packages/browser-sdk/src/lib/react/Grid/useGridParticipants.ts
+++ b/packages/browser-sdk/src/lib/react/Grid/useGridParticipants.ts
@@ -90,16 +90,13 @@ function useGridParticipants({
     floatingParticipant,
     isConstrained = false,
 }: Props = {}) {
-    const [state, setState] = React.useState<GridState>({
-        allClientViews: [],
-        spotlightedParticipants: [],
-        numParticipants: 0,
-    });
     const client = React.useContext(WherebyContext)?.getGrid();
 
     if (!client) {
         throw new Error("useGridParticipants must be used within a WherebyProvider");
     }
+
+    const [state, setState] = React.useState<GridState>(() => client.getState());
 
     const handleClientViewChanged = React.useCallback(
         (clientViews: ClientView[]) => {
@@ -135,6 +132,8 @@ function useGridParticipants({
         const unsubscribeClientViews = client.subscribeClientViews(handleClientViewChanged);
         const unsubscribeSpotlighted = client.subscribeSpotlightedParticipants(handleSpotlightedParticipantsChanged);
         const unsubscribeNumParticipants = client.subscribeNumberOfClientViews(handleNumParticipantsChanged);
+
+        setState(client.getState());
 
         return () => {
             unsubscribeClientViews();

--- a/packages/browser-sdk/src/stories/components/FakeGridClient.tsx
+++ b/packages/browser-sdk/src/stories/components/FakeGridClient.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { ClientView, WherebyClient } from "@whereby.com/core";
+import { ClientView, GridState, WherebyClient } from "@whereby.com/core";
 import { WherebyContext } from "../../lib/react/Provider";
 import { NAMES, sampleNameForIndex } from "./VideoGridTestData";
 
@@ -90,21 +90,26 @@ export class FakeGridClient {
         this.numberOfClientViewsSubscribers.forEach((cb) => cb(this.clientViews.length));
     }
 
+    public getState(): GridState {
+        return {
+            allClientViews: this.clientViews,
+            spotlightedParticipants: this.spotlighted,
+            numParticipants: this.clientViews.length,
+        };
+    }
+
     public subscribeClientViews(callback: (clientViews: ClientView[]) => void): () => void {
         this.clientViewSubscribers.add(callback);
-        callback(this.clientViews);
         return () => this.clientViewSubscribers.delete(callback);
     }
 
     public subscribeSpotlightedParticipants(callback: (spotlighted: ClientView[]) => void): () => void {
         this.spotlightedSubscribers.add(callback);
-        callback(this.spotlighted);
         return () => this.spotlightedSubscribers.delete(callback);
     }
 
     public subscribeNumberOfClientViews(callback: (num: number) => void): () => void {
         this.numberOfClientViewsSubscribers.add(callback);
-        callback(this.clientViews.length);
         return () => this.numberOfClientViewsSubscribers.delete(callback);
     }
 

--- a/packages/browser-sdk/src/stories/video-grid-ui.stories.tsx
+++ b/packages/browser-sdk/src/stories/video-grid-ui.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { StoryObj } from "@storybook/react-vite";
 import "./styles.css";
-import { useRoomConnection } from "../lib/react";
+import { useLocalMedia, useRoomConnection } from "../lib/react";
 import { Provider as WherebyProvider } from "../lib/react/Provider";
 import { Grid as VideoGrid, GridCell, GridVideoView } from "../lib/react/Grid";
 import {
@@ -12,6 +12,7 @@ import {
     ParticipantMenuTrigger,
 } from "../lib/react/Grid/ParticipantMenu";
 import { FakeParticipantsProvider } from "./components/FakeGridClient";
+import PrecallExperience from "./components/PrecallExperience";
 
 const defaultArgs: StoryObj = {
     name: "Examples/Video Grid UI",
@@ -228,6 +229,123 @@ export const VideoGridStoryCustom = {
         gridGap: 0,
         videoGridGap: 0,
         enableSubgrid: true,
+    },
+};
+
+function VideoGridWithLocalMediaInner({
+    roomUrl,
+    displayName,
+    externalId,
+    gridGap,
+    videoGridGap,
+    enableSubgrid,
+    stageParticipantLimit,
+}: {
+    roomUrl: string;
+    displayName?: string;
+    externalId?: string;
+    gridGap?: number;
+    videoGridGap?: number;
+    enableSubgrid?: boolean;
+    stageParticipantLimit?: number;
+}) {
+    const localMedia = useLocalMedia({ audio: true, video: true });
+    const [shouldJoin, setShouldJoin] = React.useState(false);
+    const {
+        state: { connectionStatus },
+        actions: { joinRoom, leaveRoom, knock, cancelKnock },
+    } = useRoomConnection(roomUrl, { localMedia, displayName, externalId });
+
+    const handleToggleJoin = () => {
+        if (shouldJoin) {
+            leaveRoom();
+        } else {
+            joinRoom();
+        }
+        setShouldJoin(!shouldJoin);
+    };
+
+    return (
+        <>
+            <PrecallExperience {...localMedia} hideVideoPreview={shouldJoin} />
+            <div className="controls">
+                <button onClick={handleToggleJoin}>{shouldJoin ? "Leave room" : "Join room"}</button>
+                <span>Connection status: {connectionStatus}</span>
+            </div>
+            {connectionStatus === "room_locked" && (
+                <div style={{ color: "red" }}>
+                    <span>Room locked, please knock....</span>
+                    <button onClick={() => knock()}>Knock</button>
+                </div>
+            )}
+            {connectionStatus === "knocking" && (
+                <div>
+                    <span>Knocking...</span>
+                    <button onClick={() => cancelKnock()}>Cancel</button>
+                </div>
+            )}
+            {connectionStatus === "knock_rejected" && <span>Rejected :(</span>}
+            {connectionStatus === "connected" && (
+                <div style={{ height: "500px", width: "100%" }}>
+                    <VideoGrid
+                        gridGap={gridGap}
+                        videoGridGap={videoGridGap}
+                        stageParticipantLimit={stageParticipantLimit}
+                        enableSubgrid={enableSubgrid}
+                    />
+                </div>
+            )}
+        </>
+    );
+}
+
+export const VideoGridWithLocalMedia = {
+    render: ({
+        roomUrl,
+        displayName,
+        externalId,
+        gridGap,
+        videoGridGap,
+        enableSubgrid,
+        stageParticipantLimit,
+    }: {
+        roomUrl: string;
+        displayName?: string;
+        externalId?: string;
+        gridGap?: number;
+        videoGridGap?: number;
+        enableSubgrid?: boolean;
+        stageParticipantLimit?: number;
+    }) => {
+        if (!roomUrl || !roomUrl.match(roomRegEx)) {
+            return <p>Set room url on the Controls panel</p>;
+        }
+
+        return (
+            <VideoGridWithLocalMediaInner
+                roomUrl={roomUrl}
+                displayName={displayName}
+                externalId={externalId}
+                gridGap={gridGap}
+                videoGridGap={videoGridGap}
+                enableSubgrid={enableSubgrid}
+                stageParticipantLimit={stageParticipantLimit}
+            />
+        );
+    },
+    argTypes: {
+        ...defaultArgs.argTypes,
+        gridGap: { control: "range", min: 0, max: 100 },
+        videoGridGap: { control: "range", min: 0, max: 100 },
+        enableSubgrid: { control: "boolean" },
+        stageParticipantLimit: { control: { type: "range", min: 1, max: 24 } },
+    },
+    args: {
+        ...defaultArgs.args,
+        gridGap: 8,
+        videoGridGap: 8,
+        enableSubgrid: true,
+        stageParticipantLimit: 12,
     },
 };
 


### PR DESCRIPTION
Closes #1091 

### Description
`useGridParticipants` currently sets initial state regardless of of the actual state. This breaks when using the local media hook first. It will then initialize with an empty grid, when you join the room alone. It will auto-correct itself on first state update because of the listener, but the initial state is wrong. This PR fixes it by reading the state on first mount.


**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing
0. Apply this patch:
```diff
diff --git a/packages/browser-sdk/src/lib/react/Grid/useGridParticipants.ts b/packages/browser-sdk/src/lib/react/Grid/useGridParticipants.ts
index 164bdbf3..b0081574 100644
--- a/packages/browser-sdk/src/lib/react/Grid/useGridParticipants.ts
+++ b/packages/browser-sdk/src/lib/react/Grid/useGridParticipants.ts
@@ -90,14 +90,17 @@ function useGridParticipants({
     floatingParticipant,
     isConstrained = false,
 }: Props = {}) {
+    const [state, setState] = React.useState<GridState>({
+        allClientViews: [],
+        spotlightedParticipants: [],
+        numParticipants: 0,
+    });
     const client = React.useContext(WherebyContext)?.getGrid();

     if (!client) {
         throw new Error("useGridParticipants must be used within a WherebyProvider");
     }

-    const [state, setState] = React.useState<GridState>(() => client.getState());
-
     const handleClientViewChanged = React.useCallback(
         (clientViews: ClientView[]) => {
             setState((prevState) => ({
@@ -133,8 +136,6 @@ function useGridParticipants({
         const unsubscribeSpotlighted = client.subscribeSpotlightedParticipants(handleSpotlightedParticipantsChanged);
         const unsubscribeNumParticipants = client.subscribeNumberOfClientViews(handleNumParticipantsChanged);

-        setState(client.getState());
-
         return () => {
             unsubscribeClientViews();
             unsubscribeSpotlighted();
```

This just reverts the main change in this PR, but you need the added storybook entry to test, so you can't just test on main.
1. `pnpm build && pnpm dev`
2. Go to the `Video Grid With Local Media` story
3. Enter the room, verify that you **don't** see yourself. This is the bug. If you toggle mic/cam, then you will be able to see yourself
4. Remove the patch, and run `pnpm build && pnpm dev`
5. Go to the `Video Grid With Local Media` story
6. Enter the room, verify that you **do** see yourself.

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
