### PR TITLE
camera-effects: terminate shared web worker and release media stream resources on cleanup

### DIFF
--- a/.changeset/terminate-camera-effects-workers.md
+++ b/.changeset/terminate-camera-effects-workers.md
@@ -1,0 +1,5 @@
+---
+"@whereby.com/camera-effects": patch
+---
+
+camera-effects: terminate shared background web worker and release media stream resources on effect cleanup

--- a/packages/camera-effects/jest.config.mjs
+++ b/packages/camera-effects/jest.config.mjs
@@ -1,0 +1,6 @@
+import path from "node:path";
+import buildConfig from "@whereby.com/jest-config/base";
+
+const __dirname = path.resolve();
+
+export default buildConfig(__dirname, {});

--- a/packages/camera-effects/package.json
+++ b/packages/camera-effects/package.json
@@ -27,8 +27,11 @@
         "build:dev": "REACT_APP_IS_DEV=true rollup -c",
         "build:prod": "REACT_APP_IS_DEV=false rollup -c",
         "clean": "rimraf dist",
-        "lint": "eslint .",
-        "lint:fix": "eslint --fix ."
+        "test": "npm run test:lint && npm run test:unit",
+        "test:unit": "jest",
+        "test:lint": "eslint src",
+        "lint": "eslint src",
+        "lint:fix": "eslint --fix src"
     },
     "devDependencies": {
         "@rollup/plugin-wasm": "^6.2.2",

--- a/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/Processor.ts
+++ b/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/Processor.ts
@@ -217,7 +217,10 @@ class Processor extends EventEmitter {
     // stop effect and free resources
     terminate() {
         if (this.transformController) this.transformController.terminate();
-        if (this.timerWorker) this.timerWorker.terminate();
+        if (this.timerWorker) {
+            this.timerWorker.terminate();
+            this.timerWorker = null;
+        }
         if (this.engine) {
             this.engine.dispose();
             this.engine = null;
@@ -300,6 +303,7 @@ class Processor extends EventEmitter {
             this.timerWorker.postMessage(returnDelay);
         } else {
             setTimeout(() => {
+                if (this._terminated) return;
                 this.emit("output", { frame }, [frame]);
             }, returnDelay);
         }

--- a/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/__tests__/createProcessor.spec.ts
+++ b/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/__tests__/createProcessor.spec.ts
@@ -1,0 +1,97 @@
+import createProcessor from "../createProcessor";
+import Processor from "../Processor";
+import ProcessorProxy from "../ProcessorProxy";
+
+interface MockWorkerInstance {
+    postMessage: jest.Mock;
+    addEventListener: jest.Mock;
+    removeEventListener: jest.Mock;
+    terminate: jest.Mock;
+}
+
+const mockWorkerInstances: MockWorkerInstance[] = [];
+
+jest.mock(
+    "web-worker:./ProcessorProxy.worker",
+    () => {
+        return jest.fn().mockImplementation(() => {
+            const listeners: Record<string, ((event: { data: { type: string; processorId: number } }) => void)[]> = {};
+            const instance: MockWorkerInstance = {
+                postMessage: jest.fn((msg) => {
+                    if (msg.type === "terminate") {
+                        // Simulate worker replying with terminated event
+                        const handler = listeners["message"];
+                        if (handler) {
+                            handler.forEach((fn) =>
+                                fn({ data: { type: "terminated", processorId: msg.processorId } }),
+                            );
+                        }
+                    }
+                }),
+                addEventListener: jest.fn((event, fn) => {
+                    listeners[event] = listeners[event] || [];
+                    listeners[event].push(fn);
+                }),
+                removeEventListener: jest.fn((event, fn) => {
+                    if (listeners[event]) {
+                        listeners[event] = listeners[event].filter((cb) => cb !== fn);
+                    }
+                }),
+                terminate: jest.fn(),
+            };
+            mockWorkerInstances.push(instance);
+            return instance;
+        });
+    },
+    { virtual: true },
+);
+
+jest.mock("../Processor", () => {
+    return jest.fn().mockImplementation(function (this: { config: unknown; terminate: jest.Mock; emit: jest.Mock }, config: unknown) {
+        this.config = config;
+        this.terminate = jest.fn();
+        this.emit = jest.fn();
+    });
+});
+
+interface ProcessorProxyInstance extends ProcessorProxy {
+    terminate(args?: unknown): void;
+}
+
+describe("createProcessor", () => {
+    beforeEach(() => {
+        mockWorkerInstances.length = 0;
+        jest.clearAllMocks();
+    });
+
+    it("creates a direct Processor on the main thread when useBackgroundWorker is false", () => {
+        const processor = createProcessor(false, { setup: {}, params: {} });
+        expect(processor).toBeInstanceOf(Processor);
+        expect(mockWorkerInstances.length).toBe(0);
+    });
+
+    it("creates and reuses sharedWorker for multiple ProcessorProxy instances, and terminates worker when all are terminated", () => {
+        const proxy1 = createProcessor(true, { setup: { id: 1 }, params: {} }) as ProcessorProxyInstance;
+        expect(proxy1).toBeInstanceOf(ProcessorProxy);
+        expect(mockWorkerInstances.length).toBe(1);
+        const worker1 = mockWorkerInstances[0];
+
+        const proxy2 = createProcessor(true, { setup: { id: 2 }, params: {} }) as ProcessorProxyInstance;
+        expect(proxy2).toBeInstanceOf(ProcessorProxy);
+        // Should reuse existing worker, not spawn a new one
+        expect(mockWorkerInstances.length).toBe(1);
+
+        // Terminate first proxy
+        proxy1.terminate({});
+        expect(worker1.terminate).not.toHaveBeenCalled();
+
+        // Terminate second proxy
+        proxy2.terminate({});
+        expect(worker1.terminate).toHaveBeenCalledTimes(1);
+
+        // Creating a new processor afterwards should create a fresh worker
+        const proxy3 = createProcessor(true, { setup: { id: 3 }, params: {} }) as ProcessorProxyInstance;
+        expect(proxy3).toBeInstanceOf(ProcessorProxy);
+        expect(mockWorkerInstances.length).toBe(2);
+    });
+});

--- a/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/createProcessor.ts
+++ b/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/createProcessor.ts
@@ -3,7 +3,8 @@ import Processor from "./Processor";
 import ProcessorProxy from "./ProcessorProxy";
 import ProcessorProxyWorker from "web-worker:./ProcessorProxy.worker";
 
-let sharedWorker;
+let sharedWorker = null;
+let activeProxyCount = 0;
 
 // creates a processor on main thread or background thread
 export default function createProcessor(useBackgroundWorker, config) {
@@ -11,6 +12,17 @@ export default function createProcessor(useBackgroundWorker, config) {
 
     if (!sharedWorker) {
         sharedWorker = new ProcessorProxyWorker();
+        activeProxyCount = 0;
     }
-    return new ProcessorProxy(sharedWorker, config);
+    activeProxyCount++;
+    const proxy = new ProcessorProxy(sharedWorker, config);
+    proxy.once("terminated", () => {
+        activeProxyCount--;
+        if (activeProxyCount <= 0) {
+            sharedWorker?.terminate();
+            sharedWorker = null;
+            activeProxyCount = 0;
+        }
+    });
+    return proxy;
 }

--- a/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/engines/webgl/backgroundBlurStage.ts
+++ b/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/engines/webgl/backgroundBlurStage.ts
@@ -12,7 +12,6 @@ function generateOptimizedGaussianKernel(sigma) {
     let x = 0;
     let currentSum = 0;
 
-    // eslint-disable-next-line no-constant-condition
     while (true) {
         const n = g(x);
         const nextSum = currentSum + (currentSum ? n * 2 : n);

--- a/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/index.ts
+++ b/packages/camera-effects/src/pipelines/tfliteSegmentCanvasEffects/index.ts
@@ -118,9 +118,13 @@ export const createEffectStream = async (inputStream, setup, params) => {
                 } catch {
                     console.warn("video element already removed from DOM");
                 }
-                videoElement.srcObject = null;
             });
         }
+
+        cleanup.push(() => {
+            videoElement.pause();
+            videoElement.srcObject = null;
+        });
 
         await new Promise((resolve) => {
             videoElement.addEventListener("loadedmetadata", resolve);
@@ -245,6 +249,7 @@ export const createEffectStream = async (inputStream, setup, params) => {
 
     const stop = () => {
         processor.terminate();
+        outputTrack?.stop?.();
     };
 
     const updateParams = async (params) => {

--- a/packages/camera-effects/tsconfig.build.json
+++ b/packages/camera-effects/tsconfig.build.json
@@ -1,4 +1,3 @@
 {
-    "extends": "@whereby.com/tsconfig/build.json",
-    "exclude": ["dist", "node_modules"]
+    "extends": "@whereby.com/tsconfig/build.json"
 }


### PR DESCRIPTION
**Summary:**
This PR fixes a Web Worker and MediaStream resource leak in @whereby.com/camera-effects.
- Adds reference counting to the singleton `sharedWorker` in createProcessor.ts, terminating the Web Worker and releasing its WebGL/TFLite context when all active `ProcessorProxy` instances are terminated.
- Terminates and nullifies `timerWorker` on `Processor.terminate()` and guards delayed output emission from firing after termination.
- Ensures <video> elements used for capturing input stream frames have their `srcObject` cleared and playback paused in `cleanup()`.
- Explicitly calls `outputTrack.stop()` when stopping effects streams to transition track state to "ended".
- Adds unit tests covering worker reference counting, reuse, and termination lifecycle.

**Related Issue:**
Fixes #1061

### Testing
- Ran unit tests in `@whereby.com/camera-effects`: `pnpm --filter=@whereby.com/camera-effects test` (all passed).
- Ran unit tests in `@whereby.com/core`: `pnpm --filter=@whereby.com/core test:unit` (63 suites, 736 tests passed).
- Ran linter: `pnpm test:lint` (passed).
- Ran package builds: `pnpm --filter=@whereby.com/camera-effects build` (succeeded).

### Checklist
- [x] My code follows the project's coding standards.
- [x] Prefixed the PR title and commit messages with the service or package name (`camera-effects:`)
- [x] I have written unit tests (if applicable).
- [x] Included Changeset markdown file.
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.