### PR TITLE
media: remove the mute-state rtcstats events

### DIFF
--- a/.changeset/quiet-lamps-rest.md
+++ b/.changeset/quiet-lamps-rest.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/media": major
+---
+
+Remove sendAudioMutedStats and sendVideoMutedStats, which sent the audio_muted and video_muted rtcstats events

--- a/packages/media/src/utils/__tests__/nodeEnvironment.spec.ts
+++ b/packages/media/src/utils/__tests__/nodeEnvironment.spec.ts
@@ -19,11 +19,9 @@ describe("@whereby.com/media in a non-browser (Node) environment", () => {
         expect(typeof rtcStats.server.connect).toBe("function");
     });
 
-    it("does not throw when sendEvent/sendAudioMuted/sendVideoMuted are called", () => {
+    it("does not throw when sendEvent is called", () => {
         const { rtcStats } = require("../../index");
 
         expect(() => rtcStats.sendEvent("custom_event", { foo: "bar" })).not.toThrow();
-        expect(() => rtcStats.sendAudioMuted(true)).not.toThrow();
-        expect(() => rtcStats.sendVideoMuted(false)).not.toThrow();
     });
 });

--- a/packages/media/src/webrtc/P2pRtcManager.ts
+++ b/packages/media/src/webrtc/P2pRtcManager.ts
@@ -441,14 +441,6 @@ export default class P2pRtcManager implements RtcManager {
         ];
     }
 
-    sendAudioMutedStats(muted: boolean) {
-        rtcStats.sendEvent("audio_muted", { muted });
-    }
-
-    sendVideoMutedStats(muted: boolean) {
-        rtcStats.sendEvent("video_muted", { muted });
-    }
-
     sendStatsCustomEvent(eventName: string, data: any) {
         rtcStats.sendEvent(eventName, data);
     }

--- a/packages/media/src/webrtc/VegaRtcManager/index.ts
+++ b/packages/media/src/webrtc/VegaRtcManager/index.ts
@@ -1804,14 +1804,6 @@ export default class VegaRtcManager implements RtcManager {
         this._qualityMonitor.close();
     }
 
-    sendAudioMutedStats(muted: boolean) {
-        rtcStats.sendEvent("audio_muted", { muted });
-    }
-
-    sendVideoMutedStats(muted: boolean) {
-        rtcStats.sendEvent("video_muted", { muted });
-    }
-
     sendStatsCustomEvent(eventName: string, data?: any) {
         rtcStats.sendEvent(eventName, data);
     }

--- a/packages/media/src/webrtc/rtcStatsService.ts
+++ b/packages/media/src/webrtc/rtcStatsService.ts
@@ -208,12 +208,6 @@ const rtcStats = {
             value,
         });
     },
-    sendAudioMuted: (muted: boolean) => {
-        rtcStats.sendEvent("audio_muted", { muted });
-    },
-    sendVideoMuted: (muted: boolean) => {
-        rtcStats.sendEvent("video_muted", { muted });
-    },
     server,
 };
 export default rtcStats;


### PR DESCRIPTION
### Description

**Summary:**

Removes `sendAudioMutedStats` and `sendVideoMutedStats` from the rtc managers, and `sendAudioMuted`/`sendVideoMuted` from the rtcstats service. Mute state is no longer sent to rtcstats from this package.

**Related Issue:**

### Testing

### Screenshots/GIFs (if applicable)

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] Prefixed the PR title and commit messages with the service or package name
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Additional Information
